### PR TITLE
refactor: apply clang-tidy fixes

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -553,7 +553,7 @@ int hotkey_for_action( action_id action, const bool restrict_to_printable )
         return key != '?';
     };
     std::vector<char> keys = keys_bound_to( action, restrict_to_printable );
-    auto valid = std::find_if( keys.begin(), keys.end(), is_valid_key );
+    auto valid = std::ranges::find_if( keys, is_valid_key );
     return valid == keys.end() ? -1 : *valid;
 }
 
@@ -678,7 +678,7 @@ auto make_register_actions( std::vector<uilist_entry> &entries, const input_cont
         const auto fn = [&]( action_id name ) -> uilist_entry {
             return { name, true, hotkey_for_action( name ), ctxt.get_action_name( action_ident( name ) ) };
         };
-        std::transform( names.begin(), names.end(), std::back_inserter( entries ), fn );
+        std::ranges::transform( names, std::back_inserter( entries ), fn );
     };
 }
 
@@ -691,7 +691,7 @@ auto make_register_categories( std::vector<uilist_entry> &entries,
             categories_by_int[last_category] = name;
             return { last_category++, true, -1, name + "…" };
         };
-        std::transform( names.begin(), names.end(), std::back_inserter( entries ),  fn );
+        std::ranges::transform( names, std::back_inserter( entries ),  fn );
     };
 }
 
@@ -767,9 +767,9 @@ action_id handle_action_menu()
 
     // sort the map by its weightings
     std::vector<std::pair<action_id, int> > sorted_pairs;
-    std::copy( action_weightings.begin(), action_weightings.end(),
-               std::back_inserter<std::vector<std::pair<action_id, int> > >( sorted_pairs ) );
-    std::reverse( sorted_pairs.begin(), sorted_pairs.end() );
+    std::ranges::copy( action_weightings,
+                       std::back_inserter<std::vector<std::pair<action_id, int> > >( sorted_pairs ) );
+    std::ranges::reverse( sorted_pairs );
 
     // Default category is called "back"
     std::string category = "back";

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1957,7 +1957,7 @@ void activity_handlers::pulp_do_turn( player_activity *act, player *p )
         const mtype *corpse_mtype = corpse->get_mtype();
         if( !corpse->is_corpse() || ( !corpse_mtype->has_flag( MF_REVIVES ) &&
                                       !corpse_mtype->zombify_into ) ||
-            ( std::find( act->str_values.begin(), act->str_values.end(), "auto_pulp_no_acid" ) !=
+            ( std::ranges::find( act->str_values, "auto_pulp_no_acid" ) !=
               act->str_values.end() && corpse_mtype->bloodType().obj().has_acid ) ) {
             // Don't smash non-rezing corpses //don't smash acid zombies when auto pulping
             continue;
@@ -4143,7 +4143,7 @@ std::vector<tripoint> get_sorted_tiles_by_distance( const tripoint &abspos,
     };
 
     std::vector<tripoint> sorted( tiles.begin(), tiles.end() );
-    std::sort( sorted.begin(), sorted.end(), cmp );
+    std::ranges::sort( sorted, cmp );
 
     return sorted;
 }

--- a/src/activity_speed.cpp
+++ b/src/activity_speed.cpp
@@ -1,5 +1,6 @@
 #include "activity_speed.h"
 
+#include <algorithm>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -134,7 +135,7 @@ void activity_speed::calc_skill_factor( const Character &who,
 
         factors.push_back( bonus );
     }
-    std::sort( factors.begin(), factors.end(), std::greater<>() );
+    std::ranges::sort( factors, std::greater<>() );
 
     int denom = 0;
     for( const auto &factor : factors ) {
@@ -251,7 +252,7 @@ void activity_speed::calc_tools_factor( Character &who,
     for( const auto &q : quality_reqs ) {
         factors.push_back( get_best_qual_mod( q, inv ) );
     }
-    std::sort( factors.begin(), factors.end(), std::greater<>() );
+    std::ranges::sort( factors, std::greater<>() );
 
     int denom = 0;
     for( const auto &factor : factors ) {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -611,7 +611,7 @@ void advanced_inventory::recalc_pane( side p )
         }
     }
     // Finally sort all items (category headers will now be moved to their proper position)
-    std::stable_sort( pane.items.begin(), pane.items.end(), advanced_inv_sorter( pane.sortby ) );
+    std::ranges::stable_sort( pane.items, advanced_inv_sorter( pane.sortby ) );
     // itemsPerPage is 0 during processing
     if( itemsPerPage > 0 ) {
         pane.paginate( itemsPerPage );

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -188,7 +188,7 @@ void advanced_inv_area::init()
     ( const ter_id & id ) {
         return get_map().ter( this->pos ) == id;
     };
-    if( std::any_of( ter_water.begin(), ter_water.end(), ter_check ) ) {
+    if( std::ranges::any_of( ter_water, ter_check ) ) {
         flags.append( _( " WATER" ) );
     }
 

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -25,6 +25,7 @@
 #include "weather.h"
 
 #if defined(TILES)
+#include <algorithm>
 #include <memory>
 
 #include "cata_tiles.h" // all animation functions will be pushed out to a cata_tiles function in some manner
@@ -113,7 +114,7 @@ bool is_radius_visible( const tripoint &center, int radius )
 
 bool is_layer_visible( const std::map<tripoint, explosion_tile> &layer )
 {
-    return std::any_of( layer.begin(), layer.end(),
+    return std::ranges::any_of( layer,
     []( const std::pair<tripoint, explosion_tile> &element ) {
         return is_point_visible( element.first );
     } );
@@ -1188,7 +1189,7 @@ void draw_cone_aoe( const tripoint &origin, const std::map<tripoint, double> &ao
             pv.val *= 1.0 - ( 2.0 / max_bucket_count );
         }
         combined_layer.insert( combined_layer.end(), layer.begin(), layer.end() );
-        if( std::any_of( combined_layer.begin(), combined_layer.end(),
+        if( std::ranges::any_of( combined_layer,
         []( const point_with_value & element ) {
         return is_point_visible( element.pt );
         } ) ) {

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -1,5 +1,7 @@
 #include "assign.h"
 
+#include <algorithm>
+
 void report_strict_violation( const JsonObject &jo, const std::string &message,
                               const std::string &name )
 {
@@ -349,8 +351,8 @@ bool assign( const JsonObject &jo,
                 obj.throw_error( "syntax error when specifying temperature", name );
             }
             const auto &unit_suffixes = units::temperature_units;
-            auto iter = std::find_if(
-                            unit_suffixes.begin(), unit_suffixes.end(),
+            auto iter = std::ranges::find_if(
+                            unit_suffixes,
                             [&suffix]( const std::pair<std::string, units::temperature> &
             suffix_value ) {
                 return suffix_value.first == suffix;
@@ -529,14 +531,14 @@ void check_assigned_dmg( const JsonObject &err,
                          const damage_instance &hi_inst )
 {
     for( const damage_unit &out_dmg : out.damage_units ) {
-        auto lo_iter = std::find_if(
-                           lo_inst.damage_units.begin(), lo_inst.damage_units.end(),
+        auto lo_iter = std::ranges::find_if(
+                           lo_inst.damage_units,
         [&out_dmg]( const damage_unit & du ) {
             return du.type == out_dmg.type || du.type == DT_NULL;
         } );
 
-        auto hi_iter = std::find_if(
-                           hi_inst.damage_units.begin(), hi_inst.damage_units.end(),
+        auto hi_iter = std::ranges::find_if(
+                           hi_inst.damage_units,
         [&out_dmg]( const damage_unit & du ) {
             return du.type == out_dmg.type || du.type == DT_NULL;
         } );

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -583,15 +583,15 @@ bool check_special_rule( const std::vector<material_id> &materials, const std::s
     }
 
     if( type == 'm' ) {
-        return std::any_of( materials.begin(), materials.end(), [&filter]( const material_id & mat ) {
-            return std::any_of( filter.begin(), filter.end(), [&mat]( const std::string & search ) {
+        return std::ranges::any_of( materials, [&filter]( const material_id & mat ) {
+            return std::ranges::any_of( filter, [&mat]( const std::string & search ) {
                 return lcmatch( mat->name(), search );
             } );
         } );
 
     } else if( type == 'M' ) {
-        return std::all_of( materials.begin(), materials.end(), [&filter]( const material_id & mat ) {
-            return std::any_of( filter.begin(), filter.end(), [&mat]( const std::string & search ) {
+        return std::ranges::all_of( materials, [&filter]( const material_id & mat ) {
+            return std::ranges::any_of( filter, [&mat]( const std::string & search ) {
                 return lcmatch( mat->name(), search );
             } );
         } );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -217,7 +217,7 @@ tripoint_abs_omt avatar::get_active_mission_target() const
 
 void avatar::set_active_mission( mission &cur_mission )
 {
-    const auto iter = std::find( active_missions.begin(), active_missions.end(), &cur_mission );
+    const auto iter = std::ranges::find( active_missions, &cur_mission );
     if( iter == active_missions.end() ) {
         debugmsg( "new active mission %d is not in the active_missions list", cur_mission.get_id() );
     } else {
@@ -241,7 +241,7 @@ void avatar::on_mission_finished( mission &cur_mission )
         add_msg_if_player( m_good, _( "Mission \"%s\" is successfully completed." ),
                            cur_mission.name() );
     }
-    const auto iter = std::find( active_missions.begin(), active_missions.end(), &cur_mission );
+    const auto iter = std::ranges::find( active_missions, &cur_mission );
     if( iter == active_missions.end() ) {
         debugmsg( "completed mission %d was not in the active_missions list", cur_mission.get_id() );
     } else {
@@ -482,8 +482,8 @@ bool avatar::read( item *loc, const bool continuous )
             };
 
             auto max_length = [&length]( const std::map<npc *, std::string> &m ) {
-                auto max_ele = std::max_element( m.begin(),
-                                                 m.end(), [&length]( const std::pair<npc *, std::string> &left,
+                auto max_ele = std::ranges::max_element( m,
+                               [&length]( const std::pair<npc *, std::string> &left,
                 const std::pair<npc *, std::string> &right ) {
                     return length( left ) < length( right );
                 } );
@@ -582,7 +582,7 @@ bool avatar::read( item *loc, const bool continuous )
     }
 
     if( !continuous ||
-    !std::all_of( learners.begin(), learners.end(), [&]( const std::pair<npc *, std::string> &elem ) {
+    !std::ranges::all_of( learners, [&]( const std::pair<npc *, std::string> &elem ) {
     return std::count( activity->values.begin(), activity->values.end(),
                        elem.first->getID().get_value() ) != 0;
     } ) ||
@@ -1067,7 +1067,7 @@ int avatar::free_upgrade_points() const
 
 std::optional<int> avatar::kill_xp_for_next_point() const
 {
-    auto it = std::lower_bound( xp_cutoffs.begin(), xp_cutoffs.end(), kill_xp() );
+    auto it = std::ranges::lower_bound( xp_cutoffs, kill_xp() );
     if( it == xp_cutoffs.end() ) {
         return std::nullopt;
     } else {
@@ -1306,8 +1306,8 @@ bool avatar::invoke_item( item *used, const tripoint &pt )
                              res.str() );
     }
 
-    umenu.desc_enabled = std::any_of( umenu.entries.begin(),
-    umenu.entries.end(), []( const uilist_entry & elem ) {
+    umenu.desc_enabled = std::ranges::any_of( umenu.entries,
+    []( const uilist_entry & elem ) {
         return !elem.desc.empty();
     } );
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -251,7 +251,7 @@ itype_id bionic_data::itype() const
 
 bool bionic_data::is_included( const bionic_id &id ) const
 {
-    return std::find( included_bionics.begin(), included_bionics.end(), id ) != included_bionics.end();
+    return std::ranges::find( included_bionics, id ) != included_bionics.end();
 }
 
 void bionic_data::load_bionic( const JsonObject &jo, const std::string &src )
@@ -1775,7 +1775,7 @@ void Character::process_bionic( bionic &bio )
         if( calendar::once_every( 30_turns ) ) {
             std::vector<effect *> bleeding_list = get_all_effects_of_type( effect_bleed );
             // Essential parts (Head/Torso) first.
-            std::sort( bleeding_list.begin(), bleeding_list.end(),
+            std::ranges::sort( bleeding_list,
             []( effect * a, effect * b ) {
                 return a->get_bp()->essential > b->get_bp()->essential;
             } );
@@ -1804,8 +1804,8 @@ void Character::process_bionic( bionic &bio )
                 const auto damaged_parts = [this, should_heal, sort_by]() {
                     const auto xs = get_all_body_parts( true );
                     auto ys = std::vector<bodypart_id> {};
-                    std::copy_if( xs.begin(), xs.end(), std::back_inserter( ys ), should_heal );
-                    std::sort( ys.begin(), ys.end(), sort_by );
+                    std::ranges::copy_if( xs, std::back_inserter( ys ), should_heal );
+                    std::ranges::sort( ys, sort_by );
                     return ys;
                 };
 
@@ -2690,7 +2690,7 @@ void Character::bionics_install_failure( const std::string &installer,
         case 4:
         case 5: {
             std::vector<bionic_id> valid;
-            std::copy_if( begin( faulty_bionics ), end( faulty_bionics ), std::back_inserter( valid ),
+            std::ranges::copy_if( faulty_bionics, std::back_inserter( valid ),
             [&]( const bionic_id & id ) {
                 return !has_bionic( id );
             } );
@@ -2972,7 +2972,7 @@ int bionic::get_quality( const quality_id &quality ) const
 bool bionic::is_this_fuel_powered( const itype_id &this_fuel ) const
 {
     const std::vector<itype_id> fuel_op = info().fuel_opts;
-    return std::find( fuel_op.begin(), fuel_op.end(), this_fuel ) != fuel_op.end();
+    return std::ranges::find( fuel_op, this_fuel ) != fuel_op.end();
 }
 
 void bionic::toggle_safe_fuel_mod()

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -1,5 +1,6 @@
 #include "bodypart.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <set>
 #include <unordered_map>
@@ -126,8 +127,8 @@ bool is_legacy_bodypart_id( const std::string &id )
         "NUM_BP",
     };
 
-    return std::find( legacy_body_parts.begin(), legacy_body_parts.end(),
-                      id ) != legacy_body_parts.end();
+    return std::ranges::find( legacy_body_parts,
+                              id ) != legacy_body_parts.end();
 }
 
 static body_part legacy_id_to_enum( const std::string &legacy_id )

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <numeric>
 #include <ostream>
+#include <ranges>
 #include <type_traits>
 
 #include "action.h"
@@ -656,7 +657,7 @@ auto Character::is_dead_state() const -> bool
     }
 
     const auto all_bps = get_all_body_parts( true );
-    cached_dead_state = std::any_of( all_bps.begin(), all_bps.end(), [this]( const bodypart_id & bp ) {
+    cached_dead_state = std::ranges::any_of( all_bps, [this]( const bodypart_id & bp ) {
         return bp->essential && get_part_hp_cur( bp ) <= 0;
     } );
     return cached_dead_state.value();
@@ -2757,7 +2758,7 @@ std::list<item *> Character::get_dependent_worn_items( const item &it ) const
             if( wit == &it || !wit->is_worn_only_with( it ) ) {
                 continue;
             }
-            const auto iter = std::find_if( dependent.begin(), dependent.end(),
+            const auto iter = std::ranges::find_if( dependent,
             [&wit]( const item * dit ) {
                 return wit == dit;
             } );
@@ -3351,7 +3352,7 @@ bool Character::wear_possessed( item &to_wear, bool interactive,
 
 ret_val<bool> Character::can_takeoff( const item &it, bool dropping ) const
 {
-    auto iter = std::find_if( worn.begin(), worn.end(), [ &it ]( item * wit ) {
+    auto iter = std::ranges::find_if( worn, [ &it ]( item * wit ) {
         return &it == wit;
     } );
 
@@ -3381,7 +3382,7 @@ bool Character::takeoff( item &it, std::vector<detached_ptr<item>> *res )
         return false;
     }
 
-    auto iter = std::find_if( worn.begin(), worn.end(), [ &it ]( item * wit ) {
+    auto iter = std::ranges::find_if( worn, [ &it ]( item * wit ) {
         return &it == wit;
     } );
 
@@ -3630,7 +3631,7 @@ bool Character::is_wearing_on_bp( const itype_id &it, const bodypart_id &bp ) co
 
 bool Character::worn_with_flag( const flag_id &flag, const bodypart_id &bp ) const
 {
-    return std::any_of( worn.begin(), worn.end(), [&flag, bp]( const item * const & it ) {
+    return std::ranges::any_of( worn, [&flag, bp]( const item * const & it ) {
         return it->has_flag( flag ) && ( bp == bodypart_str_id::NULL_ID() ||
                                          it->covers( bp ) );
     } );
@@ -3649,7 +3650,7 @@ const item *Character::item_worn_with_flag( const flag_id &flag, const bodypart_
 
 bool Character::worn_with_id( const itype_id &item_id, const bodypart_id &bp ) const
 {
-    return std::any_of( worn.begin(), worn.end(), [&item_id, bp]( const item * const & it ) {
+    return std::ranges::any_of( worn, [&item_id, bp]( const item * const & it ) {
         return it->typeId() == item_id && ( bp == bodypart_str_id::NULL_ID() ||
                                             it->covers( bp ) );
     } );
@@ -3921,7 +3922,7 @@ bool Character::meets_skill_requirements( const std::map<skill_id, int> &req,
 
 bool Character::meets_skill_requirements( const construction &con ) const
 {
-    return std::all_of( con.required_skills.begin(), con.required_skills.end(),
+    return std::ranges::all_of( con.required_skills,
     [&]( const std::pair<skill_id, int> &pr ) {
         return get_skill_level( pr.first ) >= pr.second;
     } );
@@ -4343,8 +4344,8 @@ location_vector<item>::iterator Character::position_to_wear_new_item( const item
 {
     // By default we put this item on after the last item on the same or any
     // lower layer.
-    return std::find_if(
-               worn.rbegin(), worn.rend(),
+    return std::ranges::find_if(
+               std::ranges::reverse_view( worn ),
     [&]( const item * const & w ) {
         return w->get_layer() <= new_item.get_layer();
     }
@@ -6671,12 +6672,12 @@ const std::vector<material_id> Character::fleshy = { material_id( "flesh" ), mat
 bool Character::made_of( const material_id &m ) const
 {
     // TODO: check for mutations that change this.
-    return std::find( fleshy.begin(), fleshy.end(), m ) != fleshy.end();
+    return std::ranges::find( fleshy, m ) != fleshy.end();
 }
 bool Character::made_of_any( const std::set<material_id> &ms ) const
 {
     // TODO: check for mutations that change this.
-    return std::any_of( fleshy.begin(), fleshy.end(), [&ms]( const material_id & e ) {
+    return std::ranges::any_of( fleshy, [&ms]( const material_id & e ) {
         return ms.count( e );
     } );
 }
@@ -8078,7 +8079,7 @@ void Character::shout( std::string msg, bool order )
 
     if( noise <= base ) {
         std::string dampened_shout;
-        std::transform( msg.begin(), msg.end(), std::back_inserter( dampened_shout ), tolower );
+        std::ranges::transform( msg, std::back_inserter( dampened_shout ), tolower );
         msg = std::move( dampened_shout );
     }
 
@@ -9719,7 +9720,7 @@ bool Character::has_activity( const activity_id &type ) const
 
 bool Character::has_activity( const std::vector<activity_id> &types ) const
 {
-    return std::find( types.begin(), types.end(), activity->id() ) != types.end();
+    return std::ranges::find( types, activity->id() ) != types.end();
 }
 
 void Character::cancel_activity()

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -344,7 +344,7 @@ static bool is_cqb_skill( const skill_id &id )
             skill_id( "bashing" ), skill_id( "stabbing" ),
         }
     };
-    return std::find( cqb_skills.begin(), cqb_skills.end(), id ) != cqb_skills.end();
+    return std::ranges::find( cqb_skills, id ) != cqb_skills.end();
 }
 
 namespace
@@ -1316,7 +1316,7 @@ void character_display::disp_info( Character &ch )
     const unsigned int effect_win_size_y_max = 1 + static_cast<unsigned>( effect_name_and_text.size() );
 
     std::vector<trait_id> traitslist = ch.get_mutations( false );
-    std::sort( traitslist.begin(), traitslist.end(), trait_display_sort );
+    std::ranges::sort( traitslist, trait_display_sort );
     const unsigned int trait_win_size_y_max = 1 + static_cast<unsigned>( traitslist.size() );
 
     std::vector<bionic> bionicslist = *ch.my_bionics;

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -1,5 +1,6 @@
 #include "character_functions.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "ammo.h"
@@ -449,7 +450,7 @@ std::string fmt_wielded_weapon( const Character &who )
         bool base = weapon.ammo_capacity() > 0 && !weapon.has_flag( flag_RELOAD_AND_SHOOT );
 
         const auto mods = weapon.gunmods();
-        bool aux = std::any_of( mods.begin(), mods.end(), [&]( const item * e ) {
+        bool aux = std::ranges::any_of( mods, [&]( const item * e ) {
             return e->is_gun() && e->ammo_capacity() > 0 && !e->has_flag( flag_RELOAD_AND_SHOOT );
         } );
 
@@ -543,7 +544,7 @@ bool try_wield_contents( Character &who, item &container, item *internal_item, b
     if( internal_item == nullptr ) {
         std::vector<std::string> opts;
         std::vector<item *> container_contents = container.contents.all_items_top();
-        std::transform( container_contents.begin(), container_contents.end(),
+        std::ranges::transform( container_contents,
         std::back_inserter( opts ), []( const item * elem ) {
             return elem->display_name();
         } );
@@ -818,7 +819,7 @@ item_reload_option select_ammo( const Character &who, item &base,
 
     // Construct item names
     std::vector<std::string> names;
-    std::transform( opts.begin(), opts.end(),
+    std::ranges::transform( opts,
     std::back_inserter( names ), [&]( const item_reload_option & e ) {
         const auto ammo_color = [&]( const std::string & name ) {
             return base.is_gun() && e.ammo->ammo_data() &&
@@ -849,7 +850,7 @@ item_reload_option select_ammo( const Character &who, item &base,
 
     // Get location descriptions
     std::vector<std::string> where;
-    std::transform( opts.begin(), opts.end(),
+    std::ranges::transform( opts,
     std::back_inserter( where ), [&]( const item_reload_option & e ) {
         bool is_ammo_container = e.ammo->is_ammo_container();
         if( is_ammo_container || e.ammo->is_container() ) {
@@ -1084,15 +1085,15 @@ item_reload_option select_ammo( const Character &who, item &base, bool prompt,
     }
 
     // sort in order of move cost (ascending), then remaining ammo (descending) with empty magazines always last
-    std::stable_sort( ammo_list.begin(), ammo_list.end(), []( const item_reload_option & lhs,
+    std::ranges::stable_sort( ammo_list, []( const item_reload_option & lhs,
     const item_reload_option & rhs ) {
         return lhs.ammo->ammo_remaining() > rhs.ammo->ammo_remaining();
     } );
-    std::stable_sort( ammo_list.begin(), ammo_list.end(), []( const item_reload_option & lhs,
+    std::ranges::stable_sort( ammo_list, []( const item_reload_option & lhs,
     const item_reload_option & rhs ) {
         return lhs.moves() < rhs.moves();
     } );
-    std::stable_sort( ammo_list.begin(), ammo_list.end(), []( const item_reload_option & lhs,
+    std::ranges::stable_sort( ammo_list, []( const item_reload_option & lhs,
     const item_reload_option & rhs ) {
         return ( lhs.ammo->ammo_remaining() != 0 ) > ( rhs.ammo->ammo_remaining() != 0 );
     } );

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -1473,7 +1473,7 @@ void computer_session::action_emerg_ref_center()
     std::vector<mission *> missions = g->u.get_active_missions();
     missions.insert( missions.end(), completed_missions.begin(), completed_missions.end() );
 
-    const bool has_mission = std::any_of( missions.begin(), missions.end(), [ &mission_type,
+    const bool has_mission = std::ranges::any_of( missions, [ &mission_type,
     &mission_target ]( mission * mission ) {
         if( mission->get_type().id == mission_type ) {
             mission_target = mission->get_target();

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -239,7 +239,7 @@ void finalize()
         }
         constructions_sorted.push_back( c.id.id() );
     }
-    std::sort( constructions_sorted.begin(), constructions_sorted.end(),
+    std::ranges::sort( constructions_sorted,
     [&]( const construction_id & l, const construction_id & r ) -> bool {
         lexicographic<construction> cmp;
         return cmp( l->id, r->id );
@@ -283,7 +283,7 @@ static std::vector<const construction *> constructions_by_group( const construct
 
 static void sort_constructions_by_name( std::vector<construction_group_str_id> &list )
 {
-    std::sort( list.begin(), list.end(),
+    std::ranges::sort( list,
     []( const construction_group_str_id & a, const construction_group_str_id & b ) {
         return localized_compare( a->name(), b->name() );
     } );
@@ -742,21 +742,21 @@ std::optional<construction_id> construction_menu( const bool blueprint )
                 constructs = available;
             } else if( category_id == construction_category_FILTER ) {
                 constructs.clear();
-                std::copy_if( available.begin(), available.end(),
-                              std::back_inserter( constructs ),
+                std::ranges::copy_if( available,
+                                      std::back_inserter( constructs ),
                 [&]( const construction_group_str_id & group ) {
                     return lcmatch( group->name(), filter );
                 } );
             } else if( category_id == construction_category_FAVORITE ) {
                 constructs.clear();
-                std::copy_if( available.begin(), available.end(), std::back_inserter( constructs ), is_favorite );
+                std::ranges::copy_if( available, std::back_inserter( constructs ), is_favorite );
             } else {
                 constructs = cat_available[category_id];
             }
             select = 0;
             if( last_construction ) {
-                const auto it = std::find( constructs.begin(), constructs.end(),
-                                           last_construction );
+                const auto it = std::ranges::find( constructs,
+                                                   last_construction );
                 if( it != constructs.end() ) {
                     select = std::distance( constructs.begin(), it );
                 }
@@ -984,14 +984,14 @@ bool can_construct( const construction &con, const tripoint &p )
     // see if the terrain type checks out
     place_okay &= has_pre_terrain( con, p );
     // see if the (deny) flags check out
-    place_okay &= std::none_of( con.deny_flags.begin(), con.deny_flags.end(),
+    place_okay &= std::ranges::none_of( con.deny_flags,
     [&p, &here]( const std::string & flag ) -> bool {
         const furn_id &furn = here.furn( p );
         const ter_id &ter = here.ter( p );
         return furn == f_null ? ter->has_flag( flag ) : furn->has_flag( flag );
     } );
     // see if the flags check out
-    place_okay &= std::all_of( con.pre_flags.begin(), con.pre_flags.end(),
+    place_okay &= std::ranges::all_of( con.pre_flags,
     [&p, &here]( const std::string & flag ) -> bool {
         const furn_id &furn = here.furn( p );
         const ter_id &ter = here.ter( p );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -177,8 +177,8 @@ void craft_command::execute( const tripoint &new_loc )
     crafter->last_batch = batch_size;
     crafter->lastrecipe = rec->ident();
 
-    const auto iter = std::find( uistate.recent_recipes.begin(), uistate.recent_recipes.end(),
-                                 rec->ident() );
+    const auto iter = std::ranges::find( uistate.recent_recipes,
+                                         rec->ident() );
     if( iter != uistate.recent_recipes.end() ) {
         uistate.recent_recipes.erase( iter );
     }
@@ -258,8 +258,8 @@ detached_ptr<item> craft_command::create_in_progress_craft()
         comp_used.count *= batch_size;
 
         //Handle duplicate component requirement
-        auto found_it = std::find_if( comps_used.begin(),
-        comps_used.end(), [&comp_used]( const item_comp & c ) {
+        auto found_it = std::ranges::find_if( comps_used,
+        [&comp_used]( const item_comp & c ) {
             return c.type == comp_used.type;
         } );
         if( found_it != comps_used.end() ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -407,7 +407,7 @@ bool player::check_eligible_containers_for_crafting( const recipe &rec, int batc
         }
 
         // we go through half-filled containers first, then go through empty containers if we need
-        std::sort( conts.begin(), conts.end(), item_ptr_compare_by_charges );
+        std::ranges::sort( conts, item_ptr_compare_by_charges );
 
         int charges_to_store = prod->charges;
         for( const item *cont : conts ) {
@@ -1684,7 +1684,7 @@ find_tool_component( const Character *player_with_inv, const std::vector<tool_co
         }
     }
 
-    std::sort( available_tools.begin(), available_tools.end(),
+    std::ranges::sort( available_tools,
     []( const avail_tool_comp & lhs, const avail_tool_comp & rhs ) {
         if( lhs.comp.use_from == usage_from::none && rhs.comp.use_from != usage_from::none ) {
             return true;
@@ -1722,7 +1722,7 @@ query_tool_selection( const std::vector<avail_tool_comp> &available_tools,
         return available_tools.front().comp;
     }
     if( is_npc ) {
-        auto iter = std::find_if( available_tools.begin(), available_tools.end(),
+        auto iter = std::ranges::find_if( available_tools,
         []( const avail_tool_comp & tool ) {
             return tool.comp.use_from == usage_from::player;
         } );
@@ -1962,7 +1962,7 @@ ret_val<bool> crafting::can_disassemble( const Character &who, const item &obj,
     }
 
     for( const auto &opts : dis.get_tools() ) {
-        const bool found = std::any_of( opts.begin(), opts.end(),
+        const bool found = std::ranges::any_of( opts,
         [&]( const tool_comp & tool ) {
             return ( tool.count <= 0 && inv.has_tools( tool.type, 1 ) ) ||
                    ( tool.count  > 0 && inv.has_charges( tool.type, tool.count ) );
@@ -2422,7 +2422,7 @@ std::set<itype_id> get_books_for_recipe( const Character &c, const inventory &cr
 std::set<itype_id> get_books_for_recipe( const recipe *r )
 {
     std::set<itype_id> book_ids;
-    std::transform( r->booksets.begin(), r->booksets.end(), std::inserter( book_ids, book_ids.end() ),
+    std::ranges::transform( r->booksets, std::inserter( book_ids, book_ids.end() ),
     []( const std::pair<itype_id, int> &pr ) {
         return pr.first;
     } );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -88,7 +88,7 @@ void load_recipe_category( const JsonObject &jsobj )
     }
 
     if( !is_hidden ) {
-        if( std::find( craft_cat_list.begin(), craft_cat_list.end(), category ) == craft_cat_list.end() ) {
+        if( std::ranges::find( craft_cat_list, category ) == craft_cat_list.end() ) {
             craft_cat_list.push_back( category );
         }
         const std::string cat_name = get_cat_unprefixed( category );
@@ -724,19 +724,19 @@ const recipe *select_crafting_recipe( int &batch_size_out )
                 }
 
                 if( subtab.cur() != "CSC_*_RECENT" ) {
-                    std::stable_sort( current.begin(), current.end(),
+                    std::ranges::stable_sort( current,
                     []( const recipe * a, const recipe * b ) {
                         return b->difficulty < a->difficulty;
                     } );
 
-                    std::stable_sort( current.begin(), current.end(),
+                    std::ranges::stable_sort( current,
                     [&]( const recipe * a, const recipe * b ) {
                         return availability_cache.at( a ).can_craft &&
                                !availability_cache.at( b ).can_craft;
                     } );
                 }
 
-                std::transform( current.begin(), current.end(),
+                std::ranges::transform( current,
                 std::back_inserter( available ), [&]( const recipe * e ) {
                     return availability_cache.at( e );
                 } );
@@ -975,7 +975,7 @@ std::string peek_related_recipe( const recipe *current, const recipe_subset &ava
             related_components.emplace_back( a.type, item::nname( a.type, 1 ) );
         }
     }
-    std::sort( related_components.begin(), related_components.end(), compare_second );
+    std::ranges::sort( related_components, compare_second );
     // current recipe result
     std::vector<std::pair<itype_id, std::string>> related_results;
     detached_ptr<item> tmp = current->create_result();
@@ -991,7 +991,7 @@ std::string peek_related_recipe( const recipe *current, const recipe_subset &ava
             related_results.emplace_back( b->result(), b->result_name() );
         }
     }
-    std::stable_sort( related_results.begin(), related_results.end(), compare_second );
+    std::ranges::stable_sort( related_results, compare_second );
 
     uilist rel_menu;
     int np_last = -1;

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -558,7 +558,7 @@ const recipe *select_crafting_recipe( int &batch_size_out )
             const nc_color color = avail.color( true );
             const std::string qry = trim( filterstring );
             std::string qry_comps;
-            if( qry.compare( 0, 2, "c:" ) == 0 ) {
+            if( qry.starts_with( "c:" ) ) {
                 qry_comps = qry.substr( 2 );
             }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1836,7 +1836,7 @@ std::vector<bodypart_id> Creature::get_all_body_parts( bool only_main ) const
         all_bps.emplace_back( elem.first );
     }
 
-    std::sort( all_bps.begin(), all_bps.end(),
+    std::ranges::sort( all_bps,
     []( const bodypart_id & lhs, const bodypart_id & rhs ) {
         return lhs->sort_order < rhs->sort_order;
     } );

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -34,7 +34,7 @@ shared_ptr_fast<monster> Creature_tracker::find( const tripoint &pos ) const
 
 int Creature_tracker::temporary_id( const monster &critter ) const
 {
-    const auto iter = std::find_if( monsters_list.begin(), monsters_list.end(),
+    const auto iter = std::ranges::find_if( monsters_list,
     [&]( const shared_ptr_fast<monster> &ptr ) {
         return ptr.get() == &critter;
     } );
@@ -108,7 +108,7 @@ void Creature_tracker::add_to_faction_map( const shared_ptr_fast<monster> &critt
 void Creature_tracker::update_faction( const monster &critter )
 {
     // find critter in monsters_list and obtain shared_ptr
-    const auto critter_ptr = std::find_if( monsters_list.begin(), monsters_list.end(),
+    const auto critter_ptr = std::ranges::find_if( monsters_list,
     [&]( const shared_ptr_fast<monster> &ptr ) {
         return ptr.get() == &critter;
     } );
@@ -159,7 +159,7 @@ bool Creature_tracker::update_pos( const monster &critter, const tripoint &new_p
         }
     }
 
-    const auto iter = std::find_if( monsters_list.begin(), monsters_list.end(),
+    const auto iter = std::ranges::find_if( monsters_list,
     [&]( const shared_ptr_fast<monster> &ptr ) {
         return ptr.get() == &critter;
     } );
@@ -190,7 +190,7 @@ void Creature_tracker::remove_from_location_map( const monster &critter )
 
     // When it's not in the map at its current location, it might still be there under,
     // another location, so look for it.
-    const auto iter = std::find_if( monsters_by_location.begin(), monsters_by_location.end(),
+    const auto iter = std::ranges::find_if( monsters_by_location,
     [&]( const decltype( monsters_by_location )::value_type & v ) {
         return v.second.get() == &critter;
     } );
@@ -201,7 +201,7 @@ void Creature_tracker::remove_from_location_map( const monster &critter )
 
 void Creature_tracker::remove( const monster &critter )
 {
-    const auto iter = std::find_if( monsters_list.begin(), monsters_list.end(),
+    const auto iter = std::ranges::find_if( monsters_list,
     [&]( const shared_ptr_fast<monster> &ptr ) {
         return ptr.get() == &critter;
     } );

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -1,5 +1,6 @@
 #include "damage.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <algorithm>
 #include <map>
@@ -132,7 +133,7 @@ void damage_instance::add( const damage_instance &added_di )
 
 void damage_instance::add( const damage_unit &new_du )
 {
-    auto iter = std::find_if( damage_units.begin(), damage_units.end(),
+    auto iter = std::ranges::find_if( damage_units,
     [&new_du]( const damage_unit & du ) {
         return du.type == new_du.type;
     } );
@@ -408,8 +409,8 @@ static damage_unit load_damage_unit_inherit( const JsonObject &curr, const damag
     damage_unit ret = load_damage_unit( curr );
 
     const std::vector<damage_unit> &parent_damage = parent.damage_units;
-    auto du_iter = std::find_if( parent_damage.begin(),
-    parent_damage.end(), [&ret]( const damage_unit & dmg ) {
+    auto du_iter = std::ranges::find_if( parent_damage,
+    [&ret]( const damage_unit & dmg ) {
         return dmg.type == ret.type;
     } );
 

--- a/src/dependency_tree.cpp
+++ b/src/dependency_tree.cpp
@@ -40,7 +40,7 @@ void dependency_node::add_child( dependency_node *child )
 
 void dependency_node::add_conflict( const dependency_node *conflict )
 {
-    auto it = std::find( conflicts.begin(), conflicts.end(), conflict );
+    auto it = std::ranges::find( conflicts, conflict );
     if( it == conflicts.end() ) {
         conflicts.push_back( conflict );
     }
@@ -103,7 +103,7 @@ void dependency_node::inherit_errors()
                 node_error_type error_type = cerror.first;
                 std::vector<std::string> cur_errors = all_errors[error_type];
                 for( auto &node_error : node_errors ) {
-                    if( std::find( cur_errors.begin(), cur_errors.end(), node_error ) ==
+                    if( std::ranges::find( cur_errors, node_error ) ==
                         cur_errors.end() ) {
                         all_errors[cerror.first].push_back( node_error );
                     }
@@ -176,7 +176,7 @@ std::vector<dependency_node *> dependency_node::get_dependencies_as_nodes() cons
     for( std::vector<dependency_node *>::reverse_iterator it =
              dependencies.rbegin();
          it != dependencies.rend(); ++it ) {
-        if( std::find( ret.begin(), ret.end(), *it ) == ret.end() ) {
+        if( std::ranges::find( ret, *it ) == ret.end() ) {
             ret.push_back( *it );
         }
     }
@@ -232,7 +232,7 @@ std::vector<dependency_node *> dependency_node::get_dependents_as_nodes() const
 
     // sort from front, keeping only one copy of the node
     for( auto &dependent : dependents ) {
-        if( std::find( ret.begin(), ret.end(), dependent ) == ret.end() ) {
+        if( std::ranges::find( ret, dependent ) == ret.end() ) {
             ret.push_back( dependent );
         }
     }
@@ -453,12 +453,12 @@ void dependency_tree::check_for_conflicting_dependencies()
     for( auto &node : master_node_map ) {
         dependency_node *this_node = &node.second;
         std::vector<dependency_node *> all_deps = get_dependencies_of_X_as_nodes( node.first );
-        std::sort( all_deps.begin(), all_deps.end(), depnode_comparator );
+        std::ranges::sort( all_deps, depnode_comparator );
 
         for( auto dep_it = all_deps.begin(); dep_it != all_deps.end(); dep_it++ ) {
             const dependency_node *this_dep = *dep_it;
             std::vector<const dependency_node *> this_dep_conflicts = this_dep->conflicts;
-            std::sort( this_dep_conflicts.begin(), this_dep_conflicts.end(), depnode_comparator );
+            std::ranges::sort( this_dep_conflicts, depnode_comparator );
 
             std::vector<const dependency_node *> both;
             std::set_intersection(

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -179,7 +179,7 @@ std::string map_data_common_t::extended_description() const
     std::stringstream ss;
     ss << "<header>" << string_format( _( "That is a %s." ), name() ) << "</header>" << '\n';
     ss << description << '\n';
-    bool has_any_harvest = std::any_of( harvest_by_season.begin(), harvest_by_season.end(),
+    bool has_any_harvest = std::ranges::any_of( harvest_by_season,
     []( const harvest_id & hv ) {
         return !hv.obj().empty();
     } );

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -68,7 +68,7 @@ std::vector<efftype_id> find_all_effect_types()
 {
     std::vector<efftype_id> all;
     all.reserve( effect_types.size() );
-    std::transform( effect_types.begin(), effect_types.end(), std::back_inserter( all ),
+    std::ranges::transform( effect_types, std::back_inserter( all ),
     []( const std::pair<efftype_id, effect_type> &pr ) {
         return pr.first;
     } );
@@ -1387,8 +1387,8 @@ void load_effect_type( const JsonObject &jo )
 
     assign( jo, "morale", new_etype.morale );
 
-    const auto morale_effect = std::find_if( new_etype.mod_data.begin(),
-    new_etype.mod_data.end(), []( decltype( *new_etype.mod_data.begin() ) & pr ) {
+    const auto morale_effect = std::ranges::find_if( new_etype.mod_data,
+    []( decltype( *new_etype.mod_data.begin() ) & pr ) {
         return std::get<2>( pr.first ) == "MORALE";
     } );
     bool has_morale_effect = morale_effect != new_etype.mod_data.end();

--- a/src/event_bus.cpp
+++ b/src/event_bus.cpp
@@ -46,7 +46,7 @@ void event_bus::subscribe( event_subscriber *s )
 
 void event_bus::unsubscribe( event_subscriber *s )
 {
-    auto it = std::find( subscribers.begin(), subscribers.end(), s );
+    auto it = std::ranges::find( subscribers, s );
     if( it == subscribers.end() ) {
         debugmsg( "Trying to remove subscriber that isn't there" );
     } else {

--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -1,8 +1,10 @@
 #include "font_loader.h"
 
+#include <algorithm>
+
 void ensure_unifont_loaded( std::vector<std::string> &font_list )
 {
-    if( std::find( std::begin( font_list ), std::end( font_list ), "unifont" ) == font_list.end() ) {
+    if( std::ranges::find( font_list, "unifont" ) == font_list.end() ) {
         font_list.emplace_back( PATH_INFO::fontdir() + "unifont.ttf" );
     }
 }

--- a/src/fungal_effects.cpp
+++ b/src/fungal_effects.cpp
@@ -239,8 +239,8 @@ void fungal_effects::spread_fungus_one_tile( const tripoint &p, const int growth
             // Replace the (already existing) seed
             // Can't use item_stack::only_item() since there might be fertilizer
             map_stack items = m.i_at( p );
-            const map_stack::iterator seed = std::find_if( items.begin(),
-            items.end(), []( const item * const & it ) {
+            const map_stack::iterator seed = std::ranges::find_if( items,
+            []( const item * const & it ) {
                 return it->is_seed();
             } );
             if( seed == items.end() || !( *seed )->is_seed() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8551,7 +8551,7 @@ void game::butcher()
                 //uses default craft materials to estimate recursive disassembly time
                 const auto components = dis.disassembly_requirements().get_components();
                 for( const auto &subcomps : components ) {
-                    if( subcomps.size() > 0 ) {
+                    if( !subcomps.empty() ) {
                         disassembly_stacks_res.emplace_back( subcomps.front().type,
                                                              subcomps.front().count * disassembly_stacks_res[i].second );
                     }

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -132,7 +132,7 @@ void gate_data::check() const
 bool gate_data::is_suitable_wall( const tripoint &pos ) const
 {
     const auto wid = get_map().ter( pos );
-    const auto iter = std::find_if( walls.begin(), walls.end(), [ wid ]( const ter_str_id & wall ) {
+    const auto iter = std::ranges::find_if( walls, [ wid ]( const ter_str_id & wall ) {
         return wall.id() == wid;
     } );
     return iter != walls.end();
@@ -314,7 +314,7 @@ void doors::close_door( map &m, Character &who, const tripoint &closep )
         if( m.furn( closep ) != furn_str_id( "f_safe_o" ) && !items_in_way.empty() ) {
             const units::volume max_nudge = 25_liter;
 
-            const auto toobig = std::find_if( items_in_way.begin(), items_in_way.end(),
+            const auto toobig = std::ranges::find_if( items_in_way,
             [&max_nudge]( const item * const & it ) {
                 return it->volume() > max_nudge;
             } );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1469,7 +1469,7 @@ static void cast_spell()
     spell &sp = *u.magic->get_spells()[spell_index];
 
     std::set<trait_id> blockers = sp.get_blocker_muts();
-    if( blockers.size() ) {
+    if( !blockers.empty() ) {
         for( trait_id blocker : blockers ) {
             if( u.has_trait( blocker ) ) {
                 add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -107,7 +107,7 @@ const harvest_id &harvest_list::load( const JsonObject &jo, const std::string &s
 
 void harvest_list::finalize()
 {
-    std::transform( entries_.begin(), entries_.end(), std::inserter( names_, names_.begin() ),
+    std::ranges::transform( entries_, std::inserter( names_, names_.begin() ),
     []( const harvest_entry & entry ) {
         return itype_id( entry.drop ).is_valid() ?
                item::nname( itype_id( entry.drop ) ) : "";

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1334,7 +1334,7 @@ static item *find_best_prying_tool( player &p )
     } );
 
     // Sort by their quality level.
-    std::sort( prying_items.begin(), prying_items.end(), []( const item * a, const item * b ) -> bool {
+    std::ranges::sort( prying_items, []( const item * a, const item * b ) -> bool {
         return a->get_quality( quality_id( "PRY" ) ) > b->get_quality( quality_id( "PRY" ) );
     } );
 
@@ -1458,7 +1458,7 @@ static item *find_best_lock_picking_tool( player &p )
     } );
 
     // Sort by their picklock level.
-    std::sort( picklocks.begin(), picklocks.end(), [&]( const item * a, const item * b ) {
+    std::ranges::sort( picklocks, [&]( const item * a, const item * b ) {
         return a->get_quality( qual_LOCKPICK ) > b->get_quality( qual_LOCKPICK );
     } );
 
@@ -2220,7 +2220,7 @@ std::vector<seed_tuple> iexamine::get_seed_entries( const std::vector<item *> &s
     }
 
     // Sort by name
-    std::sort( seed_entries.begin(), seed_entries.end(),
+    std::ranges::sort( seed_entries,
     []( const seed_tuple & l, const seed_tuple & r ) {
         return std::get<1>( l ).compare( std::get<1>( r ) ) < 0;
     } );
@@ -2386,8 +2386,8 @@ void iexamine::harvest_plant( player &p, const tripoint &examp, bool from_activi
     map &here = get_map();
     // Can't use item_stack::only_item() since there might be fertilizer
     map_stack items = here.i_at( examp );
-    map_stack::iterator seed_it = std::find_if( items.begin(),
-    items.end(), []( const item * const & it ) {
+    map_stack::iterator seed_it = std::ranges::find_if( items,
+    []( const item * const & it ) {
         return it->is_seed();
     } );
 
@@ -2488,8 +2488,8 @@ void iexamine::fertilize_plant( player &p, const tripoint &tile, const itype_id 
 
     // Can't use item_stack::only_item() since there might be fertilizer
     map_stack items = here.i_at( tile );
-    map_stack::iterator seed_it = std::find_if( items.begin(),
-    items.end(), []( const item * const & it ) {
+    map_stack::iterator seed_it = std::ranges::find_if( items,
+    []( const item * const & it ) {
         return it->is_seed();
     } );
     if( seed_it == items.end() ) {
@@ -2522,7 +2522,7 @@ itype_id iexamine::choose_fertilizer( player &p, const std::string &pname, bool 
     std::vector<itype_id> f_types;
     std::vector<std::string> f_names;
     for( auto &f : f_inv ) {
-        if( std::find( f_types.begin(), f_types.end(), f->typeId() ) == f_types.end() ) {
+        if( std::ranges::find( f_types, f->typeId() ) == f_types.end() ) {
             f_types.push_back( f->typeId() );
             f_names.push_back( f->tname() );
         }
@@ -2549,8 +2549,8 @@ void iexamine::aggie_plant( player &p, const tripoint &examp )
     map &here = get_map();
     // Can't use item_stack::only_item() since there might be fertilizer
     map_stack items = here.i_at( examp );
-    map_stack::iterator seed_it = std::find_if( items.begin(),
-    items.end(), []( const item * const & it ) {
+    map_stack::iterator seed_it = std::ranges::find_if( items,
+    []( const item * const & it ) {
         return it->is_seed();
     } );
 
@@ -2870,11 +2870,11 @@ void iexamine::autoclave_full( player &, const tripoint &examp )
     }
 
     map_stack items = here.i_at( examp );
-    bool cbms = std::all_of( items.begin(), items.end(), []( const item * const & i ) {
+    bool cbms = std::ranges::all_of( items, []( const item * const & i ) {
         return i->is_bionic();
     } );
 
-    bool cbms_not_packed = std::all_of( items.begin(), items.end(), []( const item * const & i ) {
+    bool cbms_not_packed = std::ranges::all_of( items, []( const item * const & i ) {
         return i->is_bionic() && i->has_flag( flag_NO_PACKED );
     } );
 
@@ -3053,7 +3053,7 @@ void iexamine::fvat_empty( player &p, const tripoint &examp )
         std::vector<itype_id> b_types;
         std::vector<std::string> b_names;
         for( auto &b : b_inv ) {
-            if( std::find( b_types.begin(), b_types.end(), b->typeId() ) == b_types.end() ) {
+            if( std::ranges::find( b_types, b->typeId() ) == b_types.end() ) {
                 b_types.push_back( b->typeId() );
                 b_names.push_back( item::nname( b->typeId() ) );
             }
@@ -3289,7 +3289,7 @@ void iexamine::keg( player &p, const tripoint &examp )
         std::vector<std::string> drink_names;
         std::vector<double> drink_rot;
         for( auto &drink : drinks_inv ) {
-            auto found_drink = std::find( drink_types.begin(), drink_types.end(), drink->typeId() );
+            auto found_drink = std::ranges::find( drink_types, drink->typeId() );
             if( found_drink == drink_types.end() ) {
                 drink_types.push_back( drink->typeId() );
                 drink_names.push_back( item::nname( drink->typeId() ) );
@@ -4870,7 +4870,7 @@ static player &best_installer( player &p, player &null_player, int difficulty )
                            skill_electronics );
         ally_skills.push_back( ally_skill );
     }
-    std::sort( ally_skills.begin(), ally_skills.end(), [&]( const std::pair<float, int> &lhs,
+    std::ranges::sort( ally_skills, [&]( const std::pair<float, int> &lhs,
     const std::pair<float, int> &rhs ) {
         return rhs.first < lhs.first;
     } );
@@ -5664,7 +5664,7 @@ static void smoker_load_food( player &p, const tripoint &examp,
             count = inv.amount_of( smokable_item->typeId() );
         }
         if( count != 0 ) {
-            auto on_list = std::find( names.begin(), names.end(), item::nname( smokable_item->typeId(), 1 ) );
+            auto on_list = std::ranges::find( names, item::nname( smokable_item->typeId(), 1 ) );
             if( on_list == names.end() ) {
                 smenu.addentry( item::nname( smokable_item->typeId(), 1 ) );
                 entries.push_back( smokable_item );
@@ -5773,7 +5773,7 @@ static void mill_load_food( player &p, const tripoint &examp,
             count = inv.amount_of( millable_item->typeId() );
         }
         if( count != 0 ) {
-            auto on_list = std::find( names.begin(), names.end(), item::nname( millable_item->typeId(), 1 ) );
+            auto on_list = std::ranges::find( names, item::nname( millable_item->typeId(), 1 ) );
             if( on_list == names.end() ) {
                 smenu.addentry( item::nname( millable_item->typeId(), 1 ) );
                 entries.push_back( millable_item );

--- a/src/iexamine_elevator.cpp
+++ b/src/iexamine_elevator.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <optional>
 
 #include "cata_algo.h"
@@ -49,7 +50,7 @@ auto dest( const elevator::tiles &elevator_here,
            int movez ) -> elevator::tiles
 {
     elevator::tiles tiles;
-    std::transform( elevator_here.begin(), elevator_here.end(), std::back_inserter( tiles ),
+    std::ranges::transform( elevator_here, std::back_inserter( tiles ),
     [turns, &sm_orig, movez]( tripoint const & p ) {
         return rotate_point_sm( { p.xy(), movez }, sm_orig, turns );
     } );
@@ -107,7 +108,7 @@ auto vehicle_status( const wrapped_vehicle &veh, const elevator::tiles &tiles ) 
     const int all_vparts_count = ps.part_count();
     const int vparts_inside = std::count_if( ps.begin(), ps.end(), [&]( const vpart_reference & vp ) {
         const tripoint p = veh.pos + vp.part().precalc[0];
-        const auto eit = std::find( tiles.cbegin(), tiles.cend(), p );
+        const auto eit = std::ranges::find( tiles, p );
         return eit != tiles.cend();
     } );
 
@@ -161,13 +162,13 @@ auto move_creatures_away( const elevator::tiles &dest ) -> void
     for( Creature &critter : g->all_creatures() ) {
         const tripoint local_pos = here.getlocal( here.getglobal( critter.pos() ) );
 
-        const auto eit = std::find( dest.cbegin(), dest.cend(), local_pos );
+        const auto eit = std::ranges::find( dest, local_pos );
         if( eit == dest.cend() ) {
             continue;
         }
 
         const auto xs = closest_points_first( *eit, 10 );
-        const auto candidate = std::find_if( xs.begin(), xs.end(), is_movable );
+        const auto candidate = std::ranges::find_if( xs, is_movable );
         if( candidate == xs.end() ) {
             continue;
         }
@@ -190,7 +191,7 @@ auto move_items( const elevator::tiles &from, const elevator::tiles &dest ) -> v
 auto move_creatures( const elevator::tiles &from, const elevator::tiles &dest ) -> void
 {
     for( Creature &critter : g->all_creatures() ) {
-        const auto eit = std::find( from.cbegin(), from.cend(), critter.pos() );
+        const auto eit = std::ranges::find( from, critter.pos() );
         if( eit != from.cend() ) {
             critter.setpos( dest[ std::distance( from.cbegin(), eit ) ] );
         }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -420,7 +420,7 @@ int input_manager::get_keycode( const std::string &name ) const
         return a->second;
     }
     // Not found in map, try to parse as int
-    if( name.compare( 0, 8, "UNKNOWN_" ) == 0 ) {
+    if( name.starts_with( "UNKNOWN_" ) ) {
         return str_to_int( name.substr( 8 ) );
     }
     return 0;

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1,5 +1,6 @@
 #include "inventory.h"
 
+#include <algorithm>
 #include <climits>
 #include <cmath>
 #include <cstdint>
@@ -100,7 +101,7 @@ void invlet_favorites::erase( char invlet )
         return;
     }
     std::string &invlets = invlets_by_id[id];
-    std::string::iterator it = std::find( invlets.begin(), invlets.end(), invlet );
+    std::string::iterator it = std::ranges::find( invlets, invlet );
     invlets.erase( it );
     ids_by_invlet[invlet_u] = itype_id();
 }
@@ -372,7 +373,7 @@ void inventory::restack( player &p )
     for( invstack::iterator iter = items.begin(); iter != items.end(); ++iter, ++idx ) {
         std::vector<item *> &stack = *iter;
         // Sort the inner stack itself, so the most recently used item is at front and keeps the invlet
-        std::sort( stack.begin(), stack.end(), []( auto * lhs, auto * rhs ) {
+        std::ranges::sort( stack, []( auto * lhs, auto * rhs ) {
             return *lhs < *rhs;
         } );
         item &topmost = *stack.front();
@@ -1204,7 +1205,7 @@ void inventory::assign_empty_invlet( item &it, const Character &p, const bool fo
                 // don't overwrite assigned keys
                 continue;
             }
-            if( std::find( binds.begin(), binds.end(), inv_char ) != binds.end() ) {
+            if( std::ranges::find( binds, inv_char ) != binds.end() ) {
                 // don't auto-assign bound keys
                 continue;
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -709,7 +709,7 @@ void item::ammo_set( const itype_id &ammo, int qty )
                     return;
                 }
                 std::vector<itype_id> opts( iter->second.begin(), iter->second.end() );
-                std::sort( opts.begin(), opts.end(), []( const itype_id & lhs, const itype_id & rhs ) {
+                std::ranges::sort( opts, []( const itype_id & lhs, const itype_id & rhs ) {
                     return lhs->magazine->capacity < rhs->magazine->capacity;
                 } );
                 mag = opts.back();
@@ -2479,7 +2479,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
 
     std::map<gun_mode_id, gun_mode> fire_modes = mod->gun_all_modes();
     if( parts->test( iteminfo_parts::GUN_BURST_PENALTY ) ) {
-        if( std::any_of( fire_modes.begin(), fire_modes.end(),
+        if( std::ranges::any_of( fire_modes,
         []( const std::pair<gun_mode_id, gun_mode> &e ) {
         return e.second.qty > 1 && !e.second.melee();
         } ) ) {
@@ -3892,7 +3892,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query &parts_
                                    _( "* This item is <info>not rigid</info>.  Its"
                                       " volume and encumbrance increase with contents." ) );
             } else {
-                bool any_encumb_increase = std::any_of( armor->data.begin(), armor->data.end(),
+                bool any_encumb_increase = std::ranges::any_of( armor->data,
                 []( armor_portion_data data ) {
                     return data.encumber != data.max_encumber;
                 } );
@@ -4170,15 +4170,15 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query &parts_
             } else {
                 // Extract item names from recipes and sort them
                 std::vector<std::pair<std::string, bool>> result_names;
-                std::transform(
-                    item_recipes.begin(), item_recipes.end(),
+                std::ranges::transform(
+                    item_recipes,
                     std::back_inserter( result_names ),
                 [&crafting_inv]( const recipe * r ) {
                     bool can_make = r->deduped_requirements().can_make_with_inventory(
                                         crafting_inv, r->get_component_filter() );
                     return std::make_pair( r->result_name(), can_make );
                 } );
-                std::sort( result_names.begin(), result_names.end(), localized_compare );
+                std::ranges::sort( result_names, localized_compare );
                 const std::string recipes =
                     enumerate_as_string( result_names.begin(), result_names.end(),
                 []( const std::pair<std::string, bool> &p ) {
@@ -4832,7 +4832,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     }
 
     if( !faults.empty() ) {
-        const bool silent = std::any_of( faults.begin(), faults.end(), []( const fault_id & f ) -> bool { return f->has_flag( "SILENT" ); } );
+        const bool silent = std::ranges::any_of( faults, []( const fault_id & f ) -> bool { return f->has_flag( "SILENT" ); } );
         if( silent ) {
             damtext.insert( 0, dirt_symbol );
         } else {
@@ -6275,7 +6275,7 @@ int item::get_encumber_when_containing(
         if( entry.covers.test( bodypart.id() ) ) {
             encumber = entry.encumber;
             // Non-rigid items add additional encumbrance proportional to their volume
-            bool any_encumb_increase = std::any_of( armor->data.begin(), armor->data.end(),
+            bool any_encumb_increase = std::ranges::any_of( armor->data,
             []( armor_portion_data data ) {
                 return data.encumber != data.max_encumber;
             } );
@@ -6929,7 +6929,7 @@ bool item::made_of_any( const std::set<material_id> &mat_idents ) const
         return false;
     }
 
-    return std::any_of( mats.begin(), mats.end(), [&mat_idents]( const material_id & e ) {
+    return std::ranges::any_of( mats, [&mat_idents]( const material_id & e ) {
         return mat_idents.count( e );
     } );
 }
@@ -6941,7 +6941,7 @@ bool item::only_made_of( const std::set<material_id> &mat_idents ) const
         return false;
     }
 
-    return std::all_of( mats.begin(), mats.end(), [&mat_idents]( const material_id & e ) {
+    return std::ranges::all_of( mats, [&mat_idents]( const material_id & e ) {
         return mat_idents.count( e );
     } );
 }
@@ -6949,7 +6949,7 @@ bool item::only_made_of( const std::set<material_id> &mat_idents ) const
 bool item::made_of( const material_id &mat_ident ) const
 {
     const std::vector<material_id> &materials = made_of();
-    return std::find( materials.begin(), materials.end(), mat_ident ) != materials.end();
+    return std::ranges::find( materials, mat_ident ) != materials.end();
 }
 
 bool item::contents_made_of( const phase_id phase ) const
@@ -6981,7 +6981,7 @@ bool item::conductive() const
 
     // If any material has electricity resistance equal to or lower than flesh (1) we are conductive.
     const std::vector<const material_type *> &mats = made_of_types();
-    return std::any_of( mats.begin(), mats.end(), []( const material_type * mt ) {
+    return std::ranges::any_of( mats, []( const material_type * mt ) {
         return mt->elec_resist() <= 1;
     } );
 }
@@ -6994,7 +6994,7 @@ bool item::reinforceable() const
 
     // If a material is reinforceable, so are we
     const std::vector<const material_type *> &mats = made_of_types();
-    return std::any_of( mats.begin(), mats.end(), []( const material_type * mt ) {
+    return std::ranges::any_of( mats, []( const material_type * mt ) {
         return mt->reinforces();
     } );
 }
@@ -7402,7 +7402,7 @@ bool item::is_salvageable() const
         return false;
     }
     const std::vector<material_id> &mats = made_of();
-    if( std::none_of( mats.begin(), mats.end(), []( const material_id & m ) {
+    if( std::ranges::none_of( mats, []( const material_id & m ) {
     return m->salvaged_into().has_value();
     } ) ) {
         return false;
@@ -8240,7 +8240,7 @@ std::vector<const item *> item::gunmods() const
 item *item::gunmod_find( const itype_id &mod )
 {
     std::vector<item *> mods = gunmods();
-    auto it = std::find_if( mods.begin(), mods.end(), [&mod]( item * e ) {
+    auto it = std::ranges::find_if( mods, [&mod]( item * e ) {
         return e->typeId() == mod;
     } );
     return it != mods.end() ? *it : nullptr;
@@ -8284,7 +8284,7 @@ ret_val<bool> item::is_gunmod_compatible( const item &mod ) const
             if( excluded ) {
                 break;
             }
-            if( std::all_of( mod_cat.begin(), mod_cat.end(), [this]( const weapon_category_id & wcid ) {
+            if( std::ranges::all_of( mod_cat, [this]( const weapon_category_id & wcid ) {
             return this->type->weapon_category.count( wcid );
             } ) ) {
                 excluded = true;
@@ -8302,7 +8302,7 @@ ret_val<bool> item::is_gunmod_compatible( const item &mod ) const
             if( usable || excluded ) {
                 break;
             }
-            if( std::all_of( mod_cat.begin(), mod_cat.end(), [this]( const weapon_category_id & wcid ) {
+            if( std::ranges::all_of( mod_cat, [this]( const weapon_category_id & wcid ) {
             return this->type->weapon_category.count( wcid );
             } ) ) {
                 usable = true;
@@ -8369,8 +8369,8 @@ std::map<gun_mode_id, gun_mode> item::gun_all_modes() const
             for( const std::pair<const gun_mode_id, gun_modifier_data> &m : e->type->gun->modes ) {
                 // prefix attached gunmods, e.g. M203_DEFAULT to avoid index key collisions
                 std::string prefix = e->is_gunmod() ? ( std::string( e->typeId() ) += "_" ) : "";
-                std::transform( prefix.begin(), prefix.end(), prefix.begin(),
-                                static_cast<int( * )( int )>( toupper ) );
+                std::ranges::transform( prefix, prefix.begin(),
+                                        static_cast<int( * )( int )>( toupper ) );
 
                 const int qty = m.second.qty();
 
@@ -10416,7 +10416,7 @@ bool item::has_effect_when_wielded( art_effect_passive effect ) const
         return false;
     }
     const std::vector<art_effect_passive> &ew = type->artifact->effects_wielded;
-    return std::find( ew.begin(), ew.end(), effect ) != ew.end();
+    return std::ranges::find( ew, effect ) != ew.end();
 }
 
 bool item::has_effect_when_worn( art_effect_passive effect ) const
@@ -10425,7 +10425,7 @@ bool item::has_effect_when_worn( art_effect_passive effect ) const
         return false;
     }
     const std::vector<art_effect_passive> &ew = type->artifact->effects_worn;
-    return std::find( ew.begin(), ew.end(), effect ) != ew.end();
+    return std::ranges::find( ew, effect ) != ew.end();
 }
 
 bool item::has_effect_when_carried( art_effect_passive effect ) const
@@ -10434,7 +10434,7 @@ bool item::has_effect_when_carried( art_effect_passive effect ) const
         return false;
     }
     const std::vector<art_effect_passive> &ec = type->artifact->effects_carried;
-    if( std::find( ec.begin(), ec.end(), effect ) != ec.end() ) {
+    if( std::ranges::find( ec, effect ) != ec.end() ) {
         return true;
     }
     for( const item *i : contents.all_items_top() ) {
@@ -10501,7 +10501,7 @@ bool item::is_tainted() const
 bool item::is_soft() const
 {
     const std::vector<material_id> mats = made_of();
-    return std::any_of( mats.begin(), mats.end(), []( const material_id & mid ) {
+    return std::ranges::any_of( mats, []( const material_id & mid ) {
         return mid.obj().soft();
     } );
 }
@@ -10753,7 +10753,7 @@ std::vector<item_comp> item::get_uncraft_components() const
     } else {
         //Make a new vector of components from the registered components
         for( const item * const &component : components ) {
-            auto iter = std::find_if( ret.begin(), ret.end(), [component]( item_comp & obj ) {
+            auto iter = std::ranges::find_if( ret, [component]( item_comp & obj ) {
                 return obj.type == component->typeId();
             } );
 

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -277,7 +277,7 @@ void game::item_action_menu()
         } );
     };
     // Add mapped actions to the menu vector.
-    std::transform( iactions.begin(), iactions.end(), std::back_inserter( menu_items ),
+    std::ranges::transform( iactions, std::back_inserter( menu_items ),
     []( const std::pair<item_action_id, item *> &elem ) {
         std::string ss = elem.second->display_name();
         if( elem.second->ammo_required() ) {

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1,5 +1,6 @@
 #include "item_contents.h"
 
+#include <algorithm>
 #include <limits>
 #include <algorithm>
 #include <memory>
@@ -121,7 +122,7 @@ void item_contents::set_item_defaults()
 void item_contents::migrate_item( item &obj, const std::set<itype_id> &migrations )
 {
     for( const itype_id &c : migrations ) {
-        if( std::none_of( items.begin(), items.end(), [&]( const item * const & e ) {
+        if( std::ranges::none_of( items, [&]( const item * const & e ) {
         return e->typeId() == c;
         } ) ) {
             obj.put_in( item::spawn( c, obj.birthday() ) );
@@ -131,7 +132,7 @@ void item_contents::migrate_item( item &obj, const std::set<itype_id> &migration
 
 bool item_contents::has_any_with( const std::function<bool( const item &it )> &filter ) const
 {
-    return std::any_of( items.begin(), items.end(), [&filter]( const item * const & it ) -> bool{ return filter( *it );} );
+    return std::ranges::any_of( items, [&filter]( const item * const & it ) -> bool{ return filter( *it );} );
 }
 
 bool item_contents::stacks_with( const item_contents &rhs ) const
@@ -144,8 +145,8 @@ bool item_contents::stacks_with( const item_contents &rhs ) const
 
 item *item_contents::get_item_with( const std::function<bool( const item &it )> &filter )
 {
-    auto bomb_it = std::find_if( items.begin(),
-                                 items.end(), [&filter]( const item * const & it ) -> bool{ return filter( *it );} );
+    auto bomb_it = std::ranges::find_if( items,
+                                         [&filter]( const item * const & it ) -> bool{ return filter( *it );} );
     if( bomb_it == items.end() ) {
         return nullptr;
     } else {
@@ -160,8 +161,8 @@ const std::vector<item *> &item_contents::all_items_top() const
 
 detached_ptr<item> item_contents::remove_top( item *it )
 {
-    auto iter = std::find_if( items.begin(),
-    items.end(), [&it]( item *&against ) {
+    auto iter = std::ranges::find_if( items,
+    [&it]( item *&against ) {
         return against == it;
     } );
     detached_ptr<item> ret;

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -53,7 +53,7 @@ detached_ptr<item> Single_item_creator::create_single( const time_point &birthda
             tmp = item::spawn( id, birthday );
         }
     } else if( type == S_ITEM_GROUP ) {
-        if( std::find( rec.begin(), rec.end(), id ) != rec.end() ) {
+        if( std::ranges::find( rec, id ) != rec.end() ) {
             debugmsg( "recursion in item spawn list %s", id.c_str() );
             return detached_ptr<item>();
         }
@@ -97,7 +97,7 @@ std::vector<detached_ptr<item>> Single_item_creator::create( const time_point &b
                 result.push_back( std::move( itm ) );
             }
         } else {
-            if( std::find( rec.begin(), rec.end(), id ) != rec.end() ) {
+            if( std::ranges::find( rec, id ) != rec.end() ) {
                 debugmsg( "recursion in item spawn list %s", id.c_str() );
                 return result;
             }

--- a/src/iteminfo_armor.cpp
+++ b/src/iteminfo_armor.cpp
@@ -78,7 +78,7 @@ auto parts_to_display( const item &it,
 {
     auto result = std::vector<BodyPartInfoPair>();
 
-    std::copy_if( xs.begin(), xs.end(), std::back_inserter( result ),
+    std::ranges::copy_if( xs, std::back_inserter( result ),
     [&it, armor]( const auto & piece ) {
         if( !piece.second.active ) {
             return false;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7274,7 +7274,7 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
                               e.c_str() );
                 }
 
-                const bool selfie = std::find( player_vec.begin(), player_vec.end(), p ) != player_vec.end();
+                const bool selfie = std::ranges::find( player_vec, p ) != player_vec.end();
 
                 if( selfie ) {
                     p->add_msg_if_player( _( "You took a selfie." ) );

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -235,7 +235,7 @@ static std::vector<language_info> load_languages( const std::string &filepath )
 
     for( language_info &info : ret ) {
         for( const std::string &g : info.genders ) {
-            if( find( all_genders.begin(), all_genders.end(), g ) == all_genders.end() ) {
+            if( std::ranges::find( all_genders, g ) == all_genders.end() ) {
                 debugmsg( "Unexpected gender '%s' in grammatical gender list for language '%d'",
                           g, info.id );
             }

--- a/src/legacy_pathfinding.cpp
+++ b/src/legacy_pathfinding.cpp
@@ -1,5 +1,6 @@
 #include "legacy_pathfinding.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <algorithm>
 #include <optional>
@@ -218,7 +219,7 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
         const auto &pf_cache = get_pathfinding_cache_ref( f.z );
         // Check all points for any special case (including just hard terrain)
         if( !( pf_cache.special[f.x][f.y] & non_normal ) &&
-        std::all_of( line_path.begin(), line_path.end(), [&pf_cache]( const tripoint & p ) {
+        std::ranges::all_of( line_path, [&pf_cache]( const tripoint & p ) {
         return !( pf_cache.special[p.x][p.y] & non_normal );
         } ) ) {
             const std::set<tripoint> sorted_line( line_path.begin(), line_path.end() );
@@ -544,7 +545,7 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
             cur = par;
         }
 
-        std::reverse( ret.begin(), ret.end() );
+        std::ranges::reverse( ret );
     }
 
     return ret;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1,6 +1,7 @@
 #include "lightmap.h" // IWYU pragma: associated
 #include "shadowcasting.h" // IWYU pragma: associated
 
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -229,8 +230,8 @@ bool map::build_vision_transparency_cache( const Character &player )
                 dirty = true;
                 vision_transparency_cache[i] = VISION_ADJUST_SOLID;
             } else {
-                if( std::find( four_diagonal_offsets.begin(), four_diagonal_offsets.end(),
-                               adjacent ) != four_diagonal_offsets.end() ) {
+                if( std::ranges::find( four_diagonal_offsets,
+                                       adjacent ) != four_diagonal_offsets.end() ) {
                     const optional_vpart_position adjacent_vp = veh_at( p + adjacent );
 
                     point adjacent_mount;
@@ -1483,8 +1484,8 @@ void map::apply_vision_transparency_cache( const tripoint &center, int target_z,
             transparency_cache[p.x][p.y] = LIGHT_TRANSPARENCY_SOLID;
         } else if( vision_transparency_cache[i] == VISION_ADJUST_HIDDEN ) {
 
-            if( std::find( four_diagonal_offsets.begin(), four_diagonal_offsets.end(),
-                           adjacent ) == four_diagonal_offsets.end() ) {
+            if( std::ranges::find( four_diagonal_offsets,
+                                   adjacent ) == four_diagonal_offsets.end() ) {
                 debugmsg( "Hidden tile not on a diagonal" );
                 continue;
             }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1709,7 +1709,7 @@ static std::string enumerate_spell_data( const spell &sp )
 static std::string enumerate_traits( const std::set<trait_id> st )
 {
     std::vector<std::string> str_vector;
-    if( st.size() ) {
+    if( !st.empty() ) {
         for( trait_id trait : st ) {
             str_vector.push_back( trait->name() );
         }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -649,7 +649,7 @@ void area_expander::sort_ascending()
 {
     // Since internal caches like 'area_search' and 'frontier' use indexes inside 'area',
     // these caches will be invalidated.
-    std::sort( area.begin(), area.end(),
+    std::ranges::sort( area,
     []( const node & a, const node & b )  -> bool {
         return a.cost < b.cost;
     } );
@@ -659,7 +659,7 @@ void area_expander::sort_descending()
 {
     // Since internal caches like 'area_search' and 'frontier' use indexes inside 'area',
     // these caches will be invalidated.
-    std::sort( area.begin(), area.end(),
+    std::ranges::sort( area,
     []( const node & a, const node & b ) -> bool {
         return a.cost > b.cost;
     } );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -514,7 +514,7 @@ void map::vehmove()
         auto same_ptr = [ elem ]( const struct wrapped_vehicle & tgt ) {
             return elem == tgt.v;
         };
-        if( std::find_if( vehicle_list.begin(), vehicle_list.end(), same_ptr ) !=
+        if( std::ranges::find_if( vehicle_list, same_ptr ) !=
             vehicle_list.end() ) {
             elem->part_removal_cleanup();
         }
@@ -570,8 +570,8 @@ bool map::vehproceed( VehicleList &vehicle_list )
 
         // Check if any vehicles exist in the active range for this z-level
         cache.veh_in_active_range = cache.veh_in_active_range &&
-                                    std::any_of( std::begin( cache.veh_exists_at ),
-        std::end( cache.veh_exists_at ), []( const auto & row ) {
+                                    std::ranges::any_of( cache.veh_exists_at,
+        []( const auto & row ) {
             return std::any_of( std::begin( row ), std::end( row ), []( bool veh_exists ) {
                 return veh_exists;
             } );
@@ -584,7 +584,7 @@ bool map::vehproceed( VehicleList &vehicle_list )
 static bool sees_veh( const Creature &c, vehicle &veh, bool force_recalc )
 {
     const auto &veh_points = veh.get_points( force_recalc );
-    return std::any_of( veh_points.begin(), veh_points.end(), [&c]( const tripoint & pt ) {
+    return std::ranges::any_of( veh_points, [&c]( const tripoint & pt ) {
         return c.sees( pt );
     } );
 }
@@ -1576,8 +1576,8 @@ std::string map::furnname( const tripoint &p )
     if( f.has_flag( "PLANT" ) ) {
         // Can't use item_stack::only_item() since there might be fertilizer
         map_stack items = i_at( p );
-        const map_stack::iterator seed = std::find_if( items.begin(),
-        items.end(), []( const item * const & it ) {
+        const map_stack::iterator seed = std::ranges::find_if( items,
+        []( const item * const & it ) {
             return it->is_seed();
         } );
         if( seed == items.end() ) {
@@ -1818,7 +1818,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain )
     // HACK: Hack around ledges in traplocs or else it gets NASTY in z-level mode
     if( old_t.trap != tr_null && old_t.trap != tr_ledge ) {
         auto &traps = traplocs[old_t.trap.to_i()];
-        const auto iter = std::find( traps.begin(), traps.end(), p );
+        const auto iter = std::ranges::find( traps, p );
         if( iter != traps.end() ) {
             traps.erase( iter );
         }
@@ -5196,7 +5196,7 @@ static void use_charges_from_furn( const furn_t &f, const itype_id &type, int &q
                 continue;
             }
             auto stack = m->i_at( p );
-            auto iter = std::find_if( stack.begin(), stack.end(),
+            auto iter = std::ranges::find_if( stack,
             [ammo]( const item * const & i ) {
                 return i->typeId() == ammo;
             } );
@@ -5603,7 +5603,7 @@ void map::remove_trap( const tripoint &p )
 
         current_submap->set_trap( l, tr_null );
         auto &traps = traplocs[tid.to_i()];
-        const auto iter = std::find( traps.begin(), traps.end(), p );
+        const auto iter = std::ranges::find( traps, p );
         if( iter != traps.end() ) {
             traps.erase( iter );
         }
@@ -7531,8 +7531,8 @@ void map::grow_plant( const tripoint &p )
     }
     // Can't use item_stack::only_item() since there might be fertilizer
     map_stack items = i_at( p );
-    map_stack::iterator seed_it = std::find_if( items.begin(),
-    items.end(), []( const item * const & it ) {
+    map_stack::iterator seed_it = std::ranges::find_if( items,
+    []( const item * const & it ) {
         return it->is_seed();
     } );
 
@@ -7558,8 +7558,8 @@ void map::grow_plant( const tripoint &p )
             }
 
             // Remove fertilizer if any
-            map_stack::iterator fertilizer = std::find_if( items.begin(),
-            items.end(), []( const item * const & it ) {
+            map_stack::iterator fertilizer = std::ranges::find_if( items,
+            []( const item * const & it ) {
                 return it->has_flag( flag_FERTILIZER );
             } );
             if( fertilizer != items.end() ) {
@@ -7574,8 +7574,8 @@ void map::grow_plant( const tripoint &p )
             }
 
             // Remove fertilizer if any
-            map_stack::iterator fertilizer = std::find_if( items.begin(),
-            items.end(), []( const item * const & it ) {
+            map_stack::iterator fertilizer = std::ranges::find_if( items,
+            []( const item * const & it ) {
                 return it->has_flag( flag_FERTILIZER );
             } );
             if( fertilizer != items.end() ) {

--- a/src/map_item_stack.cpp
+++ b/src/map_item_stack.cpp
@@ -60,7 +60,7 @@ std::vector<map_item_stack> filter_item_stacks( const std::vector<map_item_stack
     std::vector<map_item_stack> ret;
 
     auto z = item_filter_from_string( filter );
-    std::copy_if( stack.begin(), stack.end(),
+    std::ranges::copy_if( stack,
     std::back_inserter( ret ), [z]( const map_item_stack & a ) {
         if( a.example != nullptr ) {
             return z( *a.example );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1275,8 +1275,8 @@ void map_data_common_t::load( const JsonObject &jo, const std::string &src )
         for( JsonObject harvest_jo : jo.get_array( "harvest_by_season" ) ) {
             auto season_strings = harvest_jo.get_tags( "seasons" );
             std::set<season_type> seasons;
-            std::transform( season_strings.begin(), season_strings.end(), std::inserter( seasons,
-                            seasons.begin() ), io::string_to_enum<season_type> );
+            std::ranges::transform( season_strings, std::inserter( seasons,
+                                    seasons.begin() ), io::string_to_enum<season_type> );
 
             harvest_id hl;
             if( harvest_jo.has_array( "entries" ) ) {

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -2181,7 +2181,7 @@ void mapgen_forest( mapgendata &dat )
         for( auto &b : dat.region.forest_composition.biomes ) {
             factors.push_back( b.second.sparseness_adjacency_factor );
         }
-        return *max_element( std::begin( factors ), std::end( factors ) );
+        return *std::ranges::max_element( factors );
     };
 
     // Get the sparesness factor for this terrain, and fill it.
@@ -2557,16 +2557,16 @@ void mapgen_lake_shore( mapgendata &dat )
                 }
             }
 
-            if( std::find( dat.region.overmap_lake.shore_extendable_overmap_terrain.begin(),
-                           dat.region.overmap_lake.shore_extendable_overmap_terrain.end(),
-                           match ) != dat.region.overmap_lake.shore_extendable_overmap_terrain.end() ) {
+            if( std::ranges::find( dat.region.overmap_lake.shore_extendable_overmap_terrain,
+
+                                   match ) != dat.region.overmap_lake.shore_extendable_overmap_terrain.end() ) {
                 adjacent_type_count[match] += 1;
             }
         }
 
         if( !adjacent_type_count.empty() ) {
-            const auto most_common_adjacent = std::max_element( std::begin( adjacent_type_count ),
-                                              std::end( adjacent_type_count ), []( const std::pair<oter_id, int> &p1,
+            const auto most_common_adjacent = std::ranges::max_element( adjacent_type_count,
+                                              []( const std::pair<oter_id, int> &p1,
             const std::pair<oter_id, int> &p2 ) {
                 return p1.second < p2.second;
             } );

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -1,5 +1,7 @@
 #include "mapgendata.h"
 
+#include <algorithm>
+
 #include "all_enum_values.h"
 #include "debug.h"
 #include "int_id.h"
@@ -41,7 +43,7 @@ mapgendata::mapgendata( map &mp, dummy_settings_t )
 {
     oter_id any = oter_id( "field" );
     t_above = t_below = terrain_type_ = any;
-    std::fill( std::begin( t_nesw ), std::end( t_nesw ), any );
+    std::ranges::fill( t_nesw, any );
 }
 
 mapgendata::mapgendata( const tripoint_abs_omt &over, map &mp, const float density,

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -547,7 +547,7 @@ bool ma_requirements::is_valid_character( const Character &u ) const
     if( !weapon_categories_allowed.empty() && is_armed ) {
         bool valid_weap_cat = false;
         for( const weapon_category_id &w_cat : weapon_categories_allowed ) {
-            if( u.used_weapon().typeId()->weapon_category.count( w_cat ) > 0 ) {
+            if( u.used_weapon().typeId()->weapon_category.contains( w_cat ) ) {
                 valid_weap_cat = true;
             }
         }
@@ -739,7 +739,7 @@ const ma_buff *ma_buff::from_effect( const effect &eff )
 {
     const std::string &id = eff.get_effect_type()->id.str();
     // Same as in get_effect_id!
-    if( id.compare( 0, 7, "mabuff:" ) != 0 ) {
+    if( !id.starts_with( "mabuff:" ) ) {
         return nullptr;
     }
     return &mabuff_id( id.substr( 7 ) ).obj();

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -317,7 +317,7 @@ material_list materials::get_compactable()
 {
     material_list all = get_all();
     material_list compactable;
-    std::copy_if( all.begin(), all.end(),
+    std::ranges::copy_if( all,
     std::back_inserter( compactable ), []( const material_type & mt ) {
         return !mt.compacts_into().empty();
     } );

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -141,7 +141,7 @@ class messages_impl
             }
 
             // update the cooldown message timer due to coalescing
-            const auto cooldown_it = std::find_if( cooldown_templates.begin(), cooldown_templates.end(),
+            const auto cooldown_it = std::ranges::find_if( cooldown_templates,
             [&m]( game_message & am ) -> bool {
                 return m.message == am.message;
             } );
@@ -209,7 +209,7 @@ class messages_impl
 
             // We look for **exactly the same** message string in the cooldown templates
             // If there is one, this means the same message was already displayed.
-            const auto cooldown_it = std::find_if( cooldown_templates.begin(), cooldown_templates.end(),
+            const auto cooldown_it = std::ranges::find_if( cooldown_templates,
             [&message]( game_message & m_cooldown ) -> bool {
                 return m_cooldown.message == message.message;
             } );
@@ -288,8 +288,8 @@ class messages_impl
 
             // Is the message string already in the cooldown queue?
             // If it's not we must put it in the cooldown queue now, otherwise just increment the number of times we have seen it.
-            const auto cooldown_message_it = std::find_if( cooldown_templates.begin(),
-            cooldown_templates.end(), [&message]( game_message & cooldown_message ) -> bool {
+            const auto cooldown_message_it = std::ranges::find_if( cooldown_templates,
+            [&message]( game_message & cooldown_message ) -> bool {
                 return cooldown_message.message == message.message;
             } );
             if( cooldown_message_it == cooldown_templates.end() ) {

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -487,8 +487,8 @@ void mission::get_all_item_group_matches( std::vector<item *> &items,
             std::vector<item *> content = std::vector<item *>();
 
             //list of item into list item*
-            std::transform(
-                content_list.begin(), content_list.end(),
+            std::ranges::transform(
+                content_list,
                 std::back_inserter( content ),
             []( item * p ) {
                 return p;

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -250,7 +250,7 @@ void mission_type::load( const JsonObject &jo, const std::string &src )
         }
     }
 
-    if( std::any_of( origins.begin(), origins.end(), []( mission_origin origin ) {
+    if( std::ranges::any_of( origins, []( mission_origin origin ) {
     return origin == ORIGIN_ANY_NPC || origin == ORIGIN_OPENER_NPC || origin == ORIGIN_SECONDARY;
 } ) ) {
         auto djo = jo.get_object( "dialogue" );
@@ -464,7 +464,7 @@ mission_type_id mission_type::get_random_id( const mission_origin origin,
 {
     std::vector<mission_type_id> valid;
     for( auto &t : get_all() ) {
-        if( std::find( t.origins.begin(), t.origins.end(), origin ) == t.origins.end() ) {
+        if( std::ranges::find( t.origins, origin ) == t.origins.end() ) {
             continue;
         }
         if( t.place( p ) ) {

--- a/src/mod_manager_ui.cpp
+++ b/src/mod_manager_ui.cpp
@@ -154,7 +154,7 @@ static void check_conflicts( const mod_id &mod, const std::vector<mod_id> &activ
 
 ret_val<bool> mod_ui::try_add( const mod_id &mod_to_add, std::vector<mod_id> &active_list )
 {
-    if( std::find( active_list.begin(), active_list.end(), mod_to_add ) != active_list.end() ) {
+    if( std::ranges::find( active_list, mod_to_add ) != active_list.end() ) {
         // The same mod can not be added twice. That makes no sense.
         return ret_val<bool>::make_failure( _( "The mod is already on the list." ) );
     }
@@ -200,7 +200,7 @@ ret_val<bool> mod_ui::try_add( const mod_id &mod_to_add, std::vector<mod_id> &ac
         std::vector<mod_id> mods_to_add;
         bool new_core = false;
         for( auto &i : dependencies ) {
-            if( std::find( active_list.begin(), active_list.end(), i ) == active_list.end() ) {
+            if( std::ranges::find( active_list, i ) == active_list.end() ) {
                 if( i->core ) {
                     mods_to_add.insert( mods_to_add.begin(), i );
                     new_core = true;
@@ -241,12 +241,12 @@ void mod_ui::try_rem( size_t selection, std::vector<mod_id> &active_list )
 
     // search through the rest of the active list for mods that depend on this one
     for( auto &i : dependents ) {
-        auto rem = std::find( active_list.begin(), active_list.end(), i );
+        auto rem = std::ranges::find( active_list, i );
         if( rem != active_list.end() ) {
             active_list.erase( rem );
         }
     }
-    std::vector<mod_id>::iterator rem = std::find( active_list.begin(), active_list.end(),
+    std::vector<mod_id>::iterator rem = std::ranges::find( active_list,
                                         sel_string );
     if( rem != active_list.end() ) {
         active_list.erase( rem );
@@ -314,7 +314,7 @@ bool mod_ui::can_shift_up( size_t selection, const std::vector<mod_id> &active_l
 
     mod_id newsel_id = active_list[newsel];
     bool newsel_is_dependency =
-        std::find( dependencies.begin(), dependencies.end(), newsel_id ) != dependencies.end();
+        std::ranges::find( dependencies, newsel_id ) != dependencies.end();
 
     return !newsel_id->core && !newsel_is_dependency;
 }
@@ -339,7 +339,7 @@ bool mod_ui::can_shift_down( size_t selection, const std::vector<mod_id> &active
     mod_id modstring = active_list[newsel];
     mod_id selstring = active_list[oldsel];
     bool sel_is_dependency =
-        std::find( dependents.begin(), dependents.end(), selstring ) != dependents.end();
+        std::ranges::find( dependents, selstring ) != dependents.end();
 
     return !modstring->core && !sel_is_dependency;
 }

--- a/src/mod_tileset.cpp
+++ b/src/mod_tileset.cpp
@@ -38,7 +38,7 @@ void reset_mod_tileset()
 
 bool mod_tileset::is_compatible( const std::string &tileset_id ) const
 {
-    const auto iter = std::find( compatibility.begin(), compatibility.end(), tileset_id );
+    const auto iter = std::ranges::find( compatibility, tileset_id );
     return iter != compatibility.end();
 }
 

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -657,7 +657,7 @@ void mdeath::broken( monster &z )
         return;
     }
     std::string item_id = z.type->id.str();
-    if( item_id.compare( 0, 4, "mon_" ) == 0 ) {
+    if( item_id.starts_with( "mon_" ) ) {
         item_id.erase( 0, 4 );
     }
     // make "broken_manhack", or "broken_eyebot", ...

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3514,7 +3514,7 @@ void monster::add_item( detached_ptr<item> &&it )
 
 detached_ptr<item> monster::remove_item( item *it )
 {
-    auto iter = std::find( inv.begin(), inv.end(), it );
+    auto iter = std::ranges::find( inv, it );
     detached_ptr<item> ret;
     if( iter != inv.end() ) {
         inv.erase( iter, &ret );

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1357,8 +1357,8 @@ void mtype::add_special_attack( const JsonObject &obj, const std::string &src )
 
     if( special_attacks.contains( new_attack->id ) ) {
         special_attacks.erase( new_attack->id );
-        const auto iter = std::find( special_attacks_names.begin(), special_attacks_names.end(),
-                                     new_attack->id );
+        const auto iter = std::ranges::find( special_attacks_names,
+                                             new_attack->id );
         if( iter != special_attacks_names.end() ) {
             special_attacks_names.erase( iter );
         }
@@ -1383,7 +1383,7 @@ void mtype::add_special_attack( JsonArray inner, const std::string & )
 
     if( special_attacks.contains( name ) ) {
         special_attacks.erase( name );
-        const auto iter = std::find( special_attacks_names.begin(), special_attacks_names.end(), name );
+        const auto iter = std::ranges::find( special_attacks_names, name );
         if( iter != special_attacks_names.end() ) {
             special_attacks_names.erase( iter );
         }
@@ -1422,7 +1422,7 @@ void mtype::remove_special_attacks( const JsonObject &jo, const std::string &mem
 {
     for( const std::string &name : jo.get_tags( member_name ) ) {
         special_attacks.erase( name );
-        const auto iter = std::find( special_attacks_names.begin(), special_attacks_names.end(), name );
+        const auto iter = std::ranges::find( special_attacks_names, name );
         if( iter != special_attacks_names.end() ) {
             special_attacks_names.erase( iter );
         }

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -377,7 +377,7 @@ void player_morale::set_permanent_typed( const morale_type &type, int bonus,
 
 bool player_morale::has( const morale_type &type ) const
 {
-    return std::any_of( points.begin(), points.end(), [&type]( const morale_point & m ) {
+    return std::ranges::any_of( points, [&type]( const morale_point & m ) {
         return m.type_matches( type );
     } );
 }
@@ -385,7 +385,7 @@ bool player_morale::has( const morale_type &type ) const
 int player_morale::get( const morale_type &type ) const
 {
     // TODO: This should be well defined for multiple bonuses of the same type!
-    auto iter = std::find_if( points.begin(), points.end(), [&type]( const morale_point & m ) {
+    auto iter = std::ranges::find_if( points, [&type]( const morale_point & m ) {
         return m.type_matches( type );
     } );
     return iter != points.end() ? iter->get_net_bonus() : 0;
@@ -527,7 +527,7 @@ void player_morale::decay( const time_duration &ticks )
         m.decay( ticks );
     };
 
-    std::for_each( points.begin(), points.end(), do_decay );
+    std::ranges::for_each( points, do_decay );
     remove_expired();
     update_bodytemp_penalty( ticks );
     invalidate();
@@ -658,8 +658,8 @@ void player_morale::display( int focus_eq, int pain_penalty, int fatigue_cap )
         return localized_compare( std::make_pair( -lhs_percent, lhs.get_name() ),
                                   std::make_pair( -rhs_percent, rhs.get_name() ) );
     };
-    std::sort( positive_morale.begin(), positive_morale.end(), sort_morale );
-    std::sort( negative_morale.begin(), negative_morale.end(), sort_morale );
+    std::ranges::sort( positive_morale, sort_morale );
+    std::ranges::sort( negative_morale, sort_morale );
 
     // Initialize lines
     const std::vector<morale_line> top_lines {
@@ -849,7 +849,7 @@ bool player_morale::consistent_with( const player_morale &morale ) const
                 continue;
             }
 
-            const auto iter = std::find_if( rhs.points.begin(), rhs.points.end(),
+            const auto iter = std::ranges::find_if( rhs.points,
             [ &lhp ]( const morale_point & rhp ) {
                 return lhp.matches( rhp );
             } );

--- a/src/mtype.cpp
+++ b/src/mtype.cpp
@@ -87,7 +87,7 @@ void mtype::set_flag( m_flag flag, bool state )
 
 bool mtype::made_of( const material_id &material ) const
 {
-    return std::find( mat.begin(), mat.end(),  material ) != mat.end();
+    return std::ranges::find( mat,  material ) != mat.end();
 }
 
 bool mtype::made_of_any( const std::set<material_id> &materials ) const
@@ -96,7 +96,7 @@ bool mtype::made_of_any( const std::set<material_id> &materials ) const
         return false;
     }
 
-    return std::any_of( mat.begin(), mat.end(), [&materials]( const material_id & e ) {
+    return std::ranges::any_of( mat, [&materials]( const material_id & e ) {
         return materials.count( e );
     } );
 }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1,5 +1,6 @@
 #include "mutation.h"
 
+#include <algorithm>
 #include <cmath>
 #include <algorithm>
 #include <cstdlib>
@@ -106,7 +107,7 @@ bool Character::has_trait( const trait_id &b ) const
 
 bool Character::has_trait_flag( const trait_flag_str_id &b ) const
 {
-    return std::any_of( cached_mutations.cbegin(), cached_mutations.cend(),
+    return std::ranges::any_of( cached_mutations,
     [&b]( const mutation_branch * mut ) -> bool {
         return mut->flags.contains( b );
     } );
@@ -710,7 +711,7 @@ static std::map<mutation_category_id, float> calc_category_weights(
     const std::map<mutation_category_id, int> &mcl, bool addition )
 {
     std::map<mutation_category_id, float> category_weights;
-    auto max_lvl_iter = std::max_element( mcl.begin(), mcl.end(),
+    auto max_lvl_iter = std::ranges::max_element( mcl,
     []( const auto & best, const auto & current ) {
         return current.second > best.second;
     } );
@@ -1121,7 +1122,7 @@ bool Character::mutate_towards( const trait_id &mut )
 
     // Check mutations of the same type - except for the ones we might need for pre-reqs
     for( const auto &consider : same_type ) {
-        if( std::find( all_prereqs.begin(), all_prereqs.end(), consider ) == all_prereqs.end() ) {
+        if( std::ranges::find( all_prereqs, consider ) == all_prereqs.end() ) {
             cancel.push_back( consider );
         }
     }
@@ -1511,7 +1512,7 @@ static mutagen_rejection try_reject_mutagen( Character &guy, const item &it, boo
             "MYCUS", "MARLOSS", "MARLOSS_SEED", "MARLOSS_GEL"
         }
     };
-    if( std::any_of( safe.begin(), safe.end(), [&it]( const std::string & flag ) {
+    if( std::ranges::any_of( safe, [&it]( const std::string & flag ) {
     return it.type->can_use( flag );
     } ) ) {
         return mutagen_rejection::accepted;
@@ -1689,7 +1690,7 @@ bool are_same_type_traits( const trait_id &trait_a, const trait_id &trait_b )
 
 bool contains_trait( std::vector<string_id<mutation_branch>> traits, const trait_id &trait )
 {
-    return std::find( traits.begin(), traits.end(), trait ) != traits.end();
+    return std::ranges::find( traits, trait ) != traits.end();
 }
 
 bool can_use_mutation( const trait_id &mut, const Character &character )

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1127,7 +1127,7 @@ detached_ptr<item> npc::wear_if_wanted( detached_ptr<item> &&it, std::string &re
                 continue;
             }
             // Find an item that covers the same body part as the new item
-            auto iter = std::find_if( worn.begin(), worn.end(), [bp]( const item * const & armor ) {
+            auto iter = std::ranges::find_if( worn, [bp]( const item * const & armor ) {
                 return armor->covers( bp );
             } );
             if( iter != worn.end() && !( is_limb_broken( bp ) && ( *iter )->has_flag( flag_SPLINT ) ) ) {
@@ -2877,7 +2877,7 @@ bool npc::dispose_item( item &obj, const std::string & )
         return true;
     }
 
-    const auto mn = std::min_element( opts.begin(), opts.end(),
+    const auto mn = std::ranges::min_element( opts,
     []( const dispose_option & lop, const dispose_option & rop ) {
         return lop.moves < rop.moves;
     } );

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -1,5 +1,6 @@
 #include "npc_class.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <list>
 #include <algorithm>
@@ -275,8 +276,8 @@ void npc_class::load( const JsonObject &jo, const std::string & )
             &p ) {
                 return p.second.id == mutation;
             };
-            if( std::find_if( mutation_categories.begin(), mutation_categories.end(),
-                              category_match ) == mutation_categories.end() ) {
+            if( std::ranges::find_if( mutation_categories,
+                                      category_match ) == mutation_categories.end() ) {
                 debugmsg( "Unrecognized mutation category %s", mutation.str() );
                 continue;
             }

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -103,7 +103,7 @@ void talk_function::assign_mission( npc &p )
     }
     miss->assign( g->u );
     p.chatbin.missions_assigned.push_back( miss );
-    const auto it = std::find( p.chatbin.missions.begin(), p.chatbin.missions.end(), miss );
+    const auto it = std::ranges::find( p.chatbin.missions, miss );
     p.chatbin.missions.erase( it );
 }
 
@@ -147,8 +147,8 @@ void talk_function::clear_mission( npc &p )
         debugmsg( "clear_mission: mission_selected == nullptr" );
         return;
     }
-    const auto it = std::find( p.chatbin.missions_assigned.begin(), p.chatbin.missions_assigned.end(),
-                               miss );
+    const auto it = std::ranges::find( p.chatbin.missions_assigned,
+                                       miss );
     if( it == p.chatbin.missions_assigned.end() ) {
         debugmsg( "clear_mission: mission_selected not in assigned" );
         return;
@@ -424,8 +424,8 @@ void talk_function::bionic_remove( npc &p )
     std::vector<itype_id> bionic_types;
     std::vector<std::string> bionic_names;
     for( const bionic &bio : all_bio ) {
-        if( std::find( bionic_types.begin(), bionic_types.end(),
-                       bio.info().itype() ) == bionic_types.end() ) {
+        if( std::ranges::find( bionic_types,
+                               bio.info().itype() ) == bionic_types.end() ) {
             if( bio.id != bio_power_storage ||
                 bio.id != bio_power_storage_mkII ) {
                 bionic_types.push_back( bio.info().itype() );

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -188,7 +188,7 @@ std::vector<item_pricing> npc_trading::init_buying( player &buyer, player &selle
                                   std::make_pair( b.locs.front()->get_category(), b.locs.front()->display_name() ) );
     };
 
-    std::sort( result.begin(), result.end(), cmp );
+    std::ranges::sort( result, cmp );
 
     return result;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,5 +1,6 @@
 #include "options.h"
 
+#include <algorithm>
 #include <locale>
 #include <cfloat>
 #include <climits>
@@ -763,8 +764,8 @@ int options_manager::cOpt::value_as<int>() const
 std::string options_manager::cOpt::getValueName() const
 {
     if( sType == "string_select" ) {
-        const auto iter = std::find_if( vItems.begin(),
-        vItems.end(), [&]( const id_and_option & e ) {
+        const auto iter = std::ranges::find_if( vItems,
+        [&]( const id_and_option & e ) {
             return e.first == sSet;
         } );
         if( iter != vItems.end() ) {
@@ -789,7 +790,7 @@ std::string options_manager::cOpt::getValueName() const
 std::string options_manager::cOpt::getDefaultText( const bool bTranslated ) const
 {
     if( sType == "string_select" ) {
-        const auto iter = std::find_if( vItems.begin(), vItems.end(),
+        const auto iter = std::ranges::find_if( vItems,
         [this]( const id_and_option & elem ) {
             return elem.first == sDefault;
         } );
@@ -1108,7 +1109,7 @@ std::vector<options_manager::id_and_option> options_manager::build_tilesets_list
     std::vector<options_manager::id_and_option> user_tilesets = load_tilesets_from(
                 PATH_INFO::user_gfx() );
     for( const options_manager::id_and_option &id : user_tilesets ) {
-        if( std::find( result.begin(), result.end(), id ) == result.end() ) {
+        if( std::ranges::find( result, id ) == result.end() ) {
             result.emplace_back( id );
         }
     }
@@ -2872,7 +2873,7 @@ struct string_col {
 std::string options_manager::show( bool ingame, const bool world_options_only,
                                    const std::function<bool()> &on_quit )
 {
-    const int iWorldOptPage = std::find_if( pages_.begin(), pages_.end(), [&]( const Page & p ) {
+    const int iWorldOptPage = std::ranges::find_if( pages_, [&]( const Page & p ) {
         return p.id_ == world_default;
     } ) - pages_.begin();
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1,5 +1,6 @@
 #include "output.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cctype>
 #include <cstdio>
@@ -1128,7 +1129,7 @@ std::vector<size_t> get_tag_positions( const std::string &s )
         ret.push_back( pos );
         pos = s.find( "</color>", pos + 1, 8 );
     }
-    std::sort( ret.begin(), ret.end() );
+    std::ranges::sort( ret );
     return ret;
 }
 
@@ -1294,7 +1295,7 @@ void draw_tabs( const catacurses::window &w, const std::vector<std::string> &tab
 void draw_tabs( const catacurses::window &w, const std::vector<std::string> &tab_texts,
                 const std::string &current_tab )
 {
-    auto it = std::find( tab_texts.begin(), tab_texts.end(), current_tab );
+    auto it = std::ranges::find( tab_texts, current_tab );
     assert( it != tab_texts.end() );
     draw_tabs( w, tab_texts, it - tab_texts.begin() );
 }

--- a/src/overmap_connection.cpp
+++ b/src/overmap_connection.cpp
@@ -1,5 +1,6 @@
 #include "overmap_connection.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <algorithm>
 #include <cassert>
@@ -61,8 +62,8 @@ bool overmap_connection::subtype::allows_terrain( const oter_id &oter ) const
         return true;    // Can be built on similar terrains.
     }
 
-    return std::any_of( locations.cbegin(),
-    locations.cend(), [&oter]( const overmap_location_id & elem ) {
+    return std::ranges::any_of( locations,
+    [&oter]( const overmap_location_id & elem ) {
         return elem->test( oter );
     } );
 }
@@ -98,8 +99,8 @@ const overmap_connection::subtype *overmap_connection::pick_subtype_for(
         return cached_subtypes[cache_index].value;
     }
 
-    const auto iter = std::find_if( subtypes.cbegin(),
-    subtypes.cend(), [&ground]( const subtype & elem ) {
+    const auto iter = std::ranges::find_if( subtypes,
+    [&ground]( const subtype & elem ) {
         return elem.allows_terrain( ground );
     } );
 
@@ -119,7 +120,7 @@ bool overmap_connection::can_start_at( const oter_id &ground ) const
 
 bool overmap_connection::has( const oter_id &oter ) const
 {
-    return std::find_if( subtypes.cbegin(), subtypes.cend(), [&oter]( const subtype & elem ) {
+    return std::ranges::find_if( subtypes, [&oter]( const subtype & elem ) {
         return oter->type_is( elem.terrain );
     } ) != subtypes.cend();
 }
@@ -184,8 +185,8 @@ void reset()
 overmap_connection_id guess_for( const oter_id &oter )
 {
     const auto &all = connections.get_all();
-    const auto iter = std::find_if( all.cbegin(),
-    all.cend(), [&oter]( const overmap_connection & elem ) {
+    const auto iter = std::ranges::find_if( all,
+    [&oter]( const overmap_connection & elem ) {
         return elem.pick_subtype_for( oter ) != nullptr;
     } );
 

--- a/src/overmap_location.cpp
+++ b/src/overmap_location.cpp
@@ -33,7 +33,7 @@ const overmap_location &string_id<overmap_location>::obj() const
 
 bool overmap_location::test( const oter_id &oter ) const
 {
-    return std::any_of( terrains.cbegin(), terrains.cend(),
+    return std::ranges::any_of( terrains,
     [ &oter ]( const oter_type_str_id & type ) {
         return oter->type_is( type );
     } );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1234,7 +1234,7 @@ std::vector<tripoint_abs_omt> overmapbuffer::find_all_async( const tripoint_abs_
 
             if( !params.max_results.has_value() ||
                 dst.size() < static_cast<size_t>( params.max_results.value() ) ) {
-                std::copy( task_result.begin(), task_result.end(), std::back_inserter( dst ) );
+                std::ranges::copy( task_result, std::back_inserter( dst ) );
                 if( params.max_results.has_value() &&
                     dst.size() > static_cast<uint64_t>( params.max_results.value() ) ) {
                     dst.resize( params.max_results.value() );
@@ -1456,7 +1456,7 @@ std::vector<overmap *> overmapbuffer::get_overmaps_near( const tripoint_abs_sm &
 
     // Sort the resulting overmaps so that the closest ones are first.
     const tripoint_abs_om center = project_to<coords::om>( location );
-    std::sort( result.begin(), result.end(), [&center]( const overmap * lhs,
+    std::ranges::sort( result, [&center]( const overmap * lhs,
     const overmap * rhs ) {
         const tripoint_abs_om lhs_pos( lhs->pos(), 0 );
         const tripoint_abs_om rhs_pos( rhs->pos(), 0 );
@@ -1584,7 +1584,7 @@ std::vector<city_reference> overmapbuffer::get_cities_near( const tripoint_abs_s
 
     for( const auto om : get_overmaps_near( location, radius ) ) {
         result.reserve( result.size() + om->cities.size() );
-        std::transform( om->cities.begin(), om->cities.end(), std::back_inserter( result ),
+        std::ranges::transform( om->cities, std::back_inserter( result ),
         [&]( city & element ) {
             const auto rel_pos_city = project_to<coords::sm>( element.pos );
             const auto abs_pos_city =
@@ -1595,7 +1595,7 @@ std::vector<city_reference> overmapbuffer::get_cities_near( const tripoint_abs_s
         } );
     }
 
-    std::sort( result.begin(), result.end(), []( const city_reference & lhs,
+    std::ranges::sort( result, []( const city_reference & lhs,
     const city_reference & rhs ) {
         return lhs.get_distance_from_bounds() < rhs.get_distance_from_bounds();
     } );
@@ -1617,7 +1617,7 @@ city_reference overmapbuffer::closest_city( const tripoint_abs_sm &center )
 city_reference overmapbuffer::closest_known_city( const tripoint_abs_sm &center )
 {
     const auto cities = get_cities_near( center, omt_to_sm_copy( OMAPX ) );
-    const auto it = std::find_if( cities.begin(), cities.end(),
+    const auto it = std::ranges::find_if( cities,
     [this]( const city_reference & elem ) {
         const tripoint_abs_omt p = project_to<coords::omt>( elem.abs_sm_pos );
         return seen( p );
@@ -1920,12 +1920,12 @@ bool overmapbuffer::add_grid_connection( const tripoint_abs_omt &lhs, const trip
     overmap_with_local_coords lhs_omc = get_om_global( lhs );
     overmap_with_local_coords rhs_omc = get_om_global( rhs );
 
-    const auto lhs_iter = std::find( six_cardinal_directions.begin(),
-                                     six_cardinal_directions.end(),
-                                     coord_diff.raw() );
-    const auto rhs_iter = std::find( six_cardinal_directions.begin(),
-                                     six_cardinal_directions.end(),
-                                     -coord_diff.raw() );
+    const auto lhs_iter = std::ranges::find( six_cardinal_directions,
+
+                          coord_diff.raw() );
+    const auto rhs_iter = std::ranges::find( six_cardinal_directions,
+
+                          -coord_diff.raw() );
 
     size_t lhs_i = std::distance( six_cardinal_directions.begin(), lhs_iter );
     size_t rhs_i = std::distance( six_cardinal_directions.begin(), rhs_iter );
@@ -1961,12 +1961,12 @@ bool overmapbuffer::remove_grid_connection( const tripoint_abs_omt &lhs,
     overmap_with_local_coords lhs_omc = get_om_global( lhs );
     overmap_with_local_coords rhs_omc = get_om_global( rhs );
 
-    const auto lhs_iter = std::find( six_cardinal_directions.begin(),
-                                     six_cardinal_directions.end(),
-                                     coord_diff.raw() );
-    const auto rhs_iter = std::find( six_cardinal_directions.begin(),
-                                     six_cardinal_directions.end(),
-                                     -coord_diff.raw() );
+    const auto lhs_iter = std::ranges::find( six_cardinal_directions,
+
+                          coord_diff.raw() );
+    const auto rhs_iter = std::ranges::find( six_cardinal_directions,
+
+                          -coord_diff.raw() );
 
     size_t lhs_i = std::distance( six_cardinal_directions.begin(), lhs_iter );
     size_t rhs_i = std::distance( six_cardinal_directions.begin(), rhs_iter );

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -534,7 +534,7 @@ std::vector<stacked_items> stack_for_pickup_ui( const
         }
 
         // Each sub-stack has to be sorted separately
-        std::sort( restacked_children.begin(), restacked_children.end(),
+        std::ranges::sort( restacked_children,
         []( const std::list<item_stack::iterator> &lhs, const std::list<item_stack::iterator> &rhs ) {
             return **lhs.front() < **rhs.front();
         } );
@@ -542,7 +542,7 @@ std::vector<stacked_items> stack_for_pickup_ui( const
     }
 
     // Sorting by parent is a bit arbitrary (parent-less go last) - sort by count?
-    std::sort( restacked_with_parents.begin(), restacked_with_parents.end(),
+    std::ranges::sort( restacked_with_parents,
     []( const stacked_items & lhs, stacked_items & rhs ) {
         return lhs.parent.has_value() && ( !rhs.parent.has_value() || **lhs.parent < **rhs.parent );
     } );
@@ -1081,8 +1081,8 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                 if( selected_stack.parent ) {
                     pickup_count &parent_stack = getitem[*selected_stack.parent];
                     if( selected_stack.pick ) {
-                        parent_stack.all_children_picked = std::all_of(
-                                                               parent_stack.children.begin(), parent_stack.children.end(),
+                        parent_stack.all_children_picked = std::ranges::all_of(
+                                                               parent_stack.children,
                         [&]( size_t child_index ) {
                             return getitem[child_index].pick;
                         } );

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -656,7 +656,7 @@ bool player_activity::can_resume_with( const player_activity &other, const Chara
             return false;
         }
         for( int foo : other.values ) {
-            if( std::find( values.begin(), values.end(), foo ) == values.end() ) {
+            if( std::ranges::find( values, foo ) == values.end() ) {
                 return false;
             }
         }

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -464,7 +464,7 @@ std::vector<detached_ptr<item>> profession::items( bool male,
         }
     }
 
-    std::stable_sort( result.begin(), result.end(),
+    std::ranges::stable_sort( result,
     []( const detached_ptr<item> &first, const detached_ptr<item> &second ) {
         return first->get_layer() < second->get_layer();
     } );
@@ -513,7 +513,7 @@ bool profession::has_flag( const std::string &flag ) const
 
 bool profession::is_locked_trait( const trait_id &trait ) const
 {
-    return std::find( _starting_traits.begin(), _starting_traits.end(), trait ) !=
+    return std::ranges::find( _starting_traits, trait ) !=
            _starting_traits.end();
 }
 
@@ -571,7 +571,7 @@ void json_item_substitution::load( const JsonObject &jo )
 
     auto check_duplicate_item = [&]( const itype_id & it ) {
         return substitutions.find( it ) != substitutions.end() ||
-               std::find_if( bonuses.begin(), bonuses.end(),
+               std::ranges::find_if( bonuses,
         [&it]( const std::pair<itype_id, trait_requirements> &p ) {
             return p.first == it;
         } ) != bonuses.end();
@@ -652,10 +652,10 @@ bool json_item_substitution::trait_requirements::meets_condition( const std::vec
         &traits ) const
 {
     const auto pred = [&traits]( const trait_id & s ) {
-        return std::find( traits.begin(), traits.end(), s ) != traits.end();
+        return std::ranges::find( traits, s ) != traits.end();
     };
-    return std::all_of( present.begin(), present.end(), pred ) &&
-           std::none_of( absent.begin(), absent.end(), pred );
+    return std::ranges::all_of( present, pred ) &&
+           std::ranges::none_of( absent, pred );
 }
 
 std::vector<detached_ptr<item>> json_item_substitution::get_substitution( const item &it,

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -343,7 +343,7 @@ std::string recipe::get_consistency_error() const
         return !elem.first.is_valid();
     };
 
-    if( std::any_of( byproducts.begin(), byproducts.end(), is_invalid_bp ) ) {
+    if( std::ranges::any_of( byproducts, is_invalid_bp ) ) {
         return "defines invalid byproducts";
     }
 
@@ -360,7 +360,7 @@ std::string recipe::get_consistency_error() const
     };
 
     if( ( skill_used && !skill_used.is_valid() ) ||
-        std::any_of( required_skills.begin(), required_skills.end(), is_invalid_skill ) ) {
+        std::ranges::any_of( required_skills, is_invalid_skill ) ) {
         return "uses invalid skill";
     }
 
@@ -368,7 +368,7 @@ std::string recipe::get_consistency_error() const
         return !elem.first->book;
     };
 
-    if( std::any_of( booksets.begin(), booksets.end(), is_invalid_book ) ) {
+    if( std::ranges::any_of( booksets, is_invalid_book ) ) {
         return "defines invalid book";
     }
 
@@ -551,7 +551,7 @@ bool recipe::will_be_blacklisted() const
             return req.first->is_blacklisted();
         };
 
-        return std::any_of( reqs.begin(), reqs.end(), req_is_blacklisted );
+        return std::ranges::any_of( reqs, req_is_blacklisted );
     };
 
     return any_is_blacklisted( reqs_internal ) || any_is_blacklisted( reqs_external );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -482,7 +482,7 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
                     if( radio_member_name == "type" ) {
                         const std::string radio_name = jsin.get_string();
                         const auto mapping =
-                            find_if( radio_type_names.begin(), radio_type_names.end(),
+                            std::ranges::find_if( radio_type_names,
                         [radio_name]( const std::pair<radio_type, std::string> &p ) {
                             return p.second == radio_name;
                         } );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2341,7 +2341,7 @@ void item::io( Archive &archive )
     // counter, it will always be 0 and it prevents proper stacking.
     if( get_chapters() == 0 ) {
         for( auto it = item_vars.begin(); it != item_vars.end(); ) {
-            if( it->first.compare( 0, 19, "remaining-chapters-" ) == 0 ) {
+            if( it->first.starts_with( "remaining-chapters-" ) ) {
                 item_vars.erase( it++ );
             } else {
                 ++it;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -1,5 +1,6 @@
 #include "scenario.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <algorithm>
 
@@ -159,7 +160,7 @@ void scenario::check_definition() const
             debugmsg( "profession %s for scenario %s does not exist", p.c_str(), id.c_str() );
         }
     }
-    if( std::any_of( professions.begin(), professions.end(), [&]( const string_id<profession> &p ) {
+    if( std::ranges::any_of( professions, [&]( const string_id<profession> &p ) {
     return std::count( professions.begin(), professions.end(), p ) > 1;
     } ) ) {
         debugmsg( "Duplicate entries in the professions array." );
@@ -310,8 +311,8 @@ std::vector<profession_id> scenario::permitted_professions() const
     const auto all = profession::get_all();
     std::vector<profession_id> &res = cached_permitted_professions;
     for( const profession &p : all ) {
-        const bool present = std::find( professions.begin(), professions.end(),
-                                        p.ident() ) != professions.end();
+        const bool present = std::ranges::find( professions,
+                                                p.ident() ) != professions.end();
 
         bool conflicting_traits = scenario_traits_conflict_with_profession_traits( p );
 
@@ -447,7 +448,7 @@ bool scenario::has_flag( const std::string &flag ) const
 bool scenario::allowed_start( const start_location_id &loc ) const
 {
     auto &vec = _allowed_locs;
-    return std::find( vec.begin(), vec.end(), loc ) != vec.end();
+    return std::ranges::find( vec, loc ) != vec.end();
 }
 
 bool scenario::can_pick( const scenario &current_scenario, const int points ) const

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1069,7 +1069,7 @@ void sfx::generate_gun_sound( const tripoint &source, const item &firing )
         selected_sound = "fire_gun";
 
         const auto mods = firing.gunmods();
-        if( std::any_of( mods.begin(), mods.end(),
+        if( std::ranges::any_of( mods,
         []( const item * e ) {
         return e->type->gunmod->loudness < 0;
     } ) ) {
@@ -1230,7 +1230,7 @@ void sfx::do_projectile_hit( const Creature &target )
             material_id( "veggy" ),
             material_id( "bone" ),
         };
-        const bool is_fleshy = std::any_of( fleshy.begin(), fleshy.end(), [&mon]( const material_id & m ) {
+        const bool is_fleshy = std::ranges::any_of( fleshy, [&mon]( const material_id & m ) {
             return mon.made_of( m );
         } );
 

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -122,7 +122,7 @@ static void add_boardable( const map &m, const tripoint &p, std::vector<tripoint
         // Don't board up the outside
         return;
     }
-    if( std::find( vec.begin(), vec.end(), p ) != vec.end() ) {
+    if( std::ranges::find( vec, p ) != vec.end() ) {
         // Already registered to be boarded
         return;
     }
@@ -164,7 +164,7 @@ static void board_up( map &m, const tripoint_range<tripoint> &range )
     }
     // Find all furniture that can be used to board up some place
     for( const tripoint &p : range ) {
-        if( std::find( boardables.begin(), boardables.end(), p ) != boardables.end() ) {
+        if( std::ranges::find( boardables, p ) != boardables.end() ) {
             continue;
         }
         if( !m.has_furn( p ) ) {
@@ -236,7 +236,7 @@ tripoint_abs_omt start_location::find_player_initial_location() const
             }
 
             const auto &terrains = special.all_terrains();
-            if( std::none_of( terrains.begin(), terrains.end(),
+            if( std::ranges::none_of( terrains,
             [&loc]( const oter_str_id & t ) {
             return is_ot_match( loc.first, t, loc.second );
             } ) ) {

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -437,8 +437,8 @@ void submap::delete_computer( point p )
 
 bool submap::contains_vehicle( vehicle *veh )
 {
-    const auto match = std::find_if(
-                           begin( vehicles ), end( vehicles ),
+    const auto match = std::ranges::find_if(
+                           vehicles,
     [veh]( const std::unique_ptr<vehicle> &v ) {
         return v.get() == veh;
     } );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1929,7 +1929,7 @@ void Character::add_addiction( add_type type, int strength )
 
 bool Character::has_addiction( add_type type ) const
 {
-    return std::any_of( addictions.begin(), addictions.end(),
+    return std::ranges::any_of( addictions,
     [type]( const addiction & ad ) {
         return ad.type == type && ad.intensity >= MIN_ADDICTION_LEVEL;
     } );
@@ -1937,7 +1937,7 @@ bool Character::has_addiction( add_type type ) const
 
 void Character::rem_addiction( add_type type )
 {
-    auto iter = std::find_if( addictions.begin(), addictions.end(),
+    auto iter = std::ranges::find_if( addictions,
     [type]( const addiction & ad ) {
         return ad.type == type;
     } );
@@ -1950,7 +1950,7 @@ void Character::rem_addiction( add_type type )
 
 int Character::addiction_level( add_type type ) const
 {
-    auto iter = std::find_if( addictions.begin(), addictions.end(),
+    auto iter = std::ranges::find_if( addictions,
     [type]( const addiction & ad ) {
         return ad.type == type;
     } );

--- a/src/trait_group.cpp
+++ b/src/trait_group.cpp
@@ -167,7 +167,7 @@ Trait_list Trait_group_creator::create( RecursionList &rec ) const
 {
 
     Trait_list result;
-    if( std::find( rec.begin(), rec.end(), id ) != rec.end() ) {
+    if( std::ranges::find( rec, id ) != rec.end() ) {
         debugmsg( "recursion in trait creation list %s", id.c_str() );
         return result;
     }

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -58,7 +58,7 @@ std::string gettext_gendered( const GenderMap &genders, const std::string &msg )
         // default if no match
         std::string chosen_gender = language_genders[0];
         for( const std::string &gender : subject_genders.second ) {
-            if( std::find( language_genders.begin(), language_genders.end(), gender ) !=
+            if( std::ranges::find( language_genders, gender ) !=
                 language_genders.end() ) {
                 chosen_gender = gender;
                 break;

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -676,7 +676,7 @@ void vpart_info::check()
             }
         };
         if( part.epower != 0 &&
-        std::none_of( handled.begin(), handled.end(), [&part]( const std::string & flag ) {
+        std::ranges::none_of( handled, [&part]( const std::string & flag ) {
         return part.has_flag( flag );
         } ) ) {
             std::string warnings_are_good_docs = enumerate_as_string( handled );

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -1,6 +1,7 @@
 #include "vehicle.h"
 #include "vehicle_part.h" // IWYU pragma: associated
 
+#include <algorithm>
 #include <cstdlib>
 #include <algorithm>
 #include <optional>
@@ -331,7 +332,7 @@ std::vector<itype_id> vehicle::get_printable_fuel_types() const
 
     std::vector<itype_id> res( opts.begin(), opts.end() );
 
-    std::sort( res.begin(), res.end(), [&]( const itype_id & lhs, const itype_id & rhs ) {
+    std::ranges::sort( res, [&]( const itype_id & lhs, const itype_id & rhs ) {
         return basic_consumption( rhs ) < basic_consumption( lhs );
     } );
 

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -650,7 +650,7 @@ bool vehicle::mod_hp( vehicle_part &pt, int qty, damage_type dt )
 
 bool vehicle::can_enable( const vehicle_part &pt, bool alert ) const
 {
-    if( std::none_of( parts.begin(), parts.end(), [&pt]( const vehicle_part & e ) {
+    if( std::ranges::none_of( parts, [&pt]( const vehicle_part & e ) {
     return &e == &pt;
 } ) || pt.removed ) {
         debugmsg( "Cannot enable removed or non-existent part" );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -915,7 +915,7 @@ bool vehicle::fold_up()
 
     std::string itype_id = "generic_folded_vehicle";
     for( const auto &elem : tags ) {
-        if( elem.compare( 0, 12, "convertible:" ) == 0 ) {
+        if( elem.starts_with( "convertible:" ) ) {
             itype_id = elem.substr( 12 );
             break;
         }

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -196,7 +196,7 @@ const weather_type_id &weather_generator::get_bad_weather() const
 
 int weather_generator::forecast_priority( const weather_type_id &w ) const
 {
-    auto it = std::find( weather_types.begin(), weather_types.end(), w );
+    auto it = std::ranges::find( weather_types, w );
     if( it == weather_types.end() ) {
         return -1;
     }
@@ -239,8 +239,8 @@ const weather_type_id &weather_generator::get_weather_conditions( const w_point 
         }
 
         if( !wrequires.required_weathers.empty() ) {
-            if( std::find( wrequires.required_weathers.begin(), wrequires.required_weathers.end(),
-                           *current_conditions ) == wrequires.required_weathers.end() ) {
+            if( std::ranges::find( wrequires.required_weathers,
+                                   *current_conditions ) == wrequires.required_weathers.end() ) {
                 continue;
             }
         }

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -370,7 +370,7 @@ void debug_menu::wishbionics( Character &c )
     std::vector<const itype *> cbm_items = item_controller->find( []( const itype & itm ) -> bool {
         return itm.can_use( "install_bionic" );
     } );
-    std::sort( cbm_items.begin(), cbm_items.end(), []( const itype * a, const itype * b ) {
+    std::ranges::sort( cbm_items, []( const itype * a, const itype * b ) {
         return localized_compare( a->nname( 1 ), b->nname( 1 ) );
     } );
 
@@ -717,9 +717,9 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
         }
         opts.emplace_back( it->tname( 1, false ), i );
     }
-    std::sort( opts.begin(), opts.end(), localized_compare );
+    std::ranges::sort( opts, localized_compare );
     std::vector<const itype *> itypes;
-    std::transform( opts.begin(), opts.end(), std::back_inserter( itypes ),
+    std::ranges::transform( opts, std::back_inserter( itypes ),
     []( const auto & pair ) {
         return pair.second;
     } );

--- a/src/wisheffect.cpp
+++ b/src/wisheffect.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <map>
 #include <sstream>
 #include <vector>
@@ -366,7 +367,7 @@ class effect_edit_callback : public uilist_callback
                     c.remove_effect( eff.get_id(), bp_from );
                     c.add_effect( eff.get_id(), eff.get_duration(), *bp, eff.get_intensity(), true );
                 }
-                auto iter_to = std::find_if( meta.begin(), meta.end(), [bp]( const entry_data & ed ) {
+                auto iter_to = std::ranges::find_if( meta, [bp]( const entry_data & ed ) {
                     return ed.body_part == *bp;
                 } );
                 size_t bp_index = std::distance( iter_to, meta.begin() ) % meta.size();

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -1,5 +1,6 @@
 #include "world.h"
 
+#include <algorithm>
 #include <sstream>
 #include <cstring>
 #include <chrono>
@@ -111,7 +112,7 @@ bool WORLDINFO::needs_lua() const
 
 bool WORLDINFO::save_exists( const save_t &name ) const
 {
-    return std::find( world_saves.begin(), world_saves.end(), name ) != world_saves.end();
+    return std::ranges::find( world_saves, name ) != world_saves.end();
 }
 
 void WORLDINFO::add_save( const save_t &name )

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -956,7 +956,7 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
                 if( !show_obsolete && mod->obsolete ) {
                     continue;
                 }
-                auto it = std::find( active_mod_order.begin(), active_mod_order.end(), mod );
+                auto it = std::ranges::find( active_mod_order, mod );
                 if( it != active_mod_order.end() ) {
                     continue;
                 }
@@ -1492,8 +1492,8 @@ void worldfactory::draw_worldgen_tabs( const catacurses::window &w, size_t curre
     };
 
     std::vector<std::string> tab_strings_translated( tab_strings );
-    std::for_each( tab_strings_translated.begin(),
-                   tab_strings_translated.end(), []( std::string & str )->void { str = _( str ); } );
+    std::ranges::for_each( tab_strings_translated,
+                           []( std::string & str )->void { str = _( str ); } );
 
     draw_tabs( w, tab_strings_translated, current );
     draw_border_below_tabs( w );
@@ -1545,8 +1545,8 @@ WORLDINFO *worldfactory::get_world( const std::string &name )
 size_t worldfactory::get_world_index( const std::string &name )
 {
     std::vector<std::string> worlds = all_worldnames();
-    size_t world_pos = std::find( worlds.begin(), worlds.end(),
-                                  name ) - worlds.begin();
+    size_t world_pos = std::ranges::find( worlds,
+                                          name ) - worlds.begin();
     if( world_pos >= worlds.size() ) {
         world_pos = 0;
     }
@@ -1572,11 +1572,11 @@ void worldfactory::delete_world( const std::string &worldname, const bool delete
 
     auto file_paths = get_files_from_path( "", worldpath, true, true );
     if( !delete_folder ) {
-        std::vector<std::string>::iterator forbidden = find_if( file_paths.begin(), file_paths.end(),
+        std::vector<std::string>::iterator forbidden = std::ranges::find_if( file_paths,
                 isForbidden );
         while( forbidden != file_paths.end() ) {
             file_paths.erase( forbidden );
-            forbidden = find_if( file_paths.begin(), file_paths.end(), isForbidden );
+            forbidden = std::ranges::find_if( file_paths, isForbidden );
         }
     }
     for( auto &file_path : file_paths ) {


### PR DESCRIPTION
## Purpose of change (The Why)

feel that c++20!

## Describe the solution (The How)

ran following migrations:

- modernize-use-ranges
- readability-container-contains
- modernize-use-starts-ends-with
- performance-faster-string-find
- readability-container-size-empty

## Describe alternatives you've considered

may need to wait till other big PRs are merged to avoid merge conflicts

## Testing

it builds, applied automatic fixes are refactorings

## Additional context

to run clang-tidy checks in parallel:

```sh
run-clang-tidy -j 10 '-checks=-*,readability-container-contains,modernize-use-starts-ends-with,performance-faster-string-find,readability-container-size-empty' -fix src/*.cpp
```

https://gist.github.com/scarf005/a5c1da9f8b70421beef1b8c590fa3c9a

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
