### PR TITLE
feat(UI): remove verbose activity speed description for certain activities

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -12,7 +12,8 @@
     "verb": "finding a mount",
     "suspendable": false,
     "special": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_READ",
@@ -48,7 +49,8 @@
     "id": "ACT_TIDY_UP",
     "type": "activity_type",
     "verb": "tidying up",
-    "special": true
+    "special": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_VEHICLE_DECONSTRUCTION",
@@ -109,13 +111,15 @@
     "id": "ACT_GENERIC_GAME",
     "type": "activity_type",
     "verb": "playing",
-    "rooted": true
+    "rooted": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_GAME",
     "type": "activity_type",
     "verb": "playing",
-    "rooted": true
+    "rooted": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_WAIT",
@@ -302,7 +306,8 @@
     "id": "ACT_SOCIALIZE",
     "type": "activity_type",
     "verb": "socializing",
-    "rooted": true
+    "rooted": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_WAIT_WEATHER",
@@ -357,12 +362,14 @@
   {
     "id": "ACT_HEATING",
     "type": "activity_type",
-    "verb": "heating"
+    "verb": "heating",
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_VIBE",
     "type": "activity_type",
-    "verb": "de-stressing"
+    "verb": "de-stressing",
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_MAKE_ZLAVE",
@@ -377,7 +384,8 @@
     "verb": "dropping",
     "suspendable": false,
     "special": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_STASH",
@@ -403,7 +411,8 @@
     "verb": "moving items",
     "suspendable": false,
     "special": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_AUTODRIVE",
@@ -411,7 +420,8 @@
     "verb": "driving",
     "suspendable": false,
     "special": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_TRAVELLING",
@@ -419,13 +429,15 @@
     "verb": "traveling",
     "suspendable": false,
     "special": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_MOVE_LOOT",
     "type": "activity_type",
     "verb": "sorting out the loot",
-    "special": true
+    "special": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_FETCH_REQUIRED",
@@ -433,7 +445,8 @@
     "verb": "fetching components",
     "suspendable": false,
     "special": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_MULTIPLE_FARM",
@@ -480,7 +493,8 @@
     "verb": "lighting the fire",
     "rooted": true,
     "special": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_TOGGLE_GATE",
@@ -496,7 +510,8 @@
     "suspendable": false,
     "rooted": true,
     "special": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_MILK",
@@ -545,7 +560,8 @@
     "id": "ACT_START_ENGINES",
     "type": "activity_type",
     "verb": "trying to start the vehicle",
-    "suspendable": false
+    "suspendable": false,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_OXYTORCH",
@@ -773,7 +789,8 @@
     "verb": "putting on items",
     "suspendable": false,
     "special": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_TREE_COMMUNION",
@@ -781,7 +798,8 @@
     "verb": "communing with the trees",
     "rooted": true,
     "suspendable": false,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_EAT_MENU",
@@ -862,7 +880,8 @@
     "verb": "canceling activity serialized with legacy code",
     "suspendable": false,
     "special": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_THROW",
@@ -877,7 +896,8 @@
     "id": "ACT_NULL",
     "type": "activity_type",
     "verb": "dummy activity",
-    "//": "dummy activity for tests, cuz, apparently it's much harder to insert it to map"
+    "//": "dummy activity for tests, cuz, apparently it's much harder to insert it to map",
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_ASSIST",

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -124,7 +124,8 @@
     "rooted": true,
     "no_resume": true,
     "refuel_fires": true,
-    "auto_needs": true
+    "auto_needs": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_CRAFT",
@@ -309,7 +310,8 @@
     "verb": "waiting",
     "rooted": true,
     "no_resume": true,
-    "auto_needs": true
+    "auto_needs": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_FIRSTAID",
@@ -614,14 +616,16 @@
     "type": "activity_type",
     "verb": "interacting with the NPC",
     "rooted": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_WAIT_STAMINA",
     "type": "activity_type",
     "verb": "catching breath",
     "rooted": true,
-    "no_resume": true
+    "no_resume": true,
+    "verbose_tooltip": false
   },
   {
     "id": "ACT_CLEAR_RUBBLE",


### PR DESCRIPTION
## Purpose of change (The Why)

Certain activities still show verbose speed description, despite not actually needing it.

## Describe the solution (The How)

Double-checking list of activities and apply needed flag.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
