### PR TITLE
feat: add grid gunsmith kit

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4973,6 +4973,20 @@
   },
   {
     "type": "construction",
+    "id": "constr_gridgunkit",
+    "group": "place_gunsmith_kit",
+    "category": "WORKSHOP",
+    "required_skills": [ [ "electronics", 1 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "SCREW", "level": 1 } ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
+    "components": [ [ [ "large_repairkit", 1 ] ], [ [ "cable", 5 ] ], [ [ "power_supply", 1 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_furniture": "f_gridgunkit"
+  },
+  {
+    "type": "construction",
     "id": "constr_gridwelderrig",
     "group": "place_welding_rig",
     "category": "WORKSHOP",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1216,6 +1216,11 @@
   },
   {
     "type": "construction_group",
+    "id": "place_gunsmith_kit",
+    "name": "Place Gunsmith Kit"
+  },
+  {
+    "type": "construction_group",
     "id": "place_autoclave",
     "name": "Place Autoclave"
   },

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -1490,6 +1490,41 @@
   },
   {
     "type": "furniture",
+    "id": "f_gridgunkit",
+    "looks_like": "large_repairkit",
+    "name": "grid gunsmith repair kit",
+    "symbol": "#",
+    "description": "A gunsmith kit connected to an electrical grid.",
+    "color": "red",
+    "move_cost_mod": -1,
+    "coverage": 10,
+    "required_str": -1,
+    "crafting_pseudo_item": "fake_gridgunkit",
+    "examine_action": "use_furn_fake_item",
+    "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
+    "deconstruct": {
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "large_repairkit", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
+    },
+    "bash": {
+      "str_min": 4,
+      "str_max": 30,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
+        { "item": "power_supply", "count": [ 1, 4 ] },
+        { "item": "scrap", "count": [ 0, 8 ] },
+        { "item": "cable", "charges": [ 1, 4 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_welderrig",
     "copy-from": "f_gridwelder",
     "looks_like": "weldrig",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -244,6 +244,31 @@
     "flags": [ "USES_GRID_POWER" ]
   },
   {
+    "id": "fake_gridgunkit",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "grid gunsmith repair kit" },
+    "sub": "large_repairkit",
+    "max_charges": 1000,
+    "charges_per_use": 25,
+    "qualities": [
+      [ "HAMMER_FINE", 1 ],
+      [ "HAMMER", 3 ],
+      [ "PRY", 1 ],
+      [ "SAW_M_FINE", 1 ],
+      [ "SAW_M", 2 ],
+      [ "WRENCH_FINE", 1 ],
+      [ "WRENCH", 2 ],
+      [ "SCREW_FINE", 1 ],
+      [ "SCREW", 1 ],
+      [ "CHISEL", 3 ],
+      [ "DRILL", 3 ],
+      [ "PULL", 2 ]
+    ],
+    "use_action": [ "GUN_CLEAN", "GUN_REPAIR" ],
+    "flags": [ "USES_GRID_POWER" ]
+  },
+  {
     "id": "fake_gridsolderingiron",
     "copy-from": "fake_item",
     "looks_like": "soldering_iron",


### PR DESCRIPTION
## Purpose of change (The Why)

Adds a grid gunsmith kit.

My charger is too cluttered and a gunsmith kit uses 25 charges per use, so it requires sitting on the charger constantly on top of a ton of other stuff. I could clear the charger but it would still have a ton of necessary items.
![image](https://github.com/user-attachments/assets/20fbb379-1d4f-47a7-94c1-7532e3b53b3a)


## Describe the solution (The How)

Adds gunsmith repair kit to the grid furniture.

## Describe alternatives you've considered

WELL I WANTED TO DO MORE but workbenches don't work with fake items because its examine action is required

## Testing

It works, it repairs my HK417 and it cleans/lubricates. It's still used in crafting.

![image](https://github.com/user-attachments/assets/bbcb5df3-9b49-4035-8b52-4ccc4581d918)
![image](https://github.com/user-attachments/assets/56dbe816-ec10-429c-b6a7-1e49f2a17e8b)
![image](https://github.com/user-attachments/assets/8305f5b4-7aa2-452f-8bdc-5dfe5de8638f)


## Additional context

None

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.