### PR TITLE
feat(balance): Adjusts recoil values for small caliber rounds and 40mm grenades

### DIFF
--- a/data/json/items/ammo/22.json
+++ b/data/json/items/ammo/22.json
@@ -8,7 +8,7 @@
     "//": "Hollowpoint damage increase of 25%",
     "damage": { "damage_type": "bullet", "amount": 20, "armor_penetration": 0 },
     "relative": { "range": 3 },
-    "proportional": { "recoil": 1.5 }
+    "proportional": { "recoil": 1.2 }
   },
   {
     "id": "22_lr",

--- a/data/json/items/ammo/32.json
+++ b/data/json/items/ammo/32.json
@@ -19,7 +19,7 @@
     "//": "Base damage of 16, balance increase of one-third.",
     "damage": { "damage_type": "bullet", "amount": 21, "armor_penetration": 12 },
     "dispersion": 70,
-    "recoil": 150,
+    "recoil": 250,
     "effects": [ "COOKOFF" ]
   },
   {

--- a/data/json/items/ammo/38.json
+++ b/data/json/items/ammo/38.json
@@ -28,7 +28,7 @@
     "//": "Hollowpoint damage bonus of 25%.",
     "damage": { "damage_type": "bullet", "amount": 30 },
     "dispersion": 30,
-    "recoil": 250,
+    "recoil": 300,
     "effects": [ "COOKOFF" ]
   },
   {

--- a/data/json/items/ammo/380.json
+++ b/data/json/items/ammo/380.json
@@ -42,7 +42,7 @@
     "count": 25,
     "damage": { "damage_type": "bullet", "amount": 30, "armor_penetration": 15 },
     "relative": { "dispersion": -15 },
-    "proportional": { "recoil": 2 }
+    "proportional": { "recoil": 1.2 }
   },
   {
     "id": "bp_380_FMJ",

--- a/data/json/items/ammo/38super.json
+++ b/data/json/items/ammo/38super.json
@@ -19,7 +19,7 @@
     "//": "Base damage of 26, balance increase of two-nineths.",
     "damage": { "damage_type": "bullet", "amount": 32, "armor_penetration": 18 },
     "dispersion": 30,
-    "recoil": 250,
+    "recoil": 550,
     "effects": [ "COOKOFF" ]
   },
   {

--- a/data/json/items/ammo/40x46mm.json
+++ b/data/json/items/ammo/40x46mm.json
@@ -16,7 +16,7 @@
     "range": 60,
     "damage": { "damage_type": "bullet", "amount": 80 },
     "dispersion": 30,
-    "recoil": 225,
+    "recoil": 2000,
     "effects": [ "COOKOFF", "NEVER_MISFIRES" ]
   },
   {
@@ -53,7 +53,7 @@
     "weight": "120 g",
     "range": 12,
     "damage": { "damage_type": "bullet", "amount": 120, "armor_multiplier": 2 },
-    "recoil": 1000,
+    "proportional": { "recoil": 1.2 },
     "casing": "40x46mm_m199_casing",
     "extend": { "effects": [ "SHOT" ] }
   },
@@ -79,7 +79,7 @@
     "weight": "120 g",
     "range": 10,
     "damage": { "damage_type": "bullet", "amount": 120, "armor_multiplier": 2 },
-    "recoil": 1000,
+    "proportional": { "recoil": 1.2 },
     "casing": "40x46mm_m118_casing",
     "extend": { "effects": [ "SHOT" ] }
   },
@@ -93,7 +93,7 @@
     "range": 10,
     "//": "Balanced as FMJ.",
     "damage": { "damage_type": "bullet", "amount": 96, "armor_penetration": 42, "armor_multiplier": 1.5 },
-    "recoil": 1000,
+    "proportional": { "recoil": 1.4 },
     "casing": "40x46mm_m118_casing"
   },
   {
@@ -106,7 +106,7 @@
     "range": 10,
     "//": "Balanced as FMJ.",
     "damage": { "damage_type": "bullet", "amount": 96, "armor_penetration": 42, "armor_multiplier": 1.5 },
-    "recoil": 1000,
+    "proportional": { "recoil": 1.4 },
     "casing": "40x46mm_m199_casing"
   },
   {
@@ -119,7 +119,7 @@
     "range": 10,
     "//": "Balanced as AP.",
     "damage": { "damage_type": "bullet", "amount": 84, "armor_penetration": 72 },
-    "recoil": 1000,
+    "proportional": { "recoil": 1.2 },
     "casing": "40x46mm_m118_casing",
     "extend": { "effects": [ "SHOT" ] }
   },
@@ -133,7 +133,7 @@
     "range": 10,
     "//": "Balanced as AP.",
     "damage": { "damage_type": "bullet", "amount": 84, "armor_penetration": 72 },
-    "recoil": 1000,
+    "proportional": { "recoil": 1.2 },
     "casing": "40x46mm_m199_casing",
     "extend": { "effects": [ "SHOT" ] }
   }

--- a/data/json/items/ammo/40x53mm.json
+++ b/data/json/items/ammo/40x53mm.json
@@ -16,7 +16,7 @@
     "range": 60,
     "damage": { "damage_type": "bullet", "amount": 80 },
     "dispersion": 30,
-    "recoil": 225,
+    "recoil": 6000,
     "effects": [ "COOKOFF", "NEVER_MISFIRES" ]
   },
   {
@@ -29,7 +29,7 @@
     "//": "Balanced as AP.",
     "range": 10,
     "damage": { "damage_type": "bullet", "amount": 91, "armor_penetration": 78 },
-    "recoil": 1000,
+    "proportional": { "recoil": 1.2 },
     "casing": "40x53mm_m169_casing",
     "extend": { "effects": [ "SHOT" ] }
   },
@@ -54,7 +54,7 @@
     "weight": "340 g",
     "range": 10,
     "damage": { "damage_type": "bullet", "amount": 130, "armor_multiplier": 2 },
-    "recoil": 1200,
+    "proportional": { "recoil": 1.2 },
     "casing": "40x53mm_m169_casing",
     "extend": { "effects": [ "SHOT" ] }
   },
@@ -68,7 +68,7 @@
     "range": 10,
     "//": "Balanced as FMJ.",
     "damage": { "damage_type": "bullet", "amount": 104, "armor_penetration": 46, "armor_multiplier": 1.5 },
-    "recoil": 1200,
+    "proportional": { "recoil": 1.4 },
     "casing": "40x53mm_m169_casing"
   }
 ]

--- a/data/json/items/ammo/45.json
+++ b/data/json/items/ammo/45.json
@@ -40,7 +40,7 @@
     "price_postapoc": "6 USD",
     "count": 10,
     "relative": { "damage": { "damage_type": "bullet", "armor_penetration": 18 }, "dispersion": -10 },
-    "proportional": { "recoil": 2 }
+    "proportional": { "recoil": 1.2 }
   },
   {
     "id": "bp_45_acp",

--- a/data/json/items/ammo/46.json
+++ b/data/json/items/ammo/46.json
@@ -19,7 +19,7 @@
     "//": "Base damage of 20, balance increase of one third.",
     "damage": { "damage_type": "bullet", "amount": 24, "armor_penetration": 24 },
     "dispersion": 40,
-    "recoil": 90,
+    "recoil": 350,
     "effects": [ "COOKOFF" ]
   },
   {

--- a/data/json/items/ammo/57.json
+++ b/data/json/items/ammo/57.json
@@ -19,7 +19,7 @@
     "//": "Base damage of 20, balance increase of one third.  Armor penetration balanced on the assumption that this is the AP variant of a hypothetical FMJ round.",
     "damage": { "damage_type": "bullet", "amount": 26, "armor_penetration": 26 },
     "dispersion": 40,
-    "recoil": 90,
+    "recoil": 400,
     "effects": [ "COOKOFF" ]
   },
   {

--- a/data/json/items/ammo/762x25.json
+++ b/data/json/items/ammo/762x25.json
@@ -30,7 +30,7 @@
     "description": "A high-pressure commercial version of the 7.62x25mm cartridge, loaded with an 85 gr. FMJ bullet.  It is more powerful than the original.",
     "//": "Hollowpoint bonus of 25%, retains armor penetration due to being a +P load.",
     "relative": { "price": 500, "range": 2, "damage": { "damage_type": "bullet", "amount": 6 } },
-    "proportional": { "recoil": 2 }
+    "proportional": { "recoil": 1.2 }
   },
   {
     "id": "762_25typeP",

--- a/data/json/items/ammo/9mm.json
+++ b/data/json/items/ammo/9mm.json
@@ -41,7 +41,7 @@
     "price_postapoc": "8 USD",
     "count": 25,
     "relative": { "damage": { "damage_type": "bullet", "armor_penetration": 15 }, "dispersion": -15 },
-    "proportional": { "recoil": 2 }
+    "proportional": { "recoil": 1.2 }
   },
   {
     "id": "9mmP2",
@@ -53,7 +53,7 @@
     "price_postapoc": "4 USD",
     "count": 10,
     "relative": { "damage": { "damage_type": "bullet", "amount": 2, "armor_penetration": 2 }, "dispersion": -15 },
-    "proportional": { "recoil": 3 }
+    "proportional": { "recoil": 1.2 }
   },
   {
     "id": "bp_9mm",

--- a/data/json/items/ammo/9x18.json
+++ b/data/json/items/ammo/9x18.json
@@ -19,7 +19,7 @@
     "//": "Base damage of 16, balance increase of one-third.",
     "damage": { "damage_type": "bullet", "amount": 21, "armor_penetration": 12 },
     "dispersion": 60,
-    "recoil": 300,
+    "recoil": 450,
     "effects": [ "COOKOFF" ]
   },
   {

--- a/doc/src/content/docs/en/mod/json/reference/items/item_creation.md
+++ b/doc/src/content/docs/en/mod/json/reference/items/item_creation.md
@@ -468,7 +468,7 @@ Guns can be defined like this:
 // aim threshold.
 "sight_dispersion": 10,    // Inaccuracy of gun derived from the sight mechanism, also in quarter-degrees
 "aim_speed": 3,            // A measure of how quickly the player can aim, in moves per point of dispersion.
-"recoil": 0,               // Recoil caused when firing, in quarter-degrees of dispersion. 10% proportional increase for military versions of a round (ie. M885A1) and 20% increase for overpressure ammunition.
+"recoil": 0,               // Recoil caused when firing, in quarter-degrees of dispersion. 10% proportional increase for military versions of a round (ie. M855A1) and 20% increase for overpressure ammunition.
 "durability": 8,           // Resistance to damage/rusting, also determines misfire chance
 "blackpowder_tolerance": 8,// One in X chance to get clogged up (per shot) when firing blackpowder ammunition (higher is better). Optional, default is 8.
 "min_cycle_recoil": 0,     // Minimum ammo recoil for gun to be able to fire more than once per attack.

--- a/doc/src/content/docs/en/mod/json/reference/items/item_creation.md
+++ b/doc/src/content/docs/en/mod/json/reference/items/item_creation.md
@@ -468,7 +468,7 @@ Guns can be defined like this:
 // aim threshold.
 "sight_dispersion": 10,    // Inaccuracy of gun derived from the sight mechanism, also in quarter-degrees
 "aim_speed": 3,            // A measure of how quickly the player can aim, in moves per point of dispersion.
-"recoil": 0,               // Recoil caused when firing, in quarter-degrees of dispersion.
+"recoil": 0,               // Recoil caused when firing, in quarter-degrees of dispersion. 10% proportional increase for military versions of a round (ie. M885A1) and 20% increase for overpressure ammunition.
 "durability": 8,           // Resistance to damage/rusting, also determines misfire chance
 "blackpowder_tolerance": 8,// One in X chance to get clogged up (per shot) when firing blackpowder ammunition (higher is better). Optional, default is 8.
 "min_cycle_recoil": 0,     // Minimum ammo recoil for gun to be able to fire more than once per attack.

--- a/doc/src/content/docs/en/mod/json/reference/items/item_creation.md
+++ b/doc/src/content/docs/en/mod/json/reference/items/item_creation.md
@@ -468,7 +468,7 @@ Guns can be defined like this:
 // aim threshold.
 "sight_dispersion": 10,    // Inaccuracy of gun derived from the sight mechanism, also in quarter-degrees
 "aim_speed": 3,            // A measure of how quickly the player can aim, in moves per point of dispersion.
-"recoil": 0,               // Recoil caused when firing, in quarter-degrees of dispersion. 10% proportional increase for military versions of a round (ie. M855A1) and 20% increase for overpressure ammunition.
+"recoil": 0,               // Recoil caused when firing, in quarter-degrees of dispersion.
 "durability": 8,           // Resistance to damage/rusting, also determines misfire chance
 "blackpowder_tolerance": 8,// One in X chance to get clogged up (per shot) when firing blackpowder ammunition (higher is better). Optional, default is 8.
 "min_cycle_recoil": 0,     // Minimum ammo recoil for gun to be able to fire more than once per attack.


### PR DESCRIPTION
## Purpose of change (The Why)

#6402 made 9mm +p+ as strong kicking as a .308 (oops) and while inspecting the code I realized some inconsistencies and plain goofiness like 5.7 and 4.6mm rounds having 90 recoil along with grenades having 225. This is physically impossible.

## Describe the solution (The How)

Makes the +p recoil proportion multiplier uniform >> 1.2 to represent a 20% increase.
It can be argued that different kinds of ammo from different manufacturers could have 10%-40% of extra recoil compared to the common version but 20% seems like a good rounding.

Sets recoil proportion multiplier for buckshot/flechette grenades to 1.2 and slugs to 1.4

Full list of stuff changes (no abstracts):
22lr CPHP: 1.5 > 1.2 mult
32 ACP: 150 > 250 - almost has twice the energy of .22lr
38 spec: 250 > 350 - almost has triple the energy of 22lr
380 +p:  2 > 1.2 mult
38 super: 250 > 550 - almost has double the energy of 38 spec
45 +p: 2 > 1.2 mult
4.6mm (HK): 90 > 350 - far too low for what it is
5.7: 90 > 400 - far too low for what it is
7.62x25 hot: 2 > 1.2 mult
9mm +p: 2 > 1.2 mult
9mm +p+: 2 > 1.2 mult (stacks with above and has a little less recoil than 10mm at this point)
9x18mm: 300 > 450 - slightly flatter than 9mm para

40x46mm: 225 > 2000 - absurdly low, raised to be a little softer than 12ga buck
40x53mm: 225 > 6000 - absurdly low, HV grenades have 3.5x the muzzle velocity with a bigger projectile and a range of 2.2kms



## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
