### PR TITLE
feat(port): add "monologue" action in speech menu with context

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -197,6 +197,7 @@ enum npc_chat_menu {
     NPC_CHAT_DONE,
     NPC_CHAT_TALK,
     NPC_CHAT_YELL,
+    NPC_CHAT_THINK,
     NPC_CHAT_SENTENCE,
     NPC_CHAT_GUARD,
     NPC_CHAT_FOLLOW,
@@ -458,6 +459,7 @@ void game::chat()
     }
     nmenu.addentry( NPC_CHAT_YELL, true, 'a', _( "Yell" ) );
     nmenu.addentry( NPC_CHAT_SENTENCE, true, 'b', _( "Yell a sentence" ) );
+    nmenu.addentry( NPC_CHAT_THINK, true, 'T', _( "Think something" ) );
     if( !animal_vehicles.empty() ) {
         nmenu.addentry( NPC_CHAT_ANIMAL_VEHICLE_FOLLOW, true, 'F',
                         _( "Whistle at your animals pulling vehicles to follow you." ) );
@@ -499,6 +501,7 @@ void game::chat()
     }
     std::string message;
     std::string yell_msg;
+    std::string think_msg;
     bool is_order = true;
     nmenu.query();
 
@@ -529,6 +532,19 @@ void game::chat()
             .max_length( 128 )
             .query();
             yell_msg = popup.text();
+            is_order = false;
+            break;
+        }
+        case NPC_CHAT_THINK: {
+            std::string popupdesc = _( "What are you thinking about?" );
+            string_input_popup popup;
+            popup.title( _( "You think" ) )
+            .width( 64 )
+            .description( popupdesc )
+            .identifier( "sentence" )
+            .max_length( 128 )
+            .query();
+            think_msg = popup.text();
             is_order = false;
             break;
         }
@@ -656,6 +672,9 @@ void game::chat()
     if( !message.empty() ) {
         add_msg( _( "You yell %s" ), message );
         u.shout( string_format( _( "%s yelling %s" ), u.disp_name(), message ), is_order );
+    }
+    if( !think_msg.empty() ) {
+        add_msg( _( "You think %s" ), think_msg );
     }
 
     u.moves -= 100;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -197,7 +197,7 @@ enum npc_chat_menu {
     NPC_CHAT_DONE,
     NPC_CHAT_TALK,
     NPC_CHAT_YELL,
-    NPC_CHAT_THINK,
+    NPC_CHAT_EMOTE,
     NPC_CHAT_SENTENCE,
     NPC_CHAT_GUARD,
     NPC_CHAT_FOLLOW,
@@ -459,7 +459,7 @@ void game::chat()
     }
     nmenu.addentry( NPC_CHAT_YELL, true, 'a', _( "Yell" ) );
     nmenu.addentry( NPC_CHAT_SENTENCE, true, 'b', _( "Yell a sentence" ) );
-    nmenu.addentry( NPC_CHAT_THINK, true, 'T', _( "Think something" ) );
+    nmenu.addentry( NPC_CHAT_EMOTE, true, 'E', _( "Emote" ) );
     if( !animal_vehicles.empty() ) {
         nmenu.addentry( NPC_CHAT_ANIMAL_VEHICLE_FOLLOW, true, 'F',
                         _( "Whistle at your animals pulling vehicles to follow you." ) );
@@ -501,7 +501,7 @@ void game::chat()
     }
     std::string message;
     std::string yell_msg;
-    std::string think_msg;
+    std::string emote_msg;
     bool is_order = true;
     nmenu.query();
 
@@ -535,16 +535,17 @@ void game::chat()
             is_order = false;
             break;
         }
-        case NPC_CHAT_THINK: {
-            std::string popupdesc = _( "What are you thinking about?" );
-            string_input_popup popup;
-            popup.title( _( "You think" ) )
+        case NPC_CHAT_EMOTE: {
+            std::string popupdesc =
+                _( "What do you want to emote?  (This will have no in-game effect!)" );
+                string_input_popup popup;
+            popup.title( _( "Emote" ) )
             .width( 64 )
             .description( popupdesc )
             .identifier( "sentence" )
             .max_length( 128 )
             .query();
-            think_msg = popup.text();
+            emote_msg = popup.text();
             is_order = false;
             break;
         }
@@ -673,8 +674,8 @@ void game::chat()
         add_msg( _( "You yell %s" ), message );
         u.shout( string_format( _( "%s yelling %s" ), u.disp_name(), message ), is_order );
     }
-    if( !think_msg.empty() ) {
-        add_msg( _( "You think %s" ), think_msg );
+    if( !emote_msg.empty() ) {
+        add_msg( m_bad, _( "%s" ), emote_msg );
     }
 
     u.moves -= 100;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -537,7 +537,7 @@ void game::chat()
         }
         case NPC_CHAT_EMOTE: {
             std::string popupdesc =
-                _( "What do you want to emote?  (This will have no in-game effect!)" );
+                _( "What do you want to emote?  (This will have no in-game effect! Use +, -, or ? at the start to add context.)" );
                 string_input_popup popup;
             popup.title( _( "Emote" ) )
             .width( 64 )
@@ -675,7 +675,15 @@ void game::chat()
         u.shout( string_format( _( "%s yelling %s" ), u.disp_name(), message ), is_order );
     }
     if( !emote_msg.empty() ) {
-        add_msg( m_bad, _( "%s" ), emote_msg );
+        if( emote_msg[0] == '-' ) {
+            add_msg( m_bad, _( "%s" ), emote_msg.substr( 1 ) );
+        } else if( emote_msg[0] == '+' ) {
+            add_msg( m_good, _( "%s" ), emote_msg.substr( 1 ) );
+        } else if( emote_msg[0] == '?' ) {
+            add_msg( m_info, _( "%s" ), emote_msg.substr( 1 ) );
+        } else {
+            add_msg( _( "%s" ), emote_msg );
+        }
     }
 
     u.moves -= 100;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -538,7 +538,7 @@ void game::chat()
         case NPC_CHAT_EMOTE: {
             std::string popupdesc =
                 _( "What do you want to emote?  (This will have no in-game effect! Use +, -, or ? at the start to add context.)" );
-                string_input_popup popup;
+            string_input_popup popup;
             popup.title( _( "Emote" ) )
             .width( 64 )
             .description( popupdesc )

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -197,7 +197,7 @@ enum npc_chat_menu {
     NPC_CHAT_DONE,
     NPC_CHAT_TALK,
     NPC_CHAT_YELL,
-    NPC_CHAT_EMOTE,
+    NPC_CHAT_MONOLOGUE,
     NPC_CHAT_SENTENCE,
     NPC_CHAT_GUARD,
     NPC_CHAT_FOLLOW,
@@ -459,7 +459,7 @@ void game::chat()
     }
     nmenu.addentry( NPC_CHAT_YELL, true, 'a', _( "Yell" ) );
     nmenu.addentry( NPC_CHAT_SENTENCE, true, 'b', _( "Yell a sentence" ) );
-    nmenu.addentry( NPC_CHAT_EMOTE, true, 'E', _( "Emote" ) );
+    nmenu.addentry( NPC_CHAT_MONOLOGUE, true, 'M', _( "Monologue" ) );
     if( !animal_vehicles.empty() ) {
         nmenu.addentry( NPC_CHAT_ANIMAL_VEHICLE_FOLLOW, true, 'F',
                         _( "Whistle at your animals pulling vehicles to follow you." ) );
@@ -501,7 +501,7 @@ void game::chat()
     }
     std::string message;
     std::string yell_msg;
-    std::string emote_msg;
+    std::string monologue_msg;
     bool is_order = true;
     nmenu.query();
 
@@ -535,17 +535,17 @@ void game::chat()
             is_order = false;
             break;
         }
-        case NPC_CHAT_EMOTE: {
+        case NPC_CHAT_MONOLOGUE: {
             std::string popupdesc =
-                _( "What do you want to emote?  (This will have no in-game effect! Use +, -, or ? at the start to add context.)" );
+                _( "What do you want to monologue?  (This has no in-game effect! Use +, -, or ? at the start to add context.)" );
             string_input_popup popup;
-            popup.title( _( "Emote" ) )
+            popup.title( _( "Monologue" ) )
             .width( 64 )
             .description( popupdesc )
             .identifier( "sentence" )
             .max_length( 128 )
             .query();
-            emote_msg = popup.text();
+            monologue_msg = popup.text();
             is_order = false;
             break;
         }
@@ -674,15 +674,15 @@ void game::chat()
         add_msg( _( "You yell %s" ), message );
         u.shout( string_format( _( "%s yelling %s" ), u.disp_name(), message ), is_order );
     }
-    if( !emote_msg.empty() ) {
-        if( emote_msg[0] == '-' ) {
-            add_msg( m_bad, _( "%s" ), emote_msg.substr( 1 ) );
-        } else if( emote_msg[0] == '+' ) {
-            add_msg( m_good, _( "%s" ), emote_msg.substr( 1 ) );
-        } else if( emote_msg[0] == '?' ) {
-            add_msg( m_info, _( "%s" ), emote_msg.substr( 1 ) );
+    if( !monologue_msg.empty() ) {
+        if( monologue_msg[0] == '-' ) {
+            add_msg( m_bad, _( "%s" ), monologue_msg.substr( 1 ) );
+        } else if( monologue_msg[0] == '+' ) {
+            add_msg( m_good, _( "%s" ), monologue_msg.substr( 1 ) );
+        } else if( monologue_msg[0] == '?' ) {
+            add_msg( m_info, _( "%s" ), monologue_msg.substr( 1 ) );
         } else {
-            add_msg( _( "%s" ), emote_msg );
+            add_msg( _( "%s" ), monologue_msg );
         }
     }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Improve roleplaying user experienc
## Describe the solution (The How)
Allow the player to monologue (previously emote) to themselves for roleplay purposes

Port DDA changes:
https://github.com/https://github.com/CleverRaven/Cataclysm-DDA/pull/61490/
https://github.com/https://github.com/CleverRaven/Cataclysm-DDA/pull/71427/

Additionally, I've added a context feature that allows you to specify if a message is m_good, m_bad, or m_info by adding +, -, or ? at the beginning
## Describe alternatives you've considered
Don't make me say it (not adding it)
## Testing
Spawned in a world, pressed CTRL+C to open speech menu, and verified the user can add messages to the log with proper context
## Additional context
NOTE: All of these have been renamed to "monologue"
![image](https://github.com/user-attachments/assets/c6dcc81b-776d-40df-83b5-39cb89beec85)
![image](https://github.com/user-attachments/assets/c7547532-85f4-43c2-9b06-d0b7f7da3bfa)
![image](https://github.com/user-attachments/assets/23973e1f-a476-4dec-a52f-22625dc96ea7)
![image](https://github.com/user-attachments/assets/fa2d8d23-91ee-4d63-9efe-1f9ca6e93b1d)
![image](https://github.com/user-attachments/assets/4f82e93e-9b90-4458-8294-5bc1ceaf88b2)
![image](https://github.com/user-attachments/assets/ab626c14-6ab6-45c6-9884-de2ab5771d64)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [X] This PR ports commits from DDA or other cataclysm forks.
  - [X] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [X] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
