### PR TITLE
fix: remove the road connection of urban_23_dense_office_theater

### DIFF
--- a/data/json/overmap/multitile_city_buildings.json
+++ b/data/json/overmap/multitile_city_buildings.json
@@ -730,8 +730,6 @@
       { "point": [ 1, 0, -1 ], "overmap": "urban_23_1_south" },
       { "point": [ 0, 0, -1 ], "overmap": "urban_23_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_23_3_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_23_4_south" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_23_5_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_23_6_south" },
@@ -743,8 +741,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ 2, 0, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
       { "point": [ -1, 0, -1 ], "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] }
     ],


### PR DESCRIPTION
## Purpose of change (The Why)
I suspect that the road connection and the use of the static road for this location make it somehow fail to appear in town but if that's not the case, the location doesn't need them anyway.
## Describe the solution (The How)
Remove the road connections and static roads from the location.
## Describe alternatives you've considered
none
## Testing
I make my character appear in the game at the location via a scenario.
## Additional context

<img src="https://github.com/user-attachments/assets/21296111-340d-42f4-bc44-113fd6174d8b">


## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.