### PR TITLE
feat(port,UI): random selection keybinds for traits, scenarios, professions, skills

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -1160,15 +1160,36 @@
     "type": "keybinding",
     "id": "REROLL_CHARACTER",
     "category": "NEW_CHAR_DESCRIPTION",
-    "name": "Reroll Random Character",
+    "name": "Reroll random character",
     "bindings": [ { "input_method": "keyboard", "key": "%" } ]
   },
   {
     "type": "keybinding",
     "id": "REROLL_CHARACTER_WITH_SCENARIO",
     "category": "NEW_CHAR_DESCRIPTION",
-    "name": "Reroll Random Character With Scenario",
+    "name": "Reroll random character with scenario",
     "bindings": [ { "input_method": "keyboard", "key": "^" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "REROLL_CHARACTER",
+    "category": "NEW_CHAR_TRAITS",
+    "name": "Reroll random character",
+    "bindings": [ { "input_method": "keyboard", "key": "%" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "REROLL_CHARACTER_WITH_SCENARIO",
+    "category": "NEW_CHAR_TRAITS",
+    "name": "Reroll random character with scenario",
+    "bindings": [ { "input_method": "keyboard", "key": "^" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "REROLL_APPEARANCE",
+    "category": "NEW_CHAR_TRAITS",
+    "name": "Reroll appearance",
+    "bindings": [ { "input_method": "keyboard", "key": "&" } ]
   },
   {
     "type": "keybinding",

--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -3558,5 +3558,50 @@
     "category": "ADVANCED_INVENTORY",
     "//": "Toggles option AIM_AUTORESET_FILTER",
     "bindings": [ { "input_method": "keyboard", "key": "T" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "RANDOMIZE",
+    "category": "NEW_CHAR_TRAITS",
+    "name": "Select random trait",
+    "bindings": [
+      { "input_method": "keyboard", "key": "*" }
+    ]
+  },
+  {
+    "type": "keybinding",
+    "id": "RANDOMIZE",
+    "category": "NEW_CHAR_PROFESSIONS",
+    "name": "Select random profession",
+    "bindings": [
+      { "input_method": "keyboard", "key": "*" }
+    ]
+  },
+  {
+    "type": "keybinding",
+    "id": "RANDOMIZE",
+    "category": "NEW_CHAR_SCENARIOS",
+    "name": "Select random scenario",
+    "bindings": [
+      { "input_method": "keyboard", "key": "*" }
+    ]
+  },
+  {
+    "type": "keybinding",
+    "id": "RANDOMIZE",
+    "category": "NEW_CHAR_SKILLS",
+    "name": "Select random skill",
+    "bindings": [
+      { "input_method": "keyboard", "key": "*" }
+    ]
+  },
+  {
+    "type": "keybinding",
+    "id": "RANDOMIZE",
+    "category": "NEW_CHAR_STATS",
+    "name": "Select random stat",
+    "bindings": [
+      { "input_method": "keyboard", "key": "*" }
+    ]
   }
 ]

--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -3564,44 +3564,34 @@
     "id": "RANDOMIZE",
     "category": "NEW_CHAR_TRAITS",
     "name": "Select random trait",
-    "bindings": [
-      { "input_method": "keyboard", "key": "*" }
-    ]
+    "bindings": [ { "input_method": "keyboard", "key": "*" } ]
   },
   {
     "type": "keybinding",
     "id": "RANDOMIZE",
     "category": "NEW_CHAR_PROFESSIONS",
     "name": "Select random profession",
-    "bindings": [
-      { "input_method": "keyboard", "key": "*" }
-    ]
+    "bindings": [ { "input_method": "keyboard", "key": "*" } ]
   },
   {
     "type": "keybinding",
     "id": "RANDOMIZE",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Select random scenario",
-    "bindings": [
-      { "input_method": "keyboard", "key": "*" }
-    ]
+    "bindings": [ { "input_method": "keyboard", "key": "*" } ]
   },
   {
     "type": "keybinding",
     "id": "RANDOMIZE",
     "category": "NEW_CHAR_SKILLS",
     "name": "Select random skill",
-    "bindings": [
-      { "input_method": "keyboard", "key": "*" }
-    ]
+    "bindings": [ { "input_method": "keyboard", "key": "*" } ]
   },
   {
     "type": "keybinding",
     "id": "RANDOMIZE",
     "category": "NEW_CHAR_STATS",
     "name": "Select random stat",
-    "bindings": [
-      { "input_method": "keyboard", "key": "*" }
-    ]
+    "bindings": [ { "input_method": "keyboard", "key": "*" } ]
   }
 ]

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -69,6 +69,7 @@ class avatar : public player
         // newcharacter.cpp
         bool create( character_type type, const std::string &tempname = "" );
         void randomize( bool random_scenario, points_left &points, bool play_now = false );
+        void randomize_cosmetics();
         bool load_template( const std::string &template_name, points_left &points );
         void save_template( const std::string &name, const points_left &points );
         void character_to_template( const std::string &name );

--- a/src/character.h
+++ b/src/character.h
@@ -733,6 +733,11 @@ class Character : public Creature, public location_visitable<Character>
         std::map<bodypart_id, int> get_armor_fire( const std::map<bodypart_id, std::vector<const item *>>
                 &clothing_map ) const;
         // --------------- Mutation Stuff ---------------
+        /** Returns the id of a random trait matching the given predicate */
+        trait_id get_random_trait( const std::function<bool( const mutation_branch & )> &func );
+        void randomize_cosmetic_trait( std::string mutation_type );
+        /** Returns true if character has a conflicting trait to the entered trait. */
+        void clear_cosmetic_traits( std::string mutation_type, trait_id trait );
 
         // In mutation.cpp
         /** Returns true if the player has the entered trait */

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3017,7 +3017,7 @@ trait_id newcharacter::random_good_trait()
     std::vector<trait_id> vTraitsGood;
 
     for( auto &traits_iter : mutation_branch::get_all() ) {
-        if( traits_iter.points > 0 && g->scen->traitquery( traits_iter.id ) ) {
+        if( traits_iter.points >= 0 && g->scen->traitquery( traits_iter.id ) ) {
             vTraitsGood.push_back( traits_iter.id );
         }
     }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2041,7 +2041,7 @@ tab_direction set_skills( avatar &u, points_left &points )
             cur_pos = modulo( cur_pos - 1, num_skills );
             currentSkill = skill_list[cur_pos].first;
         } else if( action == "RANDOMIZE" ) {
-            cur_pos = modulo( rng( 0, num_skills-1 ), num_skills );
+            cur_pos = modulo( rng( 0, num_skills - 1 ), num_skills );
         } else if( action == "LEFT" ) {
             const int level = u.get_skill_level( currentSkill->ident() );
             if( level > 0 ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1347,8 +1347,7 @@ tab_direction set_traits( avatar &u, points_left &points )
             } else {
                 iCurrentLine[iCurWorkingPage]--;
             }
-        }
-        else if( action == "REROLL_CHARACTER" ) {
+        } else if( action == "REROLL_CHARACTER" ) {
             points.init_from_options();
             u.randomize( false, points );
             // Return tab_direction::NONE so we re-enter this tab again, but it forces a complete redrawing of it.
@@ -3102,7 +3101,7 @@ trait_id Character::get_random_trait( const std::function<bool( const mutation_b
 
 void Character::randomize_cosmetic_trait( std::string mutation_type )
 {
-    trait_id trait = get_random_trait( [mutation_type]( const mutation_branch &mb ) {
+    trait_id trait = get_random_trait( [mutation_type]( const mutation_branch & mb ) {
         return mb.points == 0 && mb.types.count( mutation_type );
     } );
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -806,6 +806,7 @@ tab_direction set_stats( avatar &u, points_left &points )
     ctxt.register_cardinal();
     ctxt.register_action( "PREV_TAB" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "RANDOMIZE" );
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "QUIT" );
 
@@ -969,6 +970,8 @@ tab_direction set_stats( avatar &u, points_left &points )
             } else {
                 sel = 4;
             }
+        } else if( action == "RANDOMIZE" ) {
+            sel = rng( 1, 4 );
         } else if( action == "LEFT" ) {
             if( sel == 1 && u.str_max > 4 ) {
                 if( u.str_max > HIGH_STAT ) {
@@ -1162,6 +1165,7 @@ tab_direction set_traits( avatar &u, points_left &points )
     ctxt.register_action( "PREV_TAB" );
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "RANDOMIZE" );
     ctxt.register_action( "QUIT" );
 #if defined(TILES)
     ctxt.register_action( "zoom_in" );
@@ -1316,6 +1320,8 @@ tab_direction set_traits( avatar &u, points_left &points )
             if( static_cast<size_t>( iCurrentLine[iCurWorkingPage] ) >= traits_size[iCurWorkingPage] ) {
                 iCurrentLine[iCurWorkingPage] = 0;
             }
+        } else if( action == "RANDOMIZE" ) {
+            iCurrentLine[iCurWorkingPage] = rng( 0, traits_size[iCurWorkingPage] - 1 );
         } else if( action == "CONFIRM" ) {
             int inc_type = 0;
             const trait_id cur_trait = vStartingTraits[iCurWorkingPage][iCurrentLine[iCurWorkingPage]].id;
@@ -1467,6 +1473,7 @@ tab_direction set_profession( avatar &u, points_left &points,
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "SORT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "RANDOMIZE" );
     ctxt.register_action( "FILTER" );
     ctxt.register_action( "QUIT" );
 
@@ -1763,6 +1770,8 @@ tab_direction set_profession( avatar &u, points_left &points,
             if( desc_offset > 0 ) {
                 desc_offset--;
             }
+        } else if( action == "RANDOMIZE" ) {
+            cur_id = rng( 0, profs_length - 1 );
         } else if( action == "RIGHT" ) {
             if( desc_offset < iheight ) {
                 desc_offset++;
@@ -1863,6 +1872,7 @@ tab_direction set_skills( avatar &u, points_left &points )
     ctxt.register_action( "SCROLL_UP" );
     ctxt.register_action( "PREV_TAB" );
     ctxt.register_action( "NEXT_TAB" );
+    ctxt.register_action( "RANDOMIZE" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "QUIT" );
 
@@ -2030,6 +2040,8 @@ tab_direction set_skills( avatar &u, points_left &points )
         } else if( action == "UP" ) {
             cur_pos = modulo( cur_pos - 1, num_skills );
             currentSkill = skill_list[cur_pos].first;
+        } else if( action == "RANDOMIZE" ) {
+            cur_pos = modulo( rng( 0, num_skills-1 ), num_skills );
         } else if( action == "LEFT" ) {
             const int level = u.get_skill_level( currentSkill->ident() );
             if( level > 0 ) {
@@ -2126,6 +2138,7 @@ tab_direction set_scenario( avatar &u, points_left &points,
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "SORT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "RANDOMIZE" );
     ctxt.register_action( "FILTER" );
     ctxt.register_action( "QUIT" );
 
@@ -2395,6 +2408,8 @@ tab_direction set_scenario( avatar &u, points_left &points,
             if( cur_id < 0 ) {
                 cur_id = scens_length - 1;
             }
+        } else if( action == "RANDOMIZE" ) {
+            cur_id = rng( 0, scens_length - 1 );
         } else if( action == "CONFIRM" ) {
             if( sorted_scens[cur_id]->has_flag( "CITY_START" ) && !scenario_sorter.cities_enabled ) {
                 continue;
@@ -3002,7 +3017,7 @@ trait_id newcharacter::random_good_trait()
     std::vector<trait_id> vTraitsGood;
 
     for( auto &traits_iter : mutation_branch::get_all() ) {
-        if( traits_iter.points >= 0 && g->scen->traitquery( traits_iter.id ) ) {
+        if( traits_iter.points > 0 && g->scen->traitquery( traits_iter.id ) ) {
             vTraitsGood.push_back( traits_iter.id );
         }
     }


### PR DESCRIPTION
## Purpose of change (The Why)
Reduce carpal tunnel
## Describe the solution (The How)
based on https://github.com/CleverRaven/Cataclysm-DDA/pull/78634/, I think there was a previous PR that added randomization to other pages but I can't find it so I just recreated the functionality myself from this PR

Also includes changes from PRs
https://github.com/CleverRaven/Cataclysm-DDA/pull/46731
https://github.com/CleverRaven/Cataclysm-DDA/pull/60959

Add a "Randomize selection" keybind to traits, scenarios, professions, and skills tab of character creation. This has been renamed from DDA's "Randomize" to be more descriptive of what it actually does, as there was some discussion on their end that the behavior was odd.

Add a "Randomize avatar" keybind to traits menu

Makes "Random character" start randomize appearance but not "custom character"
## Describe alternatives you've considered
The usual

## Testing

Created new character, ensured I could randomize selection on each page added and that the keybind could be properly changed.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [X] This PR ports commits from DDA or other cataclysm forks.
  - [X] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
<!--
please remove sections irrelevant to this PR.

  - [X] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
