### PR TITLE
fix: remove pots and pans being dropped from the advanced butchery station

### DIFF
--- a/data/json/vehicleparts/utilities.json
+++ b/data/json/vehicleparts/utilities.json
@@ -174,9 +174,7 @@
     "breaks_into": [
       { "count": [ 4, 6 ], "item": "steel_lump" },
       { "count": [ 4, 6 ], "item": "steel_chunk" },
-      { "count": [ 4, 6 ], "item": "scrap" },
-      { "item": "pan", "prob": 50 },
-      { "item": "pot", "prob": 50 }
+      { "count": [ 4, 6 ], "item": "scrap" }
     ],
     "broken_color": "light_cyan",
     "broken_symbol": "x",


### PR DESCRIPTION
## Purpose of change 
pots and pans are not part of the crafting recipe so should not drop from the advanced butchery station

## Describe the solution 
removes the drops from the item
## Describe alternatives you've considered
adding more pots and pans
## Additional context
followup to #6166

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

