### PR TITLE
fix: introduce missing `hands` workbench to activity speed formula

### DIFF
--- a/src/activity_speed.cpp
+++ b/src/activity_speed.cpp
@@ -284,28 +284,36 @@ void activity_speed::calc_morale_factor( const Character &who )
 
 void activity_speed::find_best_bench( const tripoint &pos, const metric metrics )
 {
+    static const workbench_info_wrapper ground_bench(
+        *string_id<furn_t>( "f_ground_crafting_spot" )->workbench );
+    static const workbench_info_wrapper hands_bench(
+        *string_id<furn_t>( "f_fake_bench_hands" )->workbench );
+
     map &here = get_map();
-    std::optional<bench_loc> bench_tmp;
-    bench = bench_loc(
-                workbench_info_wrapper(
-                    *string_id<furn_t>( "f_ground_crafting_spot" )->workbench ),
-                pos );
+    bench = bench_loc( ground_bench, pos );
+    auto bench_tmp = bench_loc( hands_bench, pos );
+
     bench_factor_custom_formula( *bench, metrics );
+    bench_factor_custom_formula( bench_tmp, metrics );
+
+    if( bench_tmp.wb_info.multiplier_adjusted > bench->wb_info.multiplier_adjusted ) {
+        bench = bench_tmp;
+    }
 
     std::vector<tripoint> reachable( PICKUP_RANGE * PICKUP_RANGE );
     here.reachable_flood_steps( reachable, pos, PICKUP_RANGE, 1, 100 );
     for( const tripoint &adj : reachable ) {
         if( const auto &wb = here.furn( adj )->workbench ) {
             bench_tmp = bench_loc( workbench_info_wrapper( *wb ), adj );
-            bench_factor_custom_formula( *bench_tmp, metrics );
-            if( bench_tmp->wb_info.multiplier_adjusted > bench->wb_info.multiplier_adjusted ) {
+            bench_factor_custom_formula( bench_tmp, metrics );
+            if( bench_tmp.wb_info.multiplier_adjusted > bench->wb_info.multiplier_adjusted ) {
                 bench = bench_tmp;
             }
         } else if( const auto &vp = here.veh_at( adj ).part_with_feature( "WORKBENCH", true ) ) {
             if( const auto &wb_info = vp->part().info().get_workbench_info() ) {
                 bench_tmp = bench_loc( workbench_info_wrapper( *wb_info ), adj );
-                bench_factor_custom_formula( *bench_tmp, metrics );
-                if( bench_tmp->wb_info.multiplier_adjusted > bench->wb_info.multiplier_adjusted ) {
+                bench_factor_custom_formula( bench_tmp, metrics );
+                if( bench_tmp.wb_info.multiplier_adjusted > bench->wb_info.multiplier_adjusted ) {
                     bench = bench_tmp;
                 }
             } else {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2444,8 +2444,7 @@ int charges_for_continuing( int full_charges )
 
 } // namespace crafting
 
-void workbench_info_wrapper::adjust_multiplier( const metric
-        &metrics )
+void workbench_info_wrapper::adjust_multiplier( const metric &metrics )
 {
     multiplier_adjusted *= lerped_multiplier( metrics.first, allowed_mass, 1000_kilogram );
     multiplier_adjusted *= lerped_multiplier( metrics.second, allowed_volume, 1000_liter );

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -60,7 +60,7 @@ struct workbench_info_wrapper {
           type( type ) {
     }
 
-    void adjust_multiplier( const std::pair<units::mass, units::volume> &metrics );
+    void adjust_multiplier( const metric &metrics );
 };
 
 struct bench_loc {


### PR DESCRIPTION
## Purpose of change (The Why)

- part #6002.
- Fixes missing hands workbench type, which was resulting in workspeed penalty in certain circumstances

## Describe the solution (The How)

- Add missing value;
- Add appropriate checks.

## Testing

- Compile;
- Start;
- Perform an activity that requires workbench;
- Check nothing breaks;
- Check u don't have penalty for missing workbench if item is small enough to work in hands(below 5 kg and 10 L).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
