### PR TITLE
fix: monster on_hit actions trigger properly

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1947,6 +1947,12 @@ void monster::melee_attack( Creature &target, float accuracy )
 
 void monster::deal_projectile_attack( Creature *source, dealt_projectile_attack &attack )
 {
+    this->deal_projectile_attack( source, nullptr, attack );
+}
+
+void monster::deal_projectile_attack( Creature *source, item *source_weapon,
+                                      dealt_projectile_attack &attack )
+{
     const auto &proj = attack.proj;
     double &missed_by = attack.missed_by; // We can change this here
 
@@ -1965,7 +1971,7 @@ void monster::deal_projectile_attack( Creature *source, dealt_projectile_attack 
         missed_by = accuracy_critical;
     }
 
-    Creature::deal_projectile_attack( source, attack );
+    Creature::deal_projectile_attack( source, source_weapon, attack );
 
     if( !is_hallucination() && attack.hit_critter == this ) {
         // Maybe TODO: Get difficulty from projectile speed/size/missed_by

--- a/src/monster.h
+++ b/src/monster.h
@@ -334,6 +334,8 @@ class monster : public Creature, public location_visitable<monster>
         void melee_attack( Creature &target, float accuracy );
         void melee_attack( Creature &p, bool ) = delete;
         using Creature::deal_projectile_attack;
+        void deal_projectile_attack( Creature *source, item *source_weapon,
+                                     dealt_projectile_attack &attack ) override;
         void deal_projectile_attack( Creature *source, dealt_projectile_attack &attack ) override;
         void apply_damage( Creature *source, item *source_weapon, item *source_projectile, bodypart_id bp,
                            int dam,


### PR DESCRIPTION
## Purpose of change (The Why)
Fixes #6412
Bug introduced in #5394

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
`monster` did not have an overload for 
`Creature::deal_projectile_attack( Creature *source, item *source_weapon, dealt_projectile_attack &attack )` so the call to it in `ballistics.cpp` [L435: critter->deal_projectile_attack( null_source ? nullptr : origin, source_weapon, attack );](https://github.com/OrenAudeles/Cataclysm-BN/blob/152482b5e2e90d240c12dd89b49d5a6ce7721e04/src/ballistics.cpp#L435) would route in all cases to the one defined for `Creature`.
So the solution is to add in an overload so that call resolution goes to the `monster` version properly.

Also forwards the `source_weapon` parameter to through the `monster::deal_projectile_attack` call to where it calls `Creature::deal_projectile_attack`
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Ran with debugger gdb and set a breakpoint on `monster::deal_projectile_attack`, `Creature::deal_projectile_attack` and `monster::on_hit`.

1. Spawn a turret with a lamp nearby so it can be seen.
2. Set time to night so it cannot see me.
3. Give myself a low damage rifle so I can damage but not destroy the turret.
4. Shoot it and check for response.

Before change: Breaks on `Creature::deal_projectile_attack` with caller on `ballistics.cpp L435` which informed me that it wasn't calling into `monster::deal_projectile_attack` at all. Checked why and saw that `monster` only had the signature without a source weapon parameter.

Confirmation change: just remove the source weapon parameter
```diff
ballistics.cpp L435
-critter->deal_projectile_attack( null_source ? nullptr : origin, source_weapon, attack );
+critter->deal_projectile_attack( null_source ? nullptr : origin, attack );
```
Retested and triggered the `"RETURN_FIRE"` action from the target turret.

Reverted confirming change, made PR changes.

Retested and triggered the `"RETURN_FIRE"` action from the target turret.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
This will also fix `"ZAPBACK", "ACIDSPLASH", and "REVENGE_AGGRO"` on_hit response actions and monster trigger anger/morale adjustments.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
