### PR TITLE
chore: use V2 save format as default

### DIFF
--- a/src/world.cpp
+++ b/src/world.cpp
@@ -85,7 +85,7 @@ WORLDINFO::WORLDINFO()
 {
     world_name = world_generator->get_next_valid_worldname();
     WORLD_OPTIONS = get_options().get_world_defaults();
-    world_save_format = save_format::V1;
+    world_save_format = save_format::V2_COMPRESSED_SQLITE3;
 
     world_saves.clear();
     active_mod_order = world_generator->get_mod_manager().get_default_mods();


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #6436

## Describe the solution (The How)

flip enum

## Describe alternatives you've considered

not flip enum

## Testing
![image](https://github.com/user-attachments/assets/a7171e77-a18e-45d4-84b8-30be0ffb174f)

defaults to V2 on world creation

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
