### PR TITLE
feat: Add Lua binding for traps

### DIFF
--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -552,8 +552,8 @@ void cata::detail::reg_map( sol::state &lua )
             return m.add_field( p, fid, intensity, age );
         } );
         luna::set_fx( ut, "remove_field_at", &map::remove_field );
-        luna::set_fx( ut, "get_trap_at", []( map & m, const tripoint & p) -> trap_id {
-            return m.tr_at(p).loadid;
+        luna::set_fx( ut, "get_trap_at", []( map & m, const tripoint & p ) -> trap_id {
+            return m.tr_at( p ).loadid;
         } );
         DOC( "Set a trap at a position on the map. It can also replace existing trap, even with `trap_null`." );
         luna::set_fx( ut, "set_trap_at", &map::trap_set );

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -32,6 +32,7 @@
 #include "skill.h"
 #include "sounds.h"
 #include "translations.h"
+#include "trap.h"
 #include "type_id.h"
 #include "ui.h"
 #include "units_angle.h"
@@ -551,6 +552,15 @@ void cata::detail::reg_map( sol::state &lua )
             return m.add_field( p, fid, intensity, age );
         } );
         luna::set_fx( ut, "remove_field_at", &map::remove_field );
+        luna::set_fx( ut, "get_trap_at", []( map & m, const tripoint & p) -> trap_id {
+            return m.tr_at(p).loadid;
+        } );
+        DOC( "Set a trap at a position on the map. It can also replace existing trap, even with `trap_null`." );
+        luna::set_fx( ut, "set_trap_at", &map::trap_set );
+        DOC( "Disarms a trap using your skills and stats, with consequences depending on success or failure." );
+        luna::set_fx( ut, "disarm_trap_at", &map::disarm_trap );
+        DOC( "Simpler version of `set_trap_at` with `trap_null`." );
+        luna::set_fx( ut, "remove_trap_at", &map::remove_trap );
     }
 
     // Register 'tinymap' class to be used in Lua

--- a/src/catalua_bindings_ids.cpp
+++ b/src/catalua_bindings_ids.cpp
@@ -23,6 +23,7 @@
 #include "mutation.h"
 #include "recipe.h"
 #include "skill.h"
+#include "trap.h"
 #include "type_id.h"
 
 template<typename T, bool do_int_id>
@@ -126,6 +127,7 @@ void cata::detail::reg_game_ids( sol::state &lua )
     reg_id<species_type, false>( lua );
     reg_id<spell_type, false>( lua );
     reg_id<ter_t, true>( lua );
+    reg_id<trap, true>( lua );
 
 }
 

--- a/src/catalua_luna_doc.h
+++ b/src/catalua_luna_doc.h
@@ -60,6 +60,7 @@ struct npc_personality;
 struct point;
 struct species_type;
 struct tripoint;
+struct trap;
 namespace units
 {
 template<Arithmetic V, typename U>
@@ -159,6 +160,7 @@ LUNA_ID( Skill, "Skill" )
 LUNA_ID( species_type, "SpeciesType" )
 LUNA_ID( spell_type, "SpellType" )
 LUNA_ID( ter_t, "Ter" )
+LUNA_ID( trap, "Trap" )
 
 // Enums
 LUNA_ENUM( add_type, "AddictionType" )

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -39,7 +39,7 @@ generic_factory<trap> trap_factory( "trap" );
 
 /** @relates string_id */
 template<>
-inline bool int_id<trap>::is_valid() const
+bool int_id<trap>::is_valid() const
 {
     return trap_factory.is_valid( *this );
 }

--- a/src/trap.h
+++ b/src/trap.h
@@ -12,6 +12,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
+#include "catalua_type_operators.h"
 
 class Character;
 class Creature;
@@ -263,6 +264,8 @@ struct trap {
         static void check_consistency();
         /*@}*/
         static size_t count();
+        
+        LUA_TYPE_OPS(trap, id);
 };
 
 const trap_function &trap_function_from_string( const std::string &function_name );

--- a/src/trap.h
+++ b/src/trap.h
@@ -264,8 +264,8 @@ struct trap {
         static void check_consistency();
         /*@}*/
         static size_t count();
-        
-        LUA_TYPE_OPS(trap, id);
+
+        LUA_TYPE_OPS( trap, id );
 };
 
 const trap_function &trap_function_from_string( const std::string &function_name );


### PR DESCRIPTION
## Purpose of change (The Why)
I hoped ever that traps(especially PORTAL) can be handled by somehow.
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Add Lua binding for traps and some of member functions of `map`.
The functions enable traps to be set, changed, or removed on map.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Gently weeps

## Testing
Checking the trap below me:
![image](https://github.com/user-attachments/assets/2e80a1c1-867f-4027-8c86-d250c2488de2)
~~(Don't be surprised. A rollmat is a trap!)~~

Set the trap next to me:
![image](https://github.com/user-attachments/assets/b46be4b2-d75b-479a-a667-72e6ddc0b459)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
