### PR TITLE
feat: write lua docs to given path

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
   "tasks": {
     "doc": "deno task doc:cli & deno task doc:lua && deno fmt",
     "doc:cli": "deno run --allow-run=./cataclysm-bn-tiles --allow-write=doc/src/content/docs ./scripts/gen_cli_docs.ts",
-    "doc:lua": "./cataclysm-bn-tiles --lua-doc && cp config/lua_doc.md doc/src/content/docs/en/mod/lua/reference/lua.md",
+    "doc:lua": "./cataclysm-bn-tiles --lua-doc doc/src/content/docs/en/mod/lua/reference/lua.md",
     "migrate-unit": "deno run -A scripts/migrate_legacy_unit.ts --path data/json; deno run -A scripts/migrate_legacy_unit.ts --path data/mods; make style-all-json-parallel",
     "dprint": "deno run -A npm:dprint",
     // creates a weekly reddit changelog template

--- a/doc/src/content/docs/en/dev/reference/cli_options.md
+++ b/doc/src/content/docs/en/dev/reference/cli_options.md
@@ -13,8 +13,8 @@ This page is auto-generated from `tools/gen_cli_docs.ts` and should not be edite
 
 :::
 
-The game executable can not only run your favorite roguelike, but also provides a number of command
-line options to help modders and developers.
+The game executable can not only run your favorite roguelike,
+but also provides a number of command line options to help modders and developers.
 
 ---
 
@@ -58,9 +58,9 @@ Base path for all game data subdirectories.
 
 If set, no debug messages will be printed.
 
-### `--lua-doc`
+### `--lua-doc <generated lua docs path>`
 
-If set, will generate Lua docs and exit.
+Generate Lua docs to given path and exit.
 
 ### `--datadir <directory name>`
 
@@ -86,8 +86,7 @@ Instructs map-sharing code to use this name for your character..
 
 ### `--addadmin <username>`
 
-Instructs map-sharing code to use this name for your character and give you access to the cheat
-functions..
+Instructs map-sharing code to use this name for your character and give you access to the cheat functions..
 
 ### `--adddebugger <username>`
 

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -32,7 +32,7 @@ void startup_lua_test()
     // Nothing to do here
 }
 
-bool generate_lua_docs( const std::string &path )
+bool generate_lua_docs( const std::filesystem::path & )
 {
     // Nothing to do here
     return false;
@@ -137,7 +137,7 @@ void startup_lua_test()
     }
 }
 
-bool generate_lua_docs( const std::string &path )
+bool generate_lua_docs( const std::filesystem::path &path )
 {
     sol::state lua = make_lua_state();
     lua.globals()["doc_gen_func"] = lua.create_table();

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -32,7 +32,7 @@ void startup_lua_test()
     // Nothing to do here
 }
 
-bool generate_lua_docs()
+bool generate_lua_docs( const std::string &path )
 {
     // Nothing to do here
     return false;
@@ -137,7 +137,7 @@ void startup_lua_test()
     }
 }
 
-bool generate_lua_docs()
+bool generate_lua_docs( const std::string &path )
 {
     sol::state lua = make_lua_state();
     lua.globals()["doc_gen_func"] = lua.create_table();
@@ -148,7 +148,7 @@ bool generate_lua_docs()
         sol::protected_function_result res = doc_gen_func();
         check_func_result( res );
         std::string ret = res;
-        write_to_file( PATH_INFO::lua_doc_output(), [&]( std::ostream & s ) {
+        write_to_file( path.string(), [&]( std::ostream & s ) -> void {
             s << ret;
         } );
     } catch( std::runtime_error &e ) {

--- a/src/catalua.h
+++ b/src/catalua.h
@@ -3,6 +3,7 @@
 #include "type_id.h"
 
 #include <memory>
+#include <filesystem>
 
 class Item_factory;
 class map;
@@ -21,7 +22,7 @@ bool has_lua();
 int get_lua_api_version();
 std::string get_lapi_version_string();
 void startup_lua_test();
-bool generate_lua_docs( const std::string &path );
+bool generate_lua_docs( const std::filesystem::path &path );
 void show_lua_console();
 void reload_lua_code();
 void debug_write_lua_backtrace( std::ostream &out );

--- a/src/catalua.h
+++ b/src/catalua.h
@@ -21,7 +21,7 @@ bool has_lua();
 int get_lua_api_version();
 std::string get_lapi_version_string();
 void startup_lua_test();
-bool generate_lua_docs();
+bool generate_lua_docs( const std::string &path );
 void show_lua_console();
 void reload_lua_code();
 void debug_write_lua_backtrace( std::ostream &out );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,7 +201,7 @@ int main( int argc, char *argv[] )
     int seed = time( nullptr );
     bool verifyexit = false;
     bool check_mods = false;
-    bool lua_doc_mode = false;
+    std::filesystem::path lua_doc_output_path;
     std::string dump;
     dump_mode dmode = dump_mode::TSV;
     std::vector<std::string> opts;
@@ -421,12 +421,16 @@ int main( int argc, char *argv[] )
                     }
                 },
                 {
-                    "--lua-doc", nullptr,
-                    "If set, will generate Lua docs and exit",
+                    "--lua-doc", "<generated lua docs path>",
+                    "Generate Lua docs to given path and exit",
                     section_default,
-                    [&]( int, const char ** ) -> int {
+                    [&]( int num_args, const char **params ) -> int {
+                        if( num_args < 1 )
+                        {
+                            return -1;
+                        }
                         test_mode = true;
-                        lua_doc_mode = true;
+                        lua_doc_output_path = params[0];
                         return 0;
                     }
                 }
@@ -753,9 +757,9 @@ int main( int argc, char *argv[] )
     DebugLog( DL::Info, DC::Main ) << "LAPI version: " << cata::get_lapi_version_string();
     cata::startup_lua_test();
 
-    if( lua_doc_mode ) {
+    if( !lua_doc_output_path.empty() ) {
         init_colors();
-        if( cata::generate_lua_docs() ) {
+        if( cata::generate_lua_docs( lua_doc_output_path ) ) {
             cata_printf( "Lua doc: Done!\n" );
             return 0;
         } else {

--- a/src/path_display.cpp
+++ b/src/path_display.cpp
@@ -96,7 +96,6 @@ auto config_directory() -> std::string
         { _( "user font config" ), PATH_INFO::user_fontconfig() },
         { _( "user keybindings" ), PATH_INFO::user_keybindings() },
         { _( "last world" ), PATH_INFO::lastworld() },
-        { _( "Lua doc output" ), PATH_INFO::lua_doc_output() },
         { _( "panel options" ), PATH_INFO::panel_options() },
         { _( "safe mode" ), PATH_INFO::safemode() },
     } );

--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -297,10 +297,6 @@ std::string PATH_INFO::soundpack_conf()
 {
     return "soundpack.txt";
 }
-std::string PATH_INFO::lua_doc_output()
-{
-    return config_dir_value + "lua_doc.md";
-}
 std::string PATH_INFO::gfxdir()
 {
     return gfxdir_value;

--- a/src/path_info.h
+++ b/src/path_info.h
@@ -55,7 +55,6 @@ std::string mods_replacements();
 std::string mods_dev_default();
 std::string mods_user_default();
 std::string soundpack_conf();
-std::string lua_doc_output();
 
 std::string credits();
 std::string motd();


### PR DESCRIPTION
## Purpose of change (The Why)

because `PATH_INFO::lua_doc_output` is too flaky. its output path was determined by `config_dir_value`, which differs per OS and build flag. this makes `deno task docs` command unreliable.

## Describe the solution (The How)

make `--lua-doc` accept path to output file instead.

## Describe alternatives you've considered

print to stdout instead? tho most of time you'd rather generate the output in file

## Testing

works in my machine

## Additional context

i need to automate lua docs generation in CI sometimes later aaaaaa

## Checklist



### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
