### PR TITLE
build: add `linux-full` cmake preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,12 @@
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
         "DYNAMIC_LINKING": "False",
         "CMAKE_CONFIGURATION_TYPES": "Debug;RelWithDebInfo;Release",
-        "CURSES": "False", "LOCALIZE": "True", "TILES": "True", "SOUND": "True", "LUA": "True", "TESTS": "True",
+        "CURSES": "False",
+        "LOCALIZE": "True",
+        "TILES": "True",
+        "SOUND": "True",
+        "LUA": "True",
+        "TESTS": "True",
         "CMAKE_INSTALL_MESSAGE": "NEVER"
       }
     },
@@ -40,24 +45,48 @@
       "description": "Target Linux (64-bit) with the GCC development environment.",
       "generator": "Ninja Multi-Config",
       "cacheVariables": {
-        "DYNAMIC_LINKING": "True", "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "CURSES": "False", "LOCALIZE": "True", "TILES": "True", "SOUND": "True", "LUA": "True", "TESTS": "False",
+        "DYNAMIC_LINKING": "True",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CURSES": "False",
+        "LOCALIZE": "True",
+        "TILES": "True",
+        "SOUND": "True",
+        "LUA": "True",
+        "TESTS": "False",
         "CMAKE_INSTALL_MESSAGE": "NEVER"
       }
     },
     {
-      "name": "linux-tiles-sounds-x64-vcpkg",
-      "inherits": ["linux-tiles-sounds-x64"],
-      "displayName": "Linux Tiles Sounds x64 VCPKG",
-      "description": "Target Linux (64-bit) with the GCC development environment and VCPKG.",
-      "generator": "Ninja Multi-Config",
-      "environment": {
-        "VCPKG_ROOT": "/usr/local/vcpkg"
-      },
+      "name": "linux-full",
+      "binaryDir": "${sourceDir}/build",
+      "displayName": "Linux Full Build (Clang, Tiles, Sounds, Tracy)",
+      "description": "Target Linux with Clang, ccache, and Tracy profiling support",
+      "generator": "Ninja",
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "VCPKG_TARGET_TRIPLET": "x64-linux",
-        "VCPKG_MANIFEST_DIR": "${sourceDir}/msvc-full-features/"
+        "CATA_CCACHE": "ON",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_C_COMPILER": "/usr/bin/clang-19",
+        "CMAKE_CXX_COMPILER": "/usr/bin/clang++-19",
+        "CMAKE_INSTALL_PREFIX": "$env{XDG_DATA_HOME}",
+        "JSON_FORMAT": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CURSES": "OFF",
+        "TILES": "ON",
+        "SOUND": "ON",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CATA_CLANG_TIDY_PLUGIN": "ON",
+        "LUA": "ON",
+        "BACKTRACE": "ON",
+        "LIBBACKTRACE": "ON",
+        "LINKER": "mold",
+        "USE_XDG_DIR": "ON",
+        "USE_HOME_DIR": "OFF",
+        "USE_PREFIX_DATA_DIR": "OFF",
+        "USE_TRACY": "ON",
+        "TRACY_VERSION": "master",
+        "TRACY_ON_DEMAND": "ON",
+        "TRACY_ONLY_IPV4": "ON"
       }
     }
   ],
@@ -67,8 +96,9 @@
       "configurePreset": "linux-tiles-sounds-x64"
     },
     {
-      "name": "linux-tiles-sounds-x64-vcpkg",
-      "configurePreset": "linux-tiles-sounds-x64-vcpkg"
+      "name": "linux-full",
+      "configurePreset": "linux-full",
+      "description": "The canonical build preset for Linux. This is the one used by the devteam."
     }
   ]
 }


### PR DESCRIPTION
## Purpose of change (The Why)

this is the build preset that i use; using it simplifies build step for everyone and simplifies tech support process 

## Describe the solution (The How)

update the build preset with mine

## Describe alternatives you've considered

not do it

## Testing

run it like this:

```sh
cmake --build --parallel 10 --preset linux-full --target cataclysm-bn-tiles
```

## Additional context

TODO: write build guide using with this preset after mdbook migration

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

