### PR TITLE
build: simplify manual release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -16,57 +16,31 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-24.04
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      release_already_exists: ${{ steps.tag_check.outputs.exists }}
     steps:
-      - name: Generate environmental variables
-        id: generate_env_vars
-        run: |
-          echo "tag_name=${{ env.VERSION }}" >> $GITHUB_OUTPUT
-          echo "release_name=Cataclysm-BN ${{ env.VERSION }}" >> $GITHUB_OUTPUT
-      - name: Check if there is existing git tag
-        id: tag_check
-        uses: mukunku/tag-exists-action@v1.6.0
-        with:
-          tag: ${{ steps.generate_env_vars.outputs.tag_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - name: Push tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
-        if: ${{ steps.tag_check.outputs.exists == 'false' }}
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ steps.generate_env_vars.outputs.tag_name }}
-          tag_prefix: ""
-      - uses: actions/checkout@v4
-      - run: git fetch origin tag ${{ steps.generate_env_vars.outputs.tag_name }} --no-tags
-      - name: Build Changelog
-        id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v4.2.0
-        with:
-          configuration: "changelog.json"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
       - name: Create release
-        id: create_release
-        uses: softprops/action-gh-release@v2.0.2
-        if: ${{ steps.tag_check.outputs.exists == 'false' }}
+        run: |
+          set +e
+          gh release view ${{ env.VERSION }} --json name --jq '.name'
+          HAS_RELEASE=$?
+          if (( $HAS_RELEASE == 0 )); then
+            echo "Release already exists, skipping." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Release does not exist, creating a new one" >> "$GITHUB_STEP_SUMMARY"
+            gh release create ${{ env.VERSION }} \
+              --title "Cataclysm-BN ${{ env.VERSION }}" \
+              --draft \
+              --prerelease \
+              --generate-notes \
+              --target ${{ github.sha }}
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.generate_env_vars.outputs.tag_name }}
-          name: ${{ steps.generate_env_vars.outputs.release_name }}
-          body: |
-            ${{ steps.build_changelog.outputs.changelog }}
-            These are the outputs for the manually triggered build of commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
-          draft: true
-          prerelease: false
+
   builds:
     needs: release
-    if: ${{ needs.release.outputs.release_already_exists == 'false' }}
     strategy:
       fail-fast: false
       matrix:
@@ -173,9 +147,6 @@ jobs:
         uses: lukka/run-vcpkg@main
         id: runvcpkg
         with:
-          additionalCachedPaths: "${{ runner.workspace }}/Cataclysm-BN/msvc-full-features/vcpkg_installed"
-          appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/**' ) }}-${{ matrix.arch }}-1
-          setupOnly: true
           vcpkgDirectory: "${{ runner.workspace }}/b/vcpkg"
       - name: Install dependencies (windows msvc) (3/3)
         if: runner.os == 'Windows'
@@ -256,12 +227,8 @@ jobs:
                mv ./app/build/outputs/bundle/stableRelease/*.aab ../cbn-${{ matrix.artifact }}-${{ env.VERSION }}.aab
           fi
       - name: Upload release asset
-        id: upload-release-asset
-        uses: shogo82148/actions-upload-release-asset@v1.7.4
+        run: |
+          gh release upload ${{ env.VERSION }} --clobber cbn-${{ matrix.artifact }}-${{ env.VERSION }}.${{ matrix.ext }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: cbn-${{ matrix.artifact }}-${{ env.VERSION }}.${{ matrix.ext }}
-          asset_name: cbn-${{ matrix.artifact }}-${{ env.VERSION }}.${{ matrix.ext }}
-          asset_content_type: ${{ matrix.content }}
+        shell: bash


### PR DESCRIPTION
## Purpose of change (The Why)

- builds no longer fails successfully because you forgot to erase existing tags
- easy to understand workflow

## Describe the solution (The How)

[Github CLI my beloved](https://cli.github.com)

- if there's no release with given tag, create one
- build and upload assets

## Describe alternatives you've considered

weep violently

## Testing

![image](https://github.com/user-attachments/assets/d67a7aec-1a66-4f9c-8201-ec19cb644b5d)

![image](https://github.com/user-attachments/assets/fe73aff4-cb74-4d45-b4b1-f2384bc54e0f)

https://github.com/scarf005/Cataclysm-BN/actions/runs/14712691311

works on my fork: https://github.com/scarf005/Cataclysm-BN/releases/tag/untagged-373935b5564b20e23f97

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
