### PR TITLE
feat(balance): Removes NO_CVD flag from RM42 knife, adjusts stats

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -201,15 +201,15 @@
     "category": "weapons",
     "weapon_category": [ "KNIVES" ],
     "name": { "str": "RM42 fighting knife", "str_pl": "RM42 fighting knives" },
-    "description": "This sturdy matte black Rivtech combat dagger features a long and slim double-edged blade with a spear-point and a distinctive slip-resistant grip which can also be used to affix it to a suitable firearm.  Originally manufactured for the military, it was very popular in films and among collectors due to its fearsome appearance.",
+    "description": "This matte black Rivtech combat dagger features a long double-edged blade converging to a spear-point and a distinctive slip-resistant grip with low-profile grooves to affix to a firearm.  Improving on the design of the legendary Fairbarn-Sykes dagger with new materials, it was very popular in films and among collectors due to its fearsome appearance.",
     "weight": "188 g",
     "volume": "750 ml",
     "price": "450 USD",
     "price_postapoc": "40 USD",
-    "to_hit": 2,
-    "bashing": 2,
-    "cutting": 20,
-    "material": [ "ceramic", "plastic" ],
+    "to_hit": 1,
+    "bashing": 4,
+    "cutting": 22,
+    "material": [ "steel", "plastic", "ceramic" ],
     "symbol": "/",
     "color": "dark_gray",
     "gunmod_data": {
@@ -219,9 +219,9 @@
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ],
     "techniques": [ "RAPID", "WBLOCK_1" ],
-    "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 19 ] ],
+    "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 3 ] ],
     "thrown_damage": [ { "damage_type": "stab", "amount": 14 } ],
-    "flags": [ "STAB", "DURABLE_MELEE", "SHEATH_KNIFE", "NO_CVD" ]
+    "flags": [ "STAB", "DURABLE_MELEE", "SHEATH_KNIFE" ]
   },
   {
     "id": "knife_swissarmy",


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

![image](https://github.com/user-attachments/assets/5c628e99-a263-4ed3-9ea9-67a43dfcffe4)

No other item in the game has NO_CVD and other stats reveal this thing hasn't been touched in quite a while.

## Describe the solution (The How)

Updates item desc.
Removes NO_CVD flag
Reduces tohit from 2 -> 1
Increases bashing 2 -> 4, cutting 20 -> 22
Adds steel to materials
Greatly reduces butchering quality

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Rarity unchanged. Being the rarest knife in the game it should also pack more punch than a regular medieval dagger, no?

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task dev` so the Lua API documentation is updated.
-->
