### PR TITLE
refactor: fix build issue for older c++20 compiler on macOS platform

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6195,13 +6195,15 @@ bodypart_str_id Character::body_window( const std::string &menu_header,
         int bonus;
     };
 
-    std::vector<healable_bp> parts;
-    for( const bodypart_id &bp : get_all_body_parts( true ) ) {
+    const auto all_body_parts_v = get_all_body_parts( true );
+    std::vector<healable_bp> parts( all_body_parts_v.size() );
+    for( size_t i = 0; i < all_body_parts_v.size(); ++i ) {
+        const bodypart_id &bp = all_body_parts_v[i];
         // Ugly!
         int heal_bonus = bp == body_part_head ? head_bonus :
                          bp == body_part_torso ? torso_bonus :
                          normal_bonus;
-        parts.emplace_back( false, bp, bp->name_as_heading.translated(), heal_bonus );
+        parts[i] = { false, bp, bp->name_as_heading.translated(), heal_bonus };
     }
 
     int max_bp_name_len = 0;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6189,7 +6189,7 @@ bodypart_str_id Character::body_window( const std::string &menu_header,
                                         float bleed, float bite, float infect, float bandage_power, float disinfectant_power ) const
 {
     struct healable_bp {
-        mutable bool allowed;
+        bool allowed;
         bodypart_id bp;
         std::string name; // Translated name as it appears in the menu.
         int bonus;
@@ -6217,7 +6217,7 @@ bodypart_str_id Character::body_window( const std::string &menu_header,
     bool is_valid_choice = false;
 
     for( size_t i = 0; i < parts.size(); i++ ) {
-        const auto &e = parts[i];
+        auto &e = parts[i];
         const bodypart_id &bp = e.bp;
         const bodypart_str_id &bp_str_id = bp.id();
         const int maximal_hp = get_part_hp_max( bp );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
User Apollo on the Bright Night's Discord server is having issues compiling on macOS with a compiler that looks to not support `emplace_back` for structures without constructors.
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Switch to indexed assignment. `emplace_back` is nice but it's just going to prevent a handful of string copies in this case. 

Outside of the primary fix also removed the `mutable` keyword for `bool healable_bp::allowed`. The structure is used only within this function and `mutable` is unnecessary.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Spend time designing and implementing a slightly more complex solution that would remove the `healable_bp` structure entirely.

## Testing
There are no mechanical changes so "compiles" is about the only thing I can do to test.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Bug & Compile issue report here: https://discord.com/channels/830879262763909202/830916451517857894/1366947388425768970
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
