### PR TITLE
style: remove spaces in `operator"" _<name>`

### DIFF
--- a/src/calendar.h
+++ b/src/calendar.h
@@ -341,27 +341,27 @@ bool x_in_y( const time_duration &a, const time_duration &b );
  * `time_duration::from_*` function.
  */
 /**@{*/
-constexpr time_duration operator"" _turns( const unsigned long long int v )
+constexpr time_duration operator""_turns( const unsigned long long int v )
 {
     return time_duration::from_turns( v );
 }
-constexpr time_duration operator"" _seconds( const unsigned long long int v )
+constexpr time_duration operator""_seconds( const unsigned long long int v )
 {
     return time_duration::from_seconds( v );
 }
-constexpr time_duration operator"" _minutes( const unsigned long long int v )
+constexpr time_duration operator""_minutes( const unsigned long long int v )
 {
     return time_duration::from_minutes( v );
 }
-constexpr time_duration operator"" _hours( const unsigned long long int v )
+constexpr time_duration operator""_hours( const unsigned long long int v )
 {
     return time_duration::from_hours( v );
 }
-constexpr time_duration operator"" _days( const unsigned long long int v )
+constexpr time_duration operator""_days( const unsigned long long int v )
 {
     return time_duration::from_days( v );
 }
-constexpr time_duration operator"" _weeks( const unsigned long long int v )
+constexpr time_duration operator""_weeks( const unsigned long long int v )
 {
     return time_duration::from_weeks( v );
 }

--- a/src/fmtlib_format.h
+++ b/src/fmtlib_format.h
@@ -4445,12 +4445,12 @@ FMT_CONSTEXPR detail::udl_formatter<Char, CHARS...> operator""_format()
     std::string message = "The answer is {}"_format(42);
   \endrst
  */
-FMT_CONSTEXPR detail::udl_formatter<char> operator"" _format( const char *s,
+FMT_CONSTEXPR detail::udl_formatter<char> operator""_format( const char *s,
         size_t n )
 {
     return {{s, n}};
 }
-FMT_CONSTEXPR detail::udl_formatter<wchar_t> operator"" _format(
+FMT_CONSTEXPR detail::udl_formatter<wchar_t> operator""_format(
     const wchar_t *s, size_t n )
 {
     return {{s, n}};
@@ -4467,11 +4467,11 @@ FMT_CONSTEXPR detail::udl_formatter<wchar_t> operator"" _format(
     fmt::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
   \endrst
  */
-FMT_CONSTEXPR detail::udl_arg<char> operator"" _a( const char *s, size_t )
+FMT_CONSTEXPR detail::udl_arg<char> operator""_a( const char *s, size_t )
 {
     return {s};
 }
-FMT_CONSTEXPR detail::udl_arg<wchar_t> operator"" _a( const wchar_t *s, size_t )
+FMT_CONSTEXPR detail::udl_arg<wchar_t> operator""_a( const wchar_t *s, size_t )
 {
     return {s};
 }

--- a/src/units_angle.h
+++ b/src/units_angle.h
@@ -69,42 +69,42 @@ inline units::angle atan2( double y, double x )
 
 } // namespace units
 
-constexpr units::angle operator"" _radians( const long double v )
+constexpr units::angle operator""_radians( const long double v )
 {
     return units::from_radians( v );
 }
 
-constexpr units::angle operator"" _radians( const unsigned long long v )
+constexpr units::angle operator""_radians( const unsigned long long v )
 {
     return units::from_radians( v );
 }
 
-constexpr units::angle operator"" _pi_radians( const long double v )
+constexpr units::angle operator""_pi_radians( const long double v )
 {
     return units::from_radians( v * M_PI );
 }
 
-constexpr units::angle operator"" _pi_radians( const unsigned long long v )
+constexpr units::angle operator""_pi_radians( const unsigned long long v )
 {
     return units::from_radians( v * M_PI );
 }
 
-constexpr units::angle operator"" _degrees( const long double v )
+constexpr units::angle operator""_degrees( const long double v )
 {
     return units::from_degrees( v );
 }
 
-constexpr units::angle operator"" _degrees( const unsigned long long v )
+constexpr units::angle operator""_degrees( const unsigned long long v )
 {
     return units::from_degrees( v );
 }
 
-constexpr units::angle operator"" _arcmin( const long double v )
+constexpr units::angle operator""_arcmin( const long double v )
 {
     return units::from_arcmin( v );
 }
 
-constexpr units::angle operator"" _arcmin( const unsigned long long v )
+constexpr units::angle operator""_arcmin( const unsigned long long v )
 {
     return units::from_arcmin( v );
 }

--- a/src/units_energy.h
+++ b/src/units_energy.h
@@ -48,23 +48,23 @@ constexpr value_type to_kilojoule( const quantity<value_type, energy_in_joule_ta
 
 } // namespace units
 
-constexpr units::energy operator"" _J( const unsigned long long v )
+constexpr units::energy operator""_J( const unsigned long long v )
 {
     return units::from_joule( v );
 }
 
-constexpr units::quantity<double, units::energy_in_joule_tag> operator"" _J(
+constexpr units::quantity<double, units::energy_in_joule_tag> operator""_J(
     const long double v )
 {
     return units::from_joule( v );
 }
 
-constexpr units::energy operator"" _kJ( const unsigned long long v )
+constexpr units::energy operator""_kJ( const unsigned long long v )
 {
     return units::from_kilojoule( v );
 }
 
-constexpr units::quantity<double, units::energy_in_joule_tag> operator"" _kJ(
+constexpr units::quantity<double, units::energy_in_joule_tag> operator""_kJ(
     const long double v )
 {
     return units::from_kilojoule( v );

--- a/src/units_mass.h
+++ b/src/units_mass.h
@@ -83,45 +83,45 @@ constexpr value_type to_newton( const quantity<value_type, mass_in_milligram_tag
 } // namespace units
 
 // Implicitly converted to mass, which has int as value_type!
-constexpr units::mass operator"" _milligram( const unsigned long long v )
+constexpr units::mass operator""_milligram( const unsigned long long v )
 {
     return units::from_milligram( v );
 }
 
-constexpr units::mass operator"" _gram( const unsigned long long v )
+constexpr units::mass operator""_gram( const unsigned long long v )
 {
     return units::from_gram( v );
 }
 
-constexpr units::mass operator"" _kilogram( const unsigned long long v )
+constexpr units::mass operator""_kilogram( const unsigned long long v )
 {
     return units::from_kilogram( v );
 }
 
-constexpr units::mass operator"" _newton( const unsigned long long v )
+constexpr units::mass operator""_newton( const unsigned long long v )
 {
     return units::from_newton( v );
 }
 
-constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _milligram(
+constexpr units::quantity<double, units::mass_in_milligram_tag> operator""_milligram(
     const long double v )
 {
     return units::from_milligram( v );
 }
 
-constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _gram(
+constexpr units::quantity<double, units::mass_in_milligram_tag> operator""_gram(
     const long double v )
 {
     return units::from_gram( v );
 }
 
-constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _kilogram(
+constexpr units::quantity<double, units::mass_in_milligram_tag> operator""_kilogram(
     const long double v )
 {
     return units::from_kilogram( v );
 }
 
-constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _newton(
+constexpr units::quantity<double, units::mass_in_milligram_tag> operator""_newton(
     const long double v )
 {
     return units::from_newton( v );

--- a/src/units_money.h
+++ b/src/units_money.h
@@ -58,34 +58,34 @@ constexpr value_type to_kusd( const quantity<value_type, money_in_cent_tag> &v )
 
 } // namespace units
 
-constexpr units::money operator"" _cent( const unsigned long long v )
+constexpr units::money operator""_cent( const unsigned long long v )
 {
     return units::from_cent( v );
 }
 
-constexpr units::quantity<double, units::money_in_cent_tag> operator"" _cent(
+constexpr units::quantity<double, units::money_in_cent_tag> operator""_cent(
     const long double v )
 {
     return units::from_cent( v );
 }
 
-constexpr units::money operator"" _USD( const unsigned long long v )
+constexpr units::money operator""_USD( const unsigned long long v )
 {
     return units::from_usd( v );
 }
 
-constexpr units::quantity<double, units::money_in_cent_tag> operator"" _USD(
+constexpr units::quantity<double, units::money_in_cent_tag> operator""_USD(
     const long double v )
 {
     return units::from_usd( v );
 }
 
-constexpr units::money operator"" _kUSD( const unsigned long long v )
+constexpr units::money operator""_kUSD( const unsigned long long v )
 {
     return units::from_kusd( v );
 }
 
-constexpr units::quantity<double, units::money_in_cent_tag> operator"" _kUSD(
+constexpr units::quantity<double, units::money_in_cent_tag> operator""_kUSD(
     const long double v )
 {
     return units::from_kusd( v );

--- a/src/units_probability.h
+++ b/src/units_probability.h
@@ -46,17 +46,17 @@ constexpr value_type to_one_in_million( const
 
 } // namespace units
 
-constexpr units::probability operator"" _pm( const unsigned long long v )
+constexpr units::probability operator""_pm( const unsigned long long v )
 {
     return units::from_one_in_million<int>( v );
 }
 
-constexpr units::probability operator"" _pct( const unsigned long long v )
+constexpr units::probability operator""_pct( const unsigned long long v )
 {
     return units::from_one_in_million<int>( v * 10000 );
 }
 
-constexpr units::probability operator"" _pct( const long double v )
+constexpr units::probability operator""_pct( const long double v )
 {
     return units::from_one_in_million<int>( v * 10000 );
 }

--- a/src/units_temperature.h
+++ b/src/units_temperature.h
@@ -134,24 +134,24 @@ constexpr value_type to_kelvins( const
 
 } // namespace units
 
-constexpr units::temperature operator"" _mc( const unsigned long long v )
+constexpr units::temperature operator""_mc( const unsigned long long v )
 {
     // Cast to int because fahrenheit conversion needs it
     // Rest gets it for consistency
     return units::from_millidegree_celsius<int>( v );
 }
 
-constexpr units::temperature operator"" _c( const unsigned long long v )
+constexpr units::temperature operator""_c( const unsigned long long v )
 {
     return units::from_celsius<int>( v );
 }
 
-constexpr units::temperature operator"" _c( const long double v )
+constexpr units::temperature operator""_c( const long double v )
 {
     return units::from_celsius<double>( static_cast<double>( v ) );
 }
 
-constexpr units::temperature operator"" _f( const unsigned long long v )
+constexpr units::temperature operator""_f( const unsigned long long v )
 {
     return units::from_fahrenheit<int>( v );
 }

--- a/src/units_volume.h
+++ b/src/units_volume.h
@@ -50,24 +50,24 @@ static constexpr volume legacy_volume_factor = from_milliliter( 250 );
 } // namespace units
 
 // Implicitly converted to volume, which has int as value_type!
-constexpr units::volume operator"" _ml( const unsigned long long v )
+constexpr units::volume operator""_ml( const unsigned long long v )
 {
     return units::from_milliliter( v );
 }
 
-constexpr units::quantity<double, units::volume_in_milliliter_tag> operator"" _ml(
+constexpr units::quantity<double, units::volume_in_milliliter_tag> operator""_ml(
     const long double v )
 {
     return units::from_milliliter( v );
 }
 
 // Implicitly converted to volume, which has int as value_type!
-constexpr units::volume operator"" _liter( const unsigned long long v )
+constexpr units::volume operator""_liter( const unsigned long long v )
 {
     return units::from_milliliter( v * 1000 );
 }
 
-constexpr units::quantity<double, units::volume_in_milliliter_tag> operator"" _liter(
+constexpr units::quantity<double, units::volume_in_milliliter_tag> operator""_liter(
     const long double v )
 {
     return units::from_milliliter( v * 1000 );


### PR DESCRIPTION
## Purpose of change (The Why)

https://github.com/fmtlib/fmt/issues/3607

clang 20 complains about spaces between `operator""` and `_<name>`

## Checklist



### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


