### PR TITLE
fix: iuse build warnings

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5857,8 +5857,7 @@ static bool einkpc_download_memory_card( player &p, item &eink, item &mc )
                     const int old_quality = atoi( chq );
 
                     if( quality > old_quality ) {
-                        chq = string_format( "%d", quality ).data();
-                        photos[strqpos] = *chq;
+                        photos[strqpos] = string_format( "%d", quality )[0];
                     }
                 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

fix this warning
```
[217/327] Building CXX object src/CMakeFiles/cataclysm-bn-tiles-common.dir/iuse.cpp.o
/run/media/home/scarf/repo/cata/Cataclysm/src/iuse.cpp:5860:31: warning: object backing the pointer chq will be destroyed at the end of the full-expression [-Wdangling-assignment-gsl]
 5860 |                         chq = string_format( "%d", quality ).data();
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

## Describe the solution (The How)

use indexing


## Checklist



### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


