### PR TITLE
fix: make furnitures able to accept items as charges

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5194,7 +5194,12 @@ std::vector<detached_ptr<item>> map::use_charges( const tripoint &origin, const 
 
     // populate a grid of spots that can be reached
     std::vector<tripoint> reachable_pts;
-    reachable_flood_steps( reachable_pts, origin, range, 1, 100 );
+
+    if( range <= 0 ) {
+        reachable_pts.push_back( origin );
+    } else {
+        reachable_flood_steps( reachable_pts, origin, range, 1, 100 );
+    }
 
     // We prefer infinite map sources where available, so search for those
     // first


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
closes #6453 
When doing that, bug occurs always like [this issue](https://github.com/cataclysmbnteam/Cataclysm-BN/issues/6453).
The problem is that `map::reachable_flood_steps()` doesn't run properly at `range = 0`, so the game on the situation says "Hey, the ammo on there are consumed too much!"
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
I finally found what the problem is, but can't fix fundamental problem by lack of understanding codes. At least make the exception.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Quitting things about `use_furn_fake_item`

## Testing
For testing, the mod with 2 things is needed.
1: Fake tool for furniture, running with ammo:
```json
[
  {
    "type": "TOOL",
    "id": "furn_fake_tool_test",
    "name": { "str": "Furn Testing" },
    "copy-from": "fake_item",
    "use_action": "MEDITATE",
    "charges_per_use": 3,
    "ammo": [ "tinder" ]
  }
]
```
`MEDITATE` is good iuse_action for testing.

2: Furniture with `use_furn_fake_item`
```json
[
  {
    "type": "furniture",
    "id": "mod_TEST_FURN",
    "name": "Test_bench",
    "symbol": "C",
    "color": "red",
    "copy-from": "f_control_station",
    "crafting_pseudo_item": "furn_fake_tool_test",
    "examine_action": "use_furn_fake_item"
  }
]
```

Then run the game with mod.
You can see it works well.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
