### PR TITLE
feat: Allow for enabling specific spells to be cast by Brawlers

### DIFF
--- a/data/json/debug_spells.json
+++ b/data/json/debug_spells.json
@@ -248,5 +248,23 @@
     "energy_source": "MANA",
     "min_duration": 400,
     "max_duration": 400
+  },
+  {
+    "id": "debug_brawler_spell",
+    "type": "SPELL",
+    "name": "Debug Brawler-appropriate spell",
+    "description": "Brawlers are allowed to spawn a sword.",
+    "message": "Not cowardly!",
+    "valid_targets": [ "self" ],
+    "flags": [ "BRAWL" ],
+    "effect": "spawn_item",
+    "effect_str": "jian",
+    "min_range": 1,
+    "max_range": 1,
+    "base_casting_time": 100,
+    "base_energy_cost": 100,
+    "energy_source": "MANA",
+    "min_duration": 400,
+    "max_duration": 400
   }
 ]

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1447,16 +1447,25 @@ static void cast_spell()
     }
 
     bool can_cast_spells = false;
+    bool has_brawler_spell = false;
     for( spell_id sp : spells ) {
         spell temp_spell = u.magic->get_spell( sp );
         if( temp_spell.can_cast( u ) ) {
             can_cast_spells = true;
+        }
+        if (temp_spell.has_flag(spell_flag::BRAWL)) {
+            has_brawler_spell = true;
         }
     }
 
     if( !can_cast_spells ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "You can't cast any of the spells you know!" ) );
+        return;
+    }
+    if (!has_brawler_spell && u.has_trait(trait_BRAWLER)) {
+        add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
+            _( "You don't know any spells you can cast as a Brawler!" ) );
         return;
     }
 
@@ -1467,7 +1476,7 @@ static void cast_spell()
 
     spell &sp = *u.magic->get_spells()[spell_index];
 
-    if( !sp.type->brawler_usable && u.has_trait( trait_BRAWLER ) ) {
+    if( !sp.has_flag(spell_flag::BRAWL) && u.has_trait( trait_BRAWLER ) ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "Pfft, that spell is for COWARDS, and a Brawler like you is no coward!" ) );
         return;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1454,12 +1454,6 @@ static void cast_spell()
         }
     }
 
-    if( u.has_trait( trait_BRAWLER ) ) {
-        add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
-                 _( "Pfft, magic is for COWARDS." ) );
-        return;
-    }
-
     if( !can_cast_spells ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "You can't cast any of the spells you know!" ) );
@@ -1472,6 +1466,12 @@ static void cast_spell()
     }
 
     spell &sp = *u.magic->get_spells()[spell_index];
+
+    if( !sp.type->brawler_usable && u.has_trait( trait_BRAWLER ) ) {
+        add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
+                 _( "Pfft, that spell is for COWARDS, and a Brawler like you is no coward!" ) );
+        return;
+    }
 
     std::set<trait_id> blockers = sp.get_blocker_muts();
     if( !blockers.empty() ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1453,7 +1453,7 @@ static void cast_spell()
         if( temp_spell.can_cast( u ) ) {
             can_cast_spells = true;
         }
-        if (temp_spell.has_flag(spell_flag::BRAWL)) {
+        if( temp_spell.has_flag( spell_flag::BRAWL ) ) {
             has_brawler_spell = true;
         }
     }
@@ -1463,9 +1463,9 @@ static void cast_spell()
                  _( "You can't cast any of the spells you know!" ) );
         return;
     }
-    if (!has_brawler_spell && u.has_trait(trait_BRAWLER)) {
+    if( !has_brawler_spell && u.has_trait( trait_BRAWLER ) ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
-            _( "You don't know any spells you can cast as a Brawler!" ) );
+                 _( "You don't know any spells you can cast as a Brawler!" ) );
         return;
     }
 
@@ -1476,7 +1476,7 @@ static void cast_spell()
 
     spell &sp = *u.magic->get_spells()[spell_index];
 
-    if( !sp.has_flag(spell_flag::BRAWL) && u.has_trait( trait_BRAWLER ) ) {
+    if( !sp.has_flag( spell_flag::BRAWL ) && u.has_trait( trait_BRAWLER ) ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "Pfft, that spell is for COWARDS, and a Brawler like you is no coward!" ) );
         return;

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -328,6 +328,8 @@ void spell_type::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "arm_encumbrance_threshold", arm_encumbrance_threshold, 20 );
     optional( jo, was_loaded, "leg_encumbrance_threshold", leg_encumbrance_threshold, 20 );
 
+    optional(jo, was_loaded, "brawler_usable", brawler_usable, false);
+
     std::string temp_string;
     optional( jo, was_loaded, "spell_class", temp_string, "NONE" );
     spell_class = trait_id( temp_string );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -102,6 +102,7 @@ std::string enum_to_string<spell_flag>( spell_flag data )
         case spell_flag::PAIN_NORESIST: return "PAIN_NORESIST";
         case spell_flag::NO_FAIL: return "NO_FAIL";
         case spell_flag::WONDER: return "WONDER";
+        case spell_flag::BRAWL: return "BRAWL";
         case spell_flag::LAST: break;
     }
     debugmsg( "Invalid spell_flag" );
@@ -327,8 +328,6 @@ void spell_type::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "energy_increment", energy_increment, 0.0f );
     optional( jo, was_loaded, "arm_encumbrance_threshold", arm_encumbrance_threshold, 20 );
     optional( jo, was_loaded, "leg_encumbrance_threshold", leg_encumbrance_threshold, 20 );
-
-    optional(jo, was_loaded, "brawler_usable", brawler_usable, false);
 
     std::string temp_string;
     optional( jo, was_loaded, "spell_class", temp_string, "NONE" );
@@ -1704,6 +1703,9 @@ static std::string enumerate_spell_data( const spell &sp )
     }
     if( sp.effect() == "target_attack" && sp.range() > 1 ) {
         spell_data.emplace_back( _( "can be cast through walls" ) );
+    }
+    if (sp.has_flag(spell_flag::BRAWL)) {
+        spell_data.emplace_back(_("can be used by Brawlers"));
     }
     return enumerate_as_string( spell_data );
 }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1704,8 +1704,8 @@ static std::string enumerate_spell_data( const spell &sp )
     if( sp.effect() == "target_attack" && sp.range() > 1 ) {
         spell_data.emplace_back( _( "can be cast through walls" ) );
     }
-    if (sp.has_flag(spell_flag::BRAWL)) {
-        spell_data.emplace_back(_("can be used by Brawlers"));
+    if( sp.has_flag( spell_flag::BRAWL ) ) {
+        spell_data.emplace_back( _( "can be used by Brawlers" ) );
     }
     return enumerate_as_string( spell_data );
 }

--- a/src/magic.h
+++ b/src/magic.h
@@ -257,6 +257,9 @@ class spell_type
         // legs. anything over this value will affect the spell.
         int leg_encumbrance_threshold = 20;
 
+        // Can a character with the Brawler trait cast the spell
+        bool brawler_usable;
+
         // spell is restricted to being cast by only this class
         // if spell_class is empty, spell is unrestricted
         trait_id spell_class;

--- a/src/magic.h
+++ b/src/magic.h
@@ -57,6 +57,7 @@ enum spell_flag {
     WONDER, // instead of casting each of the extra_spells, it picks N of them and casts them (where N is std::min( damage(), number_of_spells ))
     PAIN_NORESIST, // pain altering spells can't be resisted (like with the deadened trait)
     NO_FAIL, // this spell cannot fail when you cast it
+    BRAWL, // this spell can be used by brawlers
     LAST
 };
 
@@ -256,9 +257,6 @@ class spell_type
         // base encumerance value for the spell to be hindered by the caster's
         // legs. anything over this value will affect the spell.
         int leg_encumbrance_threshold = 20;
-
-        // Can a character with the Brawler trait cast the spell
-        bool brawler_usable;
 
         // spell is restricted to being cast by only this class
         // if spell_class is empty, spell is unrestricted


### PR DESCRIPTION
## Purpose of change (The Why)

As raised by Kheir and a few other members of the community, wholesale banning Brawlers from casting spells is perhaps a bit overkill.

While my initial stance was that those who opposed it and wanted to let spells through should code in the exceptions, I realized that this was a far better solution and one that I'd end up likely needing in some capacity in the future.

I'm somewhat surprised I didn't think of this initially.

## Describe the solution (The How)

- Adds a new spell flag, `"BRAWL"`
- Changes the check that prevents Brawlers from casting spells to instead also check for the spell flag, and let it through if it's detected
- Keeps a wholesale "You can't cast any of your spells because you're a brawler!" style of message around for the sake of it.
- Adds a debug spell for testing reasons

## Describe alternatives you've considered

- Do it via an actual entry in the spells

That's how I did it originally, but I realized it was a bit silly when we have spell flags right there for simple booleans

- Add it to the can_cast_spells check instead of a new one for the "Can't cast any spells" style message

Just didn't feel right, and I felt that it should print out a unique message to make the cause clear.

## Testing

- Compiled
- Loaded in
- Tested while none of my known spells were able to be cast by brawlers, confirmed that it displayed the correct message
- Tested casting a non-brawler appropriate spell when I had a brawler appropriate spell, similarly displays correct message
- Tested the brawler-acceptable spell, it works just fine

## Additional context

I'm not adding it to spells in MN myself yet, though either I'll PR it later or someone else interested can.

Not added to docs yet because Scarf still hasn't finished migrating them and I don't want to make merge conflicts for him.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
