### PR TITLE
feat(UI): clearer `"info"` field for some json flags

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -269,7 +269,8 @@
   {
     "id": "EXOSUIT",
     "type": "json_flag",
-    "context": [ "ARMOR", "TOOL_ARMOR" ]
+    "context": [ "ARMOR", "TOOL_ARMOR" ],
+    "info": "This clothing is an <info>exo-suit</info>. If <info>powered on</info>, it will provide an <good>increase in strength, speed, and weight capacity</good>."
   },
   {
     "id": "FANCY",
@@ -318,7 +319,8 @@
     "id": "FLASH_PROTECTION",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "//": "Used for eyes protection from flashbang."
+    "//": "Used for eyes protection from flashbang.",
+    "info": "This clothing will <good>partially protect from a flash from a flashbang</good>."
   },
   {
     "id": "FLOTATION",
@@ -392,13 +394,13 @@
     "id": "HYGROMETER",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This gear is equipped with an accurate hygrometer (which is used to measure humidity)."
+    "info": "This gear is equipped with an accurate hygrometer (which is used to <info>measure humidity</info>)."
   },
   {
     "id": "BRASS_CATCHER",
     "type": "json_flag",
     "context": [ "GUNMOD" ],
-    "info": "This gun mod catches ejected casings."
+    "info": "This gun mod <info>catches ejected casings</info>."
   },
   {
     "id": "IRREMOVABLE",
@@ -506,7 +508,7 @@
     "id": "POLEARM",
     "type": "json_flag",
     "context": [ "GENERIC", "TOOL" ],
-    "info": "As a weapon, this item needs considerable space to use properly and does 70% of its normal damage to adjacent enemies."
+    "info": "As a weapon, this item <info>needs considerable space to use</info> properly and <bad>does 70% of its normal damage to adjacent enemies</bad>."
   },
   {
     "id": "SPAWN_FRIENDLY",
@@ -1632,7 +1634,7 @@
     "id": "MOUNTED_GUN",
     "type": "json_flag",
     "context": [  ],
-    "info": "This weapon <bad>can only be fired if mounted</bad> on a vehicle or furniture (window, table, mound of dirt, etc.) to fire, <info>Large or Huge</info> mutants or those with active <info>Power Armor</info> can fire from the hip with <bad>reduced accuracy.</bad>"
+    "info": "This weapon <bad>can only be fired if mounted</bad> on a vehicle or furniture (window, table, mound of dirt, etc.) to fire, <info>Large or Huge</info> mutants or those with active <info>Power Armor</info> can fire from the hip with <bad>reduced accuracy</bad>."
   },
   {
     "id": "MYCUS_OK",
@@ -1951,7 +1953,8 @@
   {
     "id": "STR_RELOAD",
     "type": "json_flag",
-    "context": [  ]
+    "context": [  ],
+    "info": "This weapon's <info>reload speed</info> is <info>increased by strength</info>"
   },
   {
     "id": "TACK",
@@ -2012,7 +2015,8 @@
   {
     "id": "UNDERWATER_GUN",
     "type": "json_flag",
-    "context": [  ]
+    "context": [  ],
+    "info": "This weapon is inherently <good>designed to work underwater</good>."
   },
   {
     "id": "UNRECOVERABLE",
@@ -2135,7 +2139,7 @@
     "id": "HEAVY_WEAPON_SUPPORT",
     "type": "json_flag",
     "context": [  ],
-    "info": "This equipment <good>allows you to fire</good> unwieldy weapons without requiring support from mountable terrain, as a <info>Large or Huge</info> mutant could, at the expense of <bad>reduced accuracy.</bad>"
+    "info": "This equipment <good>allows you to fire</good> unwieldy weapons without requiring support from mountable terrain, as a <info>Large or Huge</info> mutant could, at the expense of <bad>reduced accuracy</bad>."
   },
   {
     "id": "FIRE_TWOHAND",
@@ -2190,7 +2194,8 @@
   {
     "id": "WATERPROOF_GUN",
     "type": "json_flag",
-    "context": [  ]
+    "context": [  ],
+    "info": "This weapon <good>can shoot underwater</good>, but <info>unless it was specifically designed to do so</info>, it <bad>will suffer from accuracy penalty</bad>."
   },
   {
     "id": "no_auto_equip",
@@ -2241,12 +2246,13 @@
     "id": "WEATHER_FORECAST",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "It can show the automated weather forcast."
+    "info": "This item can show the <info>automated weather forcast</info>."
   },
   {
     "id": "WINDMETER",
     "type": "json_flag",
-    "context": [  ]
+    "context": [  ],
+    "info": "This item can show the <info>current heading and speed of the wind</info> as well as <info>perceived temperature</info>."
   },
   {
     "id": "HIDDEN",

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1954,7 +1954,7 @@
     "id": "STR_RELOAD",
     "type": "json_flag",
     "context": [  ],
-    "info": "This weapon's <info>reload speed</info> is <info>increased by strength</info>"
+    "info": "This weapon's <info>reload speed</info> is <good>increased by strength</good>."
   },
   {
     "id": "TACK",
@@ -2246,7 +2246,7 @@
     "id": "WEATHER_FORECAST",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This item can show the <info>automated weather forcast</info>."
+    "info": "This item can show the <info>automated weather forecast</info>."
   },
   {
     "id": "WINDMETER",

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -269,8 +269,7 @@
   {
     "id": "EXOSUIT",
     "type": "json_flag",
-    "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This clothing is an <info>exo-suit</info>. If <info>powered on</info>, it will provide an <good>increase in strength, speed, and weight capacity</good>."
+    "context": [ "ARMOR", "TOOL_ARMOR" ]
   },
   {
     "id": "FANCY",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2221,7 +2221,7 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
     }
     if( ammo.ammo_effects.contains( ammo_effect_RECYCLED ) &&
         parts->test( iteminfo_parts::AMMO_FX_RECYCLED ) ) {
-        fx.emplace_back( _( "This ammo has been <bad>hand-loaded</bad>." ) );
+        fx.emplace_back( _( "This ammo has been <bad>hand-loaded</bad> and has a <bad>small chance to misfire</bad>." ) );
     }
     if( ammo.ammo_effects.contains( ammo_effect_BLACKPOWDER ) &&
         parts->test( iteminfo_parts::AMMO_FX_BLACKPOWDER ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2222,7 +2222,7 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
     if( ammo.ammo_effects.contains( ammo_effect_RECYCLED ) &&
         parts->test( iteminfo_parts::AMMO_FX_RECYCLED ) ) {
         fx.emplace_back(
-            _( "This ammo has been <bad>hand-loaded</bad> and has a <bad>small chance to misfire</bad>." ) );
+            _( "This ammo has been <info>hand-loaded</info> and has a <bad>small chance to misfire</bad>." ) );
     }
     if( ammo.ammo_effects.contains( ammo_effect_BLACKPOWDER ) &&
         parts->test( iteminfo_parts::AMMO_FX_BLACKPOWDER ) ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5857,8 +5857,7 @@ static bool einkpc_download_memory_card( player &p, item &eink, item &mc )
                     const int old_quality = atoi( chq );
 
                     if( quality > old_quality ) {
-                        chq = string_format( "%d", quality ).data();
-                        photos[strqpos] = *chq;
+                        photos[strqpos] = string_format( "%d", quality )[0];
                     }
                 }
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
To add, expand or better explain some of the json flags. Hand-loaded ammo flag just states that the ammo is hand-loaded, which gives an average user zero useful information (hand-loaded ammo has 1/256 chance to misfire independent of gun condition), exosuits increase speed/strength/carry capacity and some flags just could use better highlights. 
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Edited a lot of "info" for flags
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
1. Loaded new world
2. Started checking new flag descriptions I added
<details>
  <summary>Screenshots</summary>
 
 
![изображение](https://github.com/user-attachments/assets/d1e23053-4729-461f-b429-ed3b7e9bd66c)
![изображение](https://github.com/user-attachments/assets/f78e3c8f-9888-4f65-a1a0-b85fdb0aeb1e)
![изображение](https://github.com/user-attachments/assets/5c3e98a2-1443-47da-be56-4c74cd259e07)
![изображение](https://github.com/user-attachments/assets/ef32ca00-9ab8-4f0b-82bc-cdd67f6c8c03)
![изображение](https://github.com/user-attachments/assets/5777bf04-62e6-4dfe-b917-d7df77f504af)
![изображение](https://github.com/user-attachments/assets/16f760a0-0cf4-4e23-b076-e87fc28d2295)
![изображение](https://github.com/user-attachments/assets/dcbebb1e-7884-4777-85de-d3396603d1b7)

  
</details>
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Purposefully leaving something like DIMENSIONAL_ANCHOR out.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.