### PR TITLE
feat: flagify `BRASS_CATCHER`

### DIFF
--- a/data/json/items/gunmod/brass_catcher.json
+++ b/data/json/items/gunmod/brass_catcher.json
@@ -13,6 +13,7 @@
     "symbol": ":",
     "color": "light_gray",
     "location": "brass catcher",
+    "flags": [ "BRASS_CATCHER" ],
     "mod_target_category": [
       [ "PISTOLS" ],
       [ "SUBMACHINE_GUNS" ],

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -37,7 +37,6 @@ static const trait_id trait_WEB_WEAVER( "WEB_WEAVER" );
 
 static const bionic_id bio_soporific( "bio_soporific" );
 
-static const itype_id itype_brass_catcher( "brass_catcher" );
 static const itype_id itype_large_repairkit( "large_repairkit" );
 static const itype_id itype_plut_cell( "plut_cell" );
 static const itype_id itype_small_repairkit( "small_repairkit" );
@@ -477,7 +476,7 @@ bool gunmod_remove( avatar &you, item &gun, item &mod )
     gun.gun_set_mode( gun_mode_id( "DEFAULT" ) );
     //TODO: add activity for removing gunmods
 
-    if( mod.typeId() == itype_brass_catcher ) {
+    if( mod.has_flag( flag_BRASS_CATCHER ) ) {
         gun.casings_handle( [&]( detached_ptr<item> &&e ) {
             you.i_add_or_drop( std::move( e ) );
             return detached_ptr<item>();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -139,7 +139,6 @@ static const fault_id fault_bionic_nonsterile( "fault_bionic_nonsterile" );
 static const gun_mode_id gun_mode_REACH( "REACH" );
 
 static const itype_id itype_barrel_small( "barrel_small" );
-static const itype_id itype_brass_catcher( "brass_catcher" );
 static const itype_id itype_cig_butt( "cig_butt" );
 static const itype_id itype_cig_lit( "cig_lit" );
 static const itype_id itype_cigar_butt( "cigar_butt" );
@@ -8330,7 +8329,7 @@ ret_val<bool> item::is_gunmod_compatible( const item &mod ) const
     } else if( mod.typeId() == itype_tuned_mechanism && has_flag( flag_NEVER_JAMS ) ) {
         return ret_val<bool>::make_failure( _( "is already eminently reliable" ) );
 
-    } else if( mod.typeId() == itype_brass_catcher && has_flag( flag_RELOAD_EJECT ) ) {
+    } else if( mod.has_flag( flag_BRASS_CATCHER ) && has_flag( flag_RELOAD_EJECT ) ) {
         return ret_val<bool>::make_failure( _( "cannot have a brass catcher" ) );
 
     } else if( ( !mod.type->mod->ammo_modifier.empty() || !mod.type->mod->magazine_adaptor.empty() )


### PR DESCRIPTION
## Purpose of change (The Why)

gunmods have been only accepting hardcoded `brass_catcher`. make mods be able to create custom brass catcher items.

## Describe the solution (The How)

make use of unused flag `BRASS_CATCHER`.

## Describe alternatives you've considered

## Testing

![image](https://github.com/user-attachments/assets/78f62607-feb0-46ed-94a8-8aa4f7995c12)
![image](https://github.com/user-attachments/assets/d8643280-4f4a-42ca-94f6-3ba025881a6e)
![image](https://github.com/user-attachments/assets/8da5371f-66fd-4a38-8a6c-300e3c6e851d)

1. spawn brass catcher and rifle of your choice (mine m16a4)
2. fire some rounds, check casings are ejected
3. attach brass catcher
4. fire some more rounds
5. confirm it works as usual

## Additional context

found while reviewing https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6495

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


