### PR TITLE
test: hide flaky monster move tests

### DIFF
--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -316,7 +316,7 @@ TEST_CASE( "write_slope_to_speed_map_square", "[.][!mayfail]" )
 
 // Characterization test for monster movement speed.
 // It's not necessarally the one true speed for monsters, we just want notice if it changes.
-TEST_CASE( "monster_speed_square", "[speed][!mayfail]" )
+TEST_CASE( "monster_speed_square", "[speed][.][!mayfail]" )
 {
     clear_all_state();
     put_player_underground();
@@ -326,7 +326,7 @@ TEST_CASE( "monster_speed_square", "[speed][!mayfail]" )
 }
 
 // TODO: Figure out why this sometimes fails, seems to be RNG-dependent
-TEST_CASE( "monster_speed_trig", "[speed][!mayfail]" )
+TEST_CASE( "monster_speed_trig", "[speed][.][!mayfail]" )
 {
     clear_all_state();
     put_player_underground();


### PR DESCRIPTION
## Purpose of change (The Why)

1. monster move tests are flaky because the random terrain generation affects test output
2. it clogs up PR files view with false-positives despite marked as `[!mayfail]`

![image](https://github.com/user-attachments/assets/01675604-426a-4e2b-9e98-d5ed6943ae4a)

## Describe the solution (The How)

hide it with https://github.com/catchorg/Catch2/blob/74fcff6e5b190fb833a231b7f7c1829e3c3ac54d/docs/command-line.md#specifying-which-tests-to-run
