### PR TITLE
ci: fix vcpkg failure

### DIFF
--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -83,8 +83,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable("ACTIONS_CACHE_URL", process.env.ACTIONS_CACHE_URL || "")
+            core.exportVariable("ACTIONS_RUNTIME_TOKEN", process.env.ACTIONS_RUNTIME_TOKEN || "")
 
       - name: Install vcpkg
         uses: lukka/run-vcpkg@main

--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -41,6 +41,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
   # There's not enough disk space to build both release and debug versions of
   # our dependencies, so we hack the triplet file to build only release versions
   # Have to use github.workspace because runner namespace isn't available yet.
@@ -76,6 +77,14 @@ jobs:
 
       - name: Install stable CMake
         uses: lukka/get-cmake@v3.31.6
+
+      # https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-actions-cache#1---export-required-github-actions-environment-variables
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Install vcpkg
         uses: lukka/run-vcpkg@main


### PR DESCRIPTION
## Purpose of change (The Why)

fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/6507

## Describe the solution (The How)

see: https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-actions-cache

## Testing

merge when cataclysm windows build succeeds (seems to work)