### PR TITLE
docs: fix bad grammar and potential error in cast_spell documentation

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/items/item_creation.md
+++ b/doc/src/content/docs/en/mod/json/reference/items/item_creation.md
@@ -1088,7 +1088,7 @@ more structured function.
     ]
 },
 "use_action": { 
-    "type": "cast_spell",       // Casts a spell based on ID, using item charges, or mana if the flag USE_PLAYER_ENERGY is on the item
+    "type": "cast_spell",       // Casts a spell based on ID using item charges or, if the flag USE_PLAYER_ENERGY is on the item, the energy source defined in the spell
     "spell_id": "magus_escape", // The ID of the spell to be casted
     "no_fail": true,            // Whether you can fail the cast
     "level": 10,                // The level its cast at


### PR DESCRIPTION
## Purpose of change (The Why)

The grammar (in particular the use of commas) is bad and the claim that it's specifically mana used to cast spells is likely false.

Also, Scarf pulled a Chaosvolt and merged #6515 wayyy too hastily **while I was writing a review**. When Royal had clearly pinged me about the PR.

## Describe the solution (The How)

Apply what should have just been a suggestion on review in a new PR

## Testing

Eyes