### PR TITLE
feat: Add extend use_action to TOOL item 

### DIFF
--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -13,6 +13,7 @@
 #include "item.h"
 #include "itype.h"
 #include "iuse.h"
+#include "json.h"
 #include "type_id.h"
 
 class Item_group;
@@ -307,10 +308,14 @@ class Item_factory
 
         void set_use_methods_from_json( const JsonObject &jo, const std::string &member,
                                         std::map<std::string, use_function> &use_methods );
+        void set_use_methods_from_array( const JsonArray &array,
+                                         std::map<std::string, use_function> &use_methods );
 
         use_function usage_from_string( const std::string &type ) const;
 
         std::pair<std::string, use_function> usage_from_object( const JsonObject &obj );
+
+        std::optional<JsonArray> extend_has_member( const JsonObject &jo, const std::string &member );
 
         /**
          * Helper function for Item_group loading
@@ -378,5 +383,3 @@ class Item_factory
 
         std::set<std::string> repair_actions;
 };
-
-

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -337,7 +337,6 @@ class Item_factory
 
         void load_basic_info( const JsonObject &jo, itype &def, const std::string &src );
         void set_qualities_from_json( const JsonObject &jo, const std::string &member, itype &def );
-        void extend_qualities_from_json( const JsonObject &jo, const std::string &member, itype &def );
         void delete_qualities_from_json( const JsonObject &jo, const std::string &member, itype &def );
         void set_properties_from_json( const JsonObject &jo, const std::string &member, itype &def );
 

--- a/tests/data/item_factory.json
+++ b/tests/data/item_factory.json
@@ -1,0 +1,48 @@
+{
+  "base_member_is_string":{
+    "id": "base_tool",
+    "type": "TOOL",
+    "category": "test_category",
+    "name": { "str": "base_tool" },
+    "use_action":"CAMERA"
+  },
+  "base_member_is_array":{
+    "id": "base_tool",
+    "type": "TOOL",
+    "category": "test_category",
+    "name": { "str": "base_tool" },
+    "use_action": [
+      "CAMERA"
+    ]
+  },
+  "base_member_missing":{
+    "id": "base_tool",
+    "type": "TOOL",
+    "category": "test_category",
+    "name": { "str": "base_tool" }
+  },
+  "test_member_extends":{
+    "id": "test_tool",
+    "type": "TOOL",
+    "category": "test_category",
+    "name": { "str": "test_tool" },
+    "copy-from": "base_tool",
+    "extend": { "use_action": ["MP3"] }
+  },
+  "test_member_sets":{
+    "id": "test_tool",
+    "type": "TOOL",
+    "category": "test_category",
+    "name": { "str": "test_tool" },
+    "copy-from": "base_tool",
+    "use_action":"MP3"
+  },
+  "test_member_deletes":{
+    "id": "test_tool",
+    "type": "TOOL",
+    "category": "test_category",
+    "name": { "str": "test_tool" },
+    "copy-from": "base_tool",
+    "delete": { "use_action": ["CAMERA"] }
+  }
+}

--- a/tests/data/item_factory.json
+++ b/tests/data/item_factory.json
@@ -36,13 +36,5 @@
     "name": { "str": "test_tool" },
     "copy-from": "base_tool",
     "use_action":"MP3"
-  },
-  "test_member_deletes":{
-    "id": "test_tool",
-    "type": "TOOL",
-    "category": "test_category",
-    "name": { "str": "test_tool" },
-    "copy-from": "base_tool",
-    "delete": { "use_action": ["CAMERA"] }
   }
 }

--- a/tests/item_factory_test.cpp
+++ b/tests/item_factory_test.cpp
@@ -23,8 +23,6 @@ TEST_CASE( "load_tool_use_action", "[item_factory]" )
     test_extends.allow_omitted_members();
     JsonObject test_sets = all_test_items.get_object( TEST_MEMBER_SETS );
     test_sets.allow_omitted_members();
-    JsonObject test_deletes = all_test_items.get_object( TEST_MEMBER_DELETES );
-    test_deletes.allow_omitted_members();
 
     SECTION( BASE_MEMBER_IS_STRING ) {
         JsonObject test_base_item = all_test_items.get_object( BASE_MEMBER_IS_STRING );
@@ -50,12 +48,7 @@ TEST_CASE( "load_tool_use_action", "[item_factory]" )
             REQUIRE( test_item->can_use( TEST_IUSE_ID ) );
         }
 
-        SECTION( TEST_MEMBER_DELETES ) {
-            test_factory.load_tool( test_deletes, TEST_ITEM_SOURCE );
-            const itype *test_item = get_item( test_factory, TEST_ITEM_NAME );
-
-            REQUIRE( !test_item->has_use() );
-        }
+        // TODO: Implement delete if needed?
     }
 
     SECTION( BASE_MEMBER_IS_ARRAY ) {
@@ -82,12 +75,7 @@ TEST_CASE( "load_tool_use_action", "[item_factory]" )
             REQUIRE( test_item->can_use( TEST_IUSE_ID ) );
         }
 
-        SECTION( TEST_MEMBER_DELETES ) {
-            test_factory.load_tool( test_deletes, TEST_ITEM_SOURCE );
-            const itype *test_item = get_item( test_factory, TEST_ITEM_NAME );
-
-            REQUIRE( !test_item->has_use() );
-        }
+        // TODO: Implement delete if needed?
     }
 
     SECTION( BASE_MEMBER_MISSING ) {

--- a/tests/item_factory_test.cpp
+++ b/tests/item_factory_test.cpp
@@ -16,7 +16,6 @@ TEST_CASE( "load_tool_use_action", "[item_factory]" )
     std::ifstream file( TEST_ITEM_JSON_FILENAME );
     JsonIn jsin( file );
     JsonObject all_test_items( jsin.get_object() );
-    std::map<std::string, use_function> test_use_methods = { { TEST_IUSE_ID, TEST_IUSE_FUNCTION } };
     Item_factory test_factory;
 
     JsonObject test_extends = all_test_items.get_object( TEST_MEMBER_EXTENDS );

--- a/tests/item_factory_test.cpp
+++ b/tests/item_factory_test.cpp
@@ -1,0 +1,131 @@
+#include "catch/catch.hpp"
+
+#include "item_factory_test.h"
+
+#include <fstream>
+#include <memory>
+
+#include "item_factory.h"
+#include "json.h"
+
+namespace item_factory_test
+{
+
+TEST_CASE( "load_tool_use_action", "[item_factory]" )
+{
+    std::ifstream file( TEST_ITEM_JSON_FILENAME );
+    JsonIn jsin( file );
+    JsonObject all_test_items( jsin.get_object() );
+    std::map<std::string, use_function> test_use_methods = { { TEST_IUSE_ID, TEST_IUSE_FUNCTION } };
+    Item_factory test_factory;
+
+    JsonObject test_extends = all_test_items.get_object( TEST_MEMBER_EXTENDS );
+    test_extends.allow_omitted_members();
+    JsonObject test_sets = all_test_items.get_object( TEST_MEMBER_SETS );
+    test_sets.allow_omitted_members();
+    JsonObject test_deletes = all_test_items.get_object( TEST_MEMBER_DELETES );
+    test_deletes.allow_omitted_members();
+
+    SECTION( BASE_MEMBER_IS_STRING ) {
+        JsonObject test_base_item = all_test_items.get_object( BASE_MEMBER_IS_STRING );
+        test_base_item.allow_omitted_members();
+
+        test_factory.load_tool( test_base_item, TEST_ITEM_SOURCE );
+        const itype *test_item = get_item( test_factory, BASE_ITEM_NAME );
+        REQUIRE( test_item->can_use( BASE_IUSE_ID ) );
+
+        SECTION( TEST_MEMBER_EXTENDS ) {
+            test_factory.load_tool( test_extends, TEST_ITEM_SOURCE );
+            const itype *test_item = get_item( test_factory, TEST_ITEM_NAME );
+
+            REQUIRE( test_item->can_use( BASE_IUSE_ID ) );
+            REQUIRE( test_item->can_use( TEST_IUSE_ID ) );
+        }
+
+        SECTION( TEST_MEMBER_SETS ) {
+            test_factory.load_tool( test_sets, TEST_ITEM_SOURCE );
+            const itype *test_item = get_item( test_factory, TEST_ITEM_NAME );
+
+            REQUIRE( !test_item->can_use( BASE_IUSE_ID ) );
+            REQUIRE( test_item->can_use( TEST_IUSE_ID ) );
+        }
+
+        SECTION( TEST_MEMBER_DELETES ) {
+            test_factory.load_tool( test_deletes, TEST_ITEM_SOURCE );
+            const itype *test_item = get_item( test_factory, TEST_ITEM_NAME );
+
+            REQUIRE( !test_item->has_use() );
+        }
+    }
+
+    SECTION( BASE_MEMBER_IS_ARRAY ) {
+        JsonObject test_base_item = all_test_items.get_object( BASE_MEMBER_IS_ARRAY );
+        test_base_item.allow_omitted_members();
+
+        test_factory.load_tool( test_base_item, TEST_ITEM_SOURCE );
+        const itype *test_item = get_item( test_factory, BASE_ITEM_NAME );
+        REQUIRE( test_item->can_use( BASE_IUSE_ID ) );
+
+        SECTION( TEST_MEMBER_EXTENDS ) {
+            test_factory.load_tool( test_extends, TEST_ITEM_SOURCE );
+            const itype *test_item = get_item( test_factory, TEST_ITEM_NAME );
+
+            REQUIRE( test_item->can_use( BASE_IUSE_ID ) );
+            REQUIRE( test_item->can_use( TEST_IUSE_ID ) );
+        }
+
+        SECTION( TEST_MEMBER_SETS ) {
+            test_factory.load_tool( test_sets, TEST_ITEM_SOURCE );
+            const itype *test_item = get_item( test_factory, TEST_ITEM_NAME );
+
+            REQUIRE( !test_item->can_use( BASE_IUSE_ID ) );
+            REQUIRE( test_item->can_use( TEST_IUSE_ID ) );
+        }
+
+        SECTION( TEST_MEMBER_DELETES ) {
+            test_factory.load_tool( test_deletes, TEST_ITEM_SOURCE );
+            const itype *test_item = get_item( test_factory, TEST_ITEM_NAME );
+
+            REQUIRE( !test_item->has_use() );
+        }
+    }
+
+    SECTION( BASE_MEMBER_MISSING ) {
+        JsonObject test_base_item = all_test_items.get_object( BASE_MEMBER_MISSING );
+        test_base_item.allow_omitted_members();
+
+        test_factory.load_tool( test_base_item, TEST_ITEM_SOURCE );
+        const itype *test_item = get_item( test_factory, BASE_ITEM_NAME );
+        REQUIRE( test_item->has_use( ) == false );
+
+        SECTION( TEST_MEMBER_EXTENDS ) {
+            test_factory.load_tool( test_extends, TEST_ITEM_SOURCE );
+            const itype *test_item = get_item( test_factory, TEST_ITEM_NAME );
+
+            REQUIRE( test_item->can_use( TEST_IUSE_ID ) );
+        }
+
+        SECTION( TEST_MEMBER_SETS ) {
+            test_factory.load_tool( test_sets, TEST_ITEM_SOURCE );
+            const itype *test_item = get_item( test_factory, TEST_ITEM_NAME );
+
+            REQUIRE( test_item->can_use( TEST_IUSE_ID ) );
+        }
+    }
+
+
+    all_test_items.allow_omitted_members();
+    file.close();
+}
+
+const itype *get_item( Item_factory &test_factory, std::string name )
+{
+    std::vector <const itype *> test_items = test_factory.find( [name]( const itype & item ) {
+        return item.nname( 1 ) == name;
+    } );
+
+    REQUIRE( test_items.size() == 1 );
+    return test_items[0];
+}
+
+}

--- a/tests/item_factory_test.h
+++ b/tests/item_factory_test.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "item_factory.h"
+#include "iuse.h"
+#include "json.h"
+
+namespace item_factory_test
+{
+const std::string TEST_ITEM_JSON_FILENAME = "tests/data/item_factory.json";
+
+const std::string BASE_MEMBER_IS_STRING = "base_member_is_string";
+const std::string BASE_MEMBER_IS_ARRAY = "base_member_is_array";
+const std::string BASE_MEMBER_MISSING = "base_member_missing";
+
+const std::string TEST_MEMBER_SETS = "test_member_sets";
+const std::string TEST_MEMBER_EXTENDS = "test_member_extends";
+const std::string TEST_MEMBER_DELETES = "test_member_deletes";
+
+const std::string BASE_ITEM_NAME = "base_tool";
+const std::string TEST_ITEM_NAME = "test_tool";
+const std::string TEST_ITEM_SOURCE = "testing";
+const std::string USE_ACTION = "use_action";
+
+const std::string BASE_IUSE_ID = "CAMERA";
+const use_function BASE_IUSE_FUNCTION = use_function( BASE_IUSE_ID, &iuse::camera );
+const size_t BASE_ARRAY_SIZE = 1;
+
+const std::string TEST_IUSE_ID = "MP3";
+const use_function TEST_IUSE_FUNCTION = use_function( TEST_IUSE_ID, &iuse::mp3 );
+
+const itype *get_item( Item_factory &test_factory, std::string name );
+}

--- a/tests/item_factory_test.h
+++ b/tests/item_factory_test.h
@@ -14,7 +14,6 @@ const std::string BASE_MEMBER_MISSING = "base_member_missing";
 
 const std::string TEST_MEMBER_SETS = "test_member_sets";
 const std::string TEST_MEMBER_EXTENDS = "test_member_extends";
-const std::string TEST_MEMBER_DELETES = "test_member_deletes";
 
 const std::string BASE_ITEM_NAME = "base_tool";
 const std::string TEST_ITEM_NAME = "test_tool";

--- a/tests/item_factory_test.h
+++ b/tests/item_factory_test.h
@@ -12,8 +12,8 @@ const std::string BASE_MEMBER_IS_STRING = "base_member_is_string";
 const std::string BASE_MEMBER_IS_ARRAY = "base_member_is_array";
 const std::string BASE_MEMBER_MISSING = "base_member_missing";
 
-const std::string TEST_MEMBER_SETS = "test_member_sets";
 const std::string TEST_MEMBER_EXTENDS = "test_member_extends";
+const std::string TEST_MEMBER_SETS = "test_member_sets";
 
 const std::string BASE_ITEM_NAME = "base_tool";
 const std::string TEST_ITEM_NAME = "test_tool";
@@ -21,11 +21,7 @@ const std::string TEST_ITEM_SOURCE = "testing";
 const std::string USE_ACTION = "use_action";
 
 const std::string BASE_IUSE_ID = "CAMERA";
-const use_function BASE_IUSE_FUNCTION = use_function( BASE_IUSE_ID, &iuse::camera );
-const size_t BASE_ARRAY_SIZE = 1;
-
 const std::string TEST_IUSE_ID = "MP3";
-const use_function TEST_IUSE_FUNCTION = use_function( TEST_IUSE_ID, &iuse::mp3 );
 
 const itype *get_item( Item_factory &test_factory, std::string name );
 }


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Inspired from trying to copy-from an e-book here
https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6520#discussion_r2083374975


<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Adds the ability to `extend` to `use_action` by modifying `set_use_action_from_json`, which is what is ultimately called from `load_tool`.

Adds tests to verify existing `TOOL` behavior is preserved.

Minor refactor to clean up some code.

There does not seem to be any doc section on JSON extend inheritance (inconsistent) behavior. BN doc lags behind DDA, which at least has a little blurb on how extend and delete are bespoke, and not guaranteed with copy-from.
Documenting that is a PR unto itself I believe, and out-of-scope. (Might be nice with a comprehensive refactor of how extend is handled, to make it more systematic and consistent than it is today)

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Considered adding delete as well but that felt annoying and less useful at this point. Tests mean we can always add later with minimal risk of regressions.

## Testing

Adds 6 tests via `SECTION` nesting. 
3 cases each of a `base_tool` item having `use_action` as a `string`, `array`, or missing it altogether.
For each case, an additional 2 test cases: one using `set`, a hard-overwrite, and one using `extend`, which is purely additive.

Original code passes the 3 `set` tests, fails the 3 `extend` tests.
New code passes all tests.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.



### Optional

- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.



