### PR TITLE
feat: allow choosing color of uilist entry in Lua

### DIFF
--- a/doc/src/content/docs/en/mod/lua/reference/lua.md
+++ b/doc/src/content/docs/en/mod/lua/reference/lua.md
@@ -5537,7 +5537,7 @@ Variable of type `string`
 #### txt_color
 
 Entry text color. Its default color is `c_red_red`, which makes color of the entry same as what `uilist` decides. So if you want to make color different, choose one except `c_red_red`.
-Variable of type `<cppval: 8nc_color >`
+Function `( UiListEntry, Color )`
 
 ## Volume
 

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -726,7 +726,9 @@ void cata::detail::reg_ui_elements( sol::state &lua )
         DOC( "Entry text of column." );
         luna::set( ut, "ctxt",  &uilist_entry::ctxt );
         DOC( "Entry text color. Its default color is `c_red_red`, which makes color of the entry same as what `uilist` decides. So if you want to make color different, choose one except `c_red_red`." );
-        luna::set( ut, "txt_color",  &uilist_entry::text_color );
+        luna::set_fx( ut, "txt_color", []( uilist_entry & ui_entry, color_id col ) {
+            ui_entry.text_color = get_all_colors().get( col );
+        } );
     }
 
     {


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
Patch for #6485 
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Change entry color from variable to function.
Now it works as `UiListEntry:txt_color(Color)`.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Open lua console and input below.
```lua
local ui = UiList.new()
ui:title("Color Testing")
ui:text("What color?")
ui:add(-1, "red")
ui:add(-1, "blue")
ui:add(-1, "yellow")
local ents = ui.entries
ents[1]:txt_color(Color.c_red)
ents[2]:txt_color(Color.c_blue)
ents[3]:txt_color(Color.c_yellow)
gdebug.log_info("your select number is", ui:query())
```

![image](https://github.com/user-attachments/assets/b9b86948-0723-4a9e-810d-9765e0273e72)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This PR modifies BN's lua API.
  - [x] I have committed the output of `deno task doc` so the Lua API documentation is updated.

<!--
please remove sections irrelevant to this PR.



- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
