### PR TITLE
feat: remove the road connection of multiple urban locations

### DIFF
--- a/data/json/overmap/multitile_city_buildings.json
+++ b/data/json/overmap/multitile_city_buildings.json
@@ -754,8 +754,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "urban_24_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_24_3_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_24_4_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_24_5_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_24_6_south" },
       { "point": [ 1, 0, 2 ], "overmap": "urban_24_7_south" },
@@ -768,8 +766,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ 2, 0, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
       { "point": [ -1, 0, -1 ], "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] }
     ],
@@ -783,8 +779,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "urban_25_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_25_3_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_25_4_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_25_5_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_25_6_south" },
       { "point": [ 1, 0, 2 ], "overmap": "urban_25_7_south" },
@@ -795,8 +789,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ 2, 0, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
       { "point": [ 0, -1, -1 ], "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] }
     ],
@@ -839,8 +831,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "urban_27_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_27_3_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_27_4_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_27_5_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_27_6_south" },
       { "point": [ 1, 0, 2 ], "overmap": "urban_27_7_south" },
@@ -853,8 +843,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ -1, 0, -1 ], "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] },
       { "point": [ 1, 1, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
       { "point": [ 1, -1, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] }
@@ -869,8 +857,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "urban_28_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_28_3_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_28_4_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_28_5_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_28_6_south" },
       { "point": [ 1, 0, 2 ], "overmap": "urban_28_7_south" },
@@ -881,8 +867,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ 2, 0, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
       { "point": [ -1, 0, -1 ], "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] }
     ],
@@ -896,8 +880,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "urban_29_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_29_3_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_29_4_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_29_5_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_29_6_south" },
       { "point": [ 1, 0, 2 ], "overmap": "urban_29_7_south" },
@@ -907,8 +889,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ 2, 0, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
       { "point": [ -1, 0, -1 ], "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] }
     ],


### PR DESCRIPTION
## Purpose of change (The Why)
Remove shoddy road connections and static road that are worse than useless for multiple locations.
## Describe the solution (The How)
In the file multitile_city_buildings.json delete the static road and road connection of the following `city_building`:
"urban_24_dense_bank_house", "urban_25_dense_diner_apt", "urban_27_dense_barber_apt", "urban_28_dense_cafe_laundry", "urban_29_dense_row"
## Describe alternatives you've considered
none
## Testing
No errors when starting a new game.
I make my character appear in the game at the concerned locations via a scenario.
## Additional context

<details>
<summary>urban 24 (before):</summary>
<br>I made myself appear on the location via a scenario.
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/5572a166-c310-47b7-8cd0-b553c7931b1e"></a>
</details>

<details>
<summary>urban 24 (After):</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/3c87e2dd-309d-4140-8d02-a8cc5dce022c"></a>
</details>

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.