### PR TITLE
feat: Update terrain flags to support different pits and ground types

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -153,7 +153,7 @@
     "time": "60 m",
     "qualities": [ [ { "id": "CUT", "level": 1 } ], [ { "id": "HAMMER", "level": 1 } ] ],
     "components": [ [ [ "wood_structural", 3, "LIST" ], [ "wood_panel", 1 ] ], [ [ "pine_bough", 24 ], [ "willowbark", 24 ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "dark_craftable": true,
     "post_terrain": "t_improvised_shelter"
   },
@@ -1062,7 +1062,7 @@
     "time": "60 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
     "components": [ [ [ "log", 2 ] ], [ [ "wood_structural_small", 3, "LIST" ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "post_terrain": "t_wall_log_half"
   },
   {
@@ -1166,7 +1166,7 @@
     "qualities": [ { "id": "GLARE", "level": 2 } ],
     "tools": [ [ [ "oxy_torch", 10 ], [ "welder", 50 ], [ "toolset", 75 ] ] ],
     "components": [ [ [ "steel_plate", 2 ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "post_terrain": "t_scrap_wall_halfway"
   },
   {
@@ -1193,7 +1193,7 @@
     "time": "120 m",
     "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
     "components": [ [ [ "brick", 15 ] ], [ [ "mortar_build", 1 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ],
-    "pre_terrain": "t_dirt",
+    "pre_flags": "FLAT",
     "post_terrain": "t_brick_wall_halfway"
   },
   {
@@ -1220,7 +1220,7 @@
     "tools": [ [ [ "con_mix", 50 ] ] ],
     "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
     "components": [ [ [ "concrete", 2 ] ], [ [ "water", 2 ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "post_terrain": "t_concrete"
   },
   {
@@ -1246,7 +1246,7 @@
     "required_skills": [ [ "fabrication", 0 ] ],
     "time": "40 m",
     "components": [ [ [ "splinter", 50 ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "dark_craftable": true,
     "post_terrain": "t_woodchips"
   },
@@ -1311,7 +1311,7 @@
     "tools": [ [ [ "con_mix", 50 ] ] ],
     "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
     "components": [ [ [ "concrete", 4 ] ], [ [ "2x4", 12 ] ], [ [ "water", 4 ], [ "water_clean", 4 ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "post_terrain": "t_sconc_wall_halfway"
   },
   {
@@ -1338,7 +1338,7 @@
     "time": "120 m",
     "qualities": [ [ { "id": "WELD", "level": 2 } ], [ { "id": "GLARE", "level": 2 } ] ],
     "components": [ [ [ "rebar", 16 ] ] ],
-    "pre_terrain": "t_pit",
+    "pre_flags": "PIT_DEEP",
     "post_terrain": "t_reb_cage"
   },
   {
@@ -1379,7 +1379,7 @@
     "time": "120 m",
     "qualities": [ [ { "id": "WELD", "level": 2 } ], [ { "id": "GLARE", "level": 2 } ] ],
     "components": [ [ [ "rebar", 16 ] ] ],
-    "pre_terrain": "t_pit",
+    "pre_flags": "PIT_DEEP",
     "post_terrain": "t_reb_cage"
   },
   {
@@ -1434,7 +1434,7 @@
     "time": "120 m",
     "qualities": [ [ { "id": "WELD", "level": 2 } ], [ { "id": "GLARE", "level": 2 } ] ],
     "components": [ [ [ "rebar", 8 ] ], [ [ "2x4", 12 ] ], [ [ "pipe", 4 ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "post_terrain": "t_ov_smreb_cage"
   },
   {
@@ -1461,7 +1461,7 @@
     "time": "180 m",
     "qualities": [ [ { "id": "WELD", "level": 2 } ], [ { "id": "GLARE", "level": 2 } ] ],
     "components": [ [ [ "rebar", 12 ] ], [ [ "2x4", 12 ] ], [ [ "pipe", 4 ] ] ],
-    "pre_terrain": "t_pit",
+    "pre_flags": "PIT_DEEP",
     "post_terrain": "t_ov_reb_cage"
   },
   {
@@ -1511,7 +1511,7 @@
         [ "vine_30", 1 ]
       ]
     ],
-    "pre_terrain": "t_pit",
+    "pre_flags": "PIT_DEEP",
     "post_terrain": "t_palisade"
   },
   {
@@ -1665,7 +1665,7 @@
       [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_30", 1 ] ]
     ],
     "pre_note": "Must be between palisade walls to function, and at least one wall must have an adjacent rope & pulley system.",
-    "pre_terrain": "t_pit",
+    "pre_flags": "PIT_DEEP",
     "post_terrain": "t_palisade_gate"
   },
   {
@@ -1916,7 +1916,7 @@
     "time": "30 m",
     "qualities": [ [ { "id": "HAMMER", "level": 1 } ], [ { "id": "DIG", "level": 2 } ] ],
     "components": [ [ [ "rock", 20 ], [ "wood_structural_small", 2, "LIST" ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "post_flags": [ "keep_items" ],
     "post_terrain": "t_grave_new",
     "post_special": "done_grave"
@@ -2393,7 +2393,7 @@
     "time": "480 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [ [ [ "rock", 40 ] ], [ [ "2x4", 4 ] ], [ [ "nail", 8 ] ] ],
-    "pre_terrain": "t_pit",
+    "pre_flags": "PIT_DEEP",
     "post_terrain": "t_covered_well"
   },
   {
@@ -3100,7 +3100,7 @@
     "tools": [ [ [ "con_mix", 125 ] ] ],
     "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
     "components": [ [ [ "concrete", 5 ] ], [ [ "water", 5 ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "pre_special": "check_ramp_low",
     "post_terrain": "t_ramp_up_low",
     "post_special": "done_ramp_low"
@@ -3117,7 +3117,7 @@
     "tools": [ [ [ "con_mix", 125 ] ] ],
     "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
     "components": [ [ [ "concrete", 5 ] ], [ [ "water", 5 ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "pre_special": "check_ramp_high",
     "post_terrain": "t_ramp_up_high",
     "post_special": "done_ramp_high"
@@ -3330,7 +3330,7 @@
     "time": "40 m",
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
     "components": [ [ [ "wind_mill", 1 ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "post_furniture": "f_wind_mill"
   },
   {
@@ -3583,7 +3583,7 @@
       [ [ "withered", 12 ], [ "straw_pile", 12 ] ]
     ],
     "pre_note": "You need a deep pit to construct a root cellar.",
-    "pre_terrain": "t_pit",
+    "pre_flags": "PIT_DEEP",
     "post_terrain": "t_rootcellar"
   },
   {
@@ -3887,7 +3887,7 @@
       [ [ "water", 1 ], [ "water_clean", 1 ] ],
       [ [ "material_sand", 20 ] ]
     ],
-    "pre_terrain": "t_dirt",
+    "pre_flags": "FLAT",
     "post_terrain": "t_adobe_brick_wall_halfway"
   },
   {
@@ -4667,7 +4667,7 @@
     "using": [ [ "soldering_standard", 10 ] ],
     "components": [ [ [ "steel_chunk", 5 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "wind_turbine", 1 ] ] ],
     "pre_note": "Will only work if constructed near a building that has an electric grid with a mounted battery.",
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "post_furniture": "f_turbine_unit"
   },
   {
@@ -4695,7 +4695,7 @@
     "using": [ [ "soldering_standard", 20 ] ],
     "components": [ [ [ "steel_chunk", 5 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "xl_wind_turbine", 1 ] ] ],
     "pre_note": "Will only work if constructed near a building that has an electric grid with a mounted battery.",
-    "pre_terrain": "t_pit_shallow",
+    "pre_flags": "PIT_SHALLOW",
     "post_furniture": "f_xl_turbine_unit"
   },
   {

--- a/data/json/furniture_and_terrain/terrain-traps.json
+++ b/data/json/furniture_and_terrain/terrain-traps.json
@@ -7,7 +7,7 @@
     "symbol": "0",
     "color": "yellow",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN", "VEH_TREAT_AS_BASH_BELOW" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN", "VEH_TREAT_AS_BASH_BELOW", "PIT_SHALLOW" ],
     "bash": { "sound": "thump", "ter_set": "t_pit", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
@@ -19,7 +19,7 @@
     "color": "brown",
     "move_cost": 10,
     "trap": "tr_pit",
-    "flags": [ "TRANSPARENT" ],
+    "flags": [ "TRANSPARENT", "PIT_DEEP" ],
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true },
     "examine_action": "pit"
   },


### PR DESCRIPTION
## Purpose of change (The Why)

Floor is floor, currently some terrain calls for dirt pits or for flat dirt.

This causes problems if you want to do anything with regions. Now you can't dig wells nor can you construct a number of things like brick walls or concrete walls.

## Describe the solution (The How)

Pits and shallow pits are now flagged PIT_SHALLOW and PIT_DEEP. This could be useful to farm mods, but it's mostly necessary right now to say "A pit is a pit." for the sake of construction. Different soil types like a sandy pit aren't important here for the construction.

Constructions that call for t_dirt now call for FLAT. So now you don't need to dig up moss and fill it back in to build a brick wall, for example.

## Describe alternatives you've considered

None, but we need to update digging result to also use terrain setting like deconstruct does. We also need a way for constructions to remember what terrain they were built on so they go back to being this new type of ground

## Testing

Wasteland soil pits from Essence 2200 can now correctly be built upon, as can brick walls be built on wasteland soil itself.

This is very important if we add pits dug from sand, clay, or any type of other soils (Martian mod, Moon mod, Nether hellscape if we get dimension support)
![image](https://github.com/user-attachments/assets/f26de247-eb33-4272-b01b-d35877e26cee)


## Additional context

This has plagued me greatly in development

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.