### PR TITLE
fix: flat tar paper roofs are roofs

### DIFF
--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -132,7 +132,7 @@
     "symbol": ".",
     "color": "dark_gray",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAMMABLE", "FLAT" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "FLAT", "ROOF" ],
     "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "bash_below": true }
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

Tar paper roofs aren't considered a roof, you can't build wind turbines on them.

"A flat, gray section of rooftop covered with tar paper." The tar paper has no reason to make it too unstable. The reason is the flat roof: "A flat, gray section of rooftop." Some tar paper makes no difference on structural integrity when you're already drilling the turbine in.

## Describe the solution (The How)

Makes them flagged as a Roof

## Describe alternatives you've considered

Violence

## Testing

Tests

## Additional context

WTF

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.