### PR TITLE
style: collapse simple statements

### DIFF
--- a/data/mods/ebook_lua/main.lua
+++ b/data/mods/ebook_lua/main.lua
@@ -205,9 +205,7 @@ mod.ebook_scan = function(user, device)
             for t_str, _ in pairs(found) do
               mod.insert_lib2(device, t_str)
               count2 = count2 + 1
-              if count2 >= dev_limit then
-                break
-              end
+              if count2 >= dev_limit then break end
             end
             gapi.add_msg(MsgType.good, string.format(locale.gettext("You scanned %d book(s)."), dev_limit))
             return dev_limit
@@ -263,9 +261,7 @@ mod.ebook_load = function(reader, device)
   -- Repeat when getting minute more than 0 AND less than charges-10.
   -- If you cancel to input number, minute is 0, and it will get back and show you data select menu.
   while true do
-    if not u_input_too_big_minute then
-      sel = ui_load:query()
-    end
+    if not u_input_too_big_minute then sel = ui_load:query() end
     u_input_too_big_minute = false
     if sel < 0 then
       --You canceled to select the book.
@@ -335,9 +331,7 @@ mod.ebook_return = function(reader, device)
   local your_items = reader:all_items(false)
   local virtual_books = {}
   for _, it in ipairs(your_items) do
-    if it:has_var("aspect") then
-      table.insert(virtual_books, it)
-    end
+    if it:has_var("aspect") then table.insert(virtual_books, it) end
   end
   if #virtual_books <= 0 then
     mod.poppin(locale.gettext("There is no book to return."))
@@ -397,9 +391,7 @@ mod.mc_io = function(reader, device)
   local your_items = reader:all_items(false)
   --Let's make your_mc!
   for _, it in ipairs(your_items) do
-    if it:has_flag(flag_MC_USED) then
-      table.insert(your_mc, it)
-    end
+    if it:has_flag(flag_MC_USED) then table.insert(your_mc, it) end
   end
   -- Escape when no mc.
   if #your_mc == 0 then
@@ -570,24 +562,16 @@ mod.ebook_info = function(reader, device)
       return -1
     elseif ans_info == 0 then
       local ch_lib = mod.check_lib(reader, device)
-      if ch_lib ~= -1 then
-        return ch_lib
-      end
+      if ch_lib ~= -1 then return ch_lib end
     elseif ans_info == 1 then
       local mc_io = mod.mc_io(reader, device)
-      if mc_io ~= -1 then
-        return mc_io
-      end
+      if mc_io ~= -1 then return mc_io end
     elseif ans_info == 2 then
       local clo_syn = mod.cloud_sync(reader, device)
-      if clo_syn ~= -1 then
-        return clo_syn
-      end
+      if clo_syn ~= -1 then return clo_syn end
     elseif ans_info == 3 then
       local res_lib = mod.reset_lib(reader, device)
-      if res_lib ~= -1 then
-        return res_lib
-      end
+      if res_lib ~= -1 then return res_lib end
     end
   end
 end
@@ -645,9 +629,7 @@ mod.ebook_ui = function(who, item, pos)
     local action_func = actions[ans]
     if action_func then
       local result = action_func(who, item)
-      if result ~= -1 then
-        return result
-      end
+      if result ~= -1 then return result end
     else
       gdebug.log_info("ebook_lua: Error occurred. What the heck did you select?")
       return 0

--- a/data/mods/ebook_lua/preload.lua
+++ b/data/mods/ebook_lua/preload.lua
@@ -9,16 +9,12 @@ mod.stor = storage
 
 mod.cache_static = function(category, name, binding_id)
   storage[category] = storage[category] or {}
-  if not storage[category][name] then
-    storage[category][name] = binding_id.new(name)
-  end
+  if not storage[category][name] then storage[category][name] = binding_id.new(name) end
   return storage[category][name]
 end
 
 ---@type fun(n: integer): TimeDuration
-mod.from_turns = function(n)
-  return TimeDuration.new().from_turns(n)
-end
+mod.from_turns = function(n) return TimeDuration.new().from_turns(n) end
 
 -- mod.cache_static( "flags", "", JsonFlagId.new())
 
@@ -36,10 +32,6 @@ mod.turntimer_hook = function(turn, func)
   storage.hook_assuarance[the_when:to_turns()] = "Requiem"
 end
 
-game.hooks.on_game_load[#game.hooks.on_game_load + 1] = function(...)
-  return mod.assure_timer_hook(...)
-end
+game.hooks.on_game_load[#game.hooks.on_game_load + 1] = function(...) return mod.assure_timer_hook(...) end
 
-game.iuse_functions["LUA_EBOOK"] = function(...)
-  return mod.ebook_ui(...)
-end
+game.iuse_functions["LUA_EBOOK"] = function(...) return mod.ebook_ui(...) end

--- a/data/mods/saveload_lua_test/main.lua
+++ b/data/mods/saveload_lua_test/main.lua
@@ -31,12 +31,8 @@ storage.tri_as_str = tostring(Tripoint.new(3, 4, 5))
 mod.on_game_load_hook = function()
   gdebug.log_info("SLT: on_load")
 
-  if storage.num then
-    gdebug.log_info("Data found! num = ", storage.num)
-  end
-  if storage.tri then
-    gdebug.log_info("Data found! tri = ", storage.tri)
-  end
+  if storage.num then gdebug.log_info("Data found! num = ", storage.num) end
+  if storage.tri then gdebug.log_info("Data found! tri = ", storage.tri) end
 end
 
 --[[
@@ -48,7 +44,5 @@ end
 mod.on_game_save_hook = function()
   gdebug.log_info("SLT: on_save")
 
-  if storage.num then
-    gdebug.log_info("Saving NUM value = ", storage.num)
-  end
+  if storage.num then gdebug.log_info("Saving NUM value = ", storage.num) end
 end

--- a/data/mods/saveload_lua_test/preload.lua
+++ b/data/mods/saveload_lua_test/preload.lua
@@ -2,10 +2,6 @@ gdebug.log_info("SLT: preload")
 
 local mod = game.mod_runtime[game.current_mod]
 
-game.hooks.on_game_load[#game.hooks.on_game_load + 1] = function(...)
-  return mod.on_game_load_hook(...)
-end
+game.hooks.on_game_load[#game.hooks.on_game_load + 1] = function(...) return mod.on_game_load_hook(...) end
 
-game.hooks.on_game_save[#game.hooks.on_game_save + 1] = function(...)
-  return mod.on_game_save_hook(...)
-end
+game.hooks.on_game_save[#game.hooks.on_game_save + 1] = function(...) return mod.on_game_save_hook(...) end

--- a/data/mods/smart_house_remotes/main.lua
+++ b/data/mods/smart_house_remotes/main.lua
@@ -34,9 +34,7 @@ mod.remote_wireless_range = 24
 mod.remote_wireless_range_z = 2
 
 -- Get abs omt of remote's base
-mod.get_remote_base_omt = function(item)
-  return item:get_var_tri(mod.var_base, Tripoint.new(0, 0, 0))
-end
+mod.get_remote_base_omt = function(item) return item:get_var_tri(mod.var_base, Tripoint.new(0, 0, 0)) end
 
 -- Get abs ms of remote's base
 mod.get_remote_base_abs_ms = function(item)
@@ -45,9 +43,7 @@ mod.get_remote_base_abs_ms = function(item)
 end
 
 -- Set remote's base abs omt
-mod.set_remote_base = function(item, p_omt)
-  item:set_var_tri(mod.var_base, p_omt)
-end
+mod.set_remote_base = function(item, p_omt) item:set_var_tri(mod.var_base, p_omt) end
 
 -- Look for spawned remotes and bind them to given omt
 mod.on_mapgen_postprocess_hook = function(map, p_omt, when)
@@ -61,9 +57,7 @@ mod.on_mapgen_postprocess_hook = function(map, p_omt, when)
       if map:has_items_at(p) then
         local items = map:get_items_at(p):as_item_stack()
         for _, item in pairs(items) do
-          if item:get_type():str() == item_id then
-            mod.set_remote_base(item, p_omt)
-          end
+          if item:get_type():str() == item_id then mod.set_remote_base(item, p_omt) end
         end
       end
     end
@@ -125,12 +119,8 @@ mod.get_neighbours_at = function(opts, block, p)
   if v ~= nil and v.idx == block.idx then
     opts[k] = nil
     block.points[#block.points + 1] = p
-    if v.can_open then
-      block.can_open_num = block.can_open_num + 1
-    end
-    if v.can_close then
-      block.can_close_num = block.can_close_num + 1
-    end
+    if v.can_open then block.can_open_num = block.can_open_num + 1 end
+    if v.can_close then block.can_close_num = block.can_close_num + 1 end
     mod.get_neighbours(opts, block, p)
   end
 end
@@ -144,9 +134,7 @@ end
 -- Helper func to check whether value is in array
 local find_in_array = function(arr, val)
   for k, v in pairs(arr) do
-    if v == val then
-      return k
-    end
+    if v == val then return k end
   end
   return nil
 end
@@ -154,9 +142,7 @@ end
 -- Helper func to check whether tile is considered as inert for one of the blocks
 local check_is_tile_inert = function(tlist, val)
   for idx, transform in pairs(tlist) do
-    if transform.i and find_in_array(transform.i, val) then
-      return idx
-    end
+    if transform.i and find_in_array(transform.i, val) then return idx end
   end
   return nil
 end
@@ -238,9 +224,7 @@ end
 mod.block_close = function(block, transform)
   for _, p in pairs(block.points) do
     local ter_at_p = gapi.get_map():get_ter_at(p):str_id()
-    if ter_at_p:str() == transform.o then
-      gapi.get_map():set_ter_at(p, TerId.new(transform.c):int_id())
-    end
+    if ter_at_p:str() == transform.o then gapi.get_map():set_ter_at(p, TerId.new(transform.c):int_id()) end
   end
 end
 
@@ -248,9 +232,7 @@ end
 mod.block_open = function(block, transform)
   for _, p in pairs(block.points) do
     local ter_at_p = gapi.get_map():get_ter_at(p):str_id()
-    if ter_at_p:str() == transform.c then
-      gapi.get_map():set_ter_at(p, TerId.new(transform.o):int_id())
-    end
+    if ter_at_p:str() == transform.c then gapi.get_map():set_ter_at(p, TerId.new(transform.o):int_id()) end
   end
 end
 
@@ -289,9 +271,7 @@ mod.show_no_endpoints_error = function()
 end
 
 -- Add message indicating the remote works
-mod.show_msg_remote_working = function()
-  gapi.add_msg(locale.gettext("The remote beeps quietly."))
-end
+mod.show_msg_remote_working = function() gapi.add_msg(locale.gettext("The remote beeps quietly.")) end
 
 -- Open or close all tiles in block
 mod.invoke_block = function(block, grid)

--- a/data/mods/smart_house_remotes/preload.lua
+++ b/data/mods/smart_house_remotes/preload.lua
@@ -6,11 +6,8 @@ gdebug.log_info("SHR: preload.")
 local mod = game.mod_runtime[game.current_mod]
 
 -- Register our map post-process hook
-game.hooks.on_mapgen_postprocess[#game.hooks.on_mapgen_postprocess + 1] = function(...)
-  return mod.on_mapgen_postprocess_hook(...)
-end
+game.hooks.on_mapgen_postprocess[#game.hooks.on_mapgen_postprocess + 1] =
+  function(...) return mod.on_mapgen_postprocess_hook(...) end
 
 -- Register our item use function
-game.iuse_functions["SMART_HOUSE_REMOTE"] = function(...)
-  return mod.iuse_function(...)
-end
+game.iuse_functions["SMART_HOUSE_REMOTE"] = function(...) return mod.iuse_function(...) end

--- a/data/mods/teleportation_mod/preload.lua
+++ b/data/mods/teleportation_mod/preload.lua
@@ -6,22 +6,12 @@ gdebug.log_info("Tele: preload.")
 local mod = game.mod_runtime[game.current_mod]
 
 -- Register our item use function
-game.iuse_functions["teleporter_controller_use"] = function(...)
-  return mod.iuse_function_controller(...)
-end
+game.iuse_functions["teleporter_controller_use"] = function(...) return mod.iuse_function_controller(...) end
 
-game.iuse_functions["teleporter_anchor_use"] = function(...)
-  return mod.iuse_function_anchor(...)
-end
+game.iuse_functions["teleporter_anchor_use"] = function(...) return mod.iuse_function_anchor(...) end
 
-game.iuse_functions["teleporter_station_use"] = function(...)
-  return mod.iuse_function_station(...)
-end
+game.iuse_functions["teleporter_station_use"] = function(...) return mod.iuse_function_station(...) end
 
-game.hooks.on_game_load[#game.hooks.on_game_load + 1] = function(...)
-  return mod.on_game_load_hook(...)
-end
+game.hooks.on_game_load[#game.hooks.on_game_load + 1] = function(...) return mod.on_game_load_hook(...) end
 
-game.hooks.on_game_save[#game.hooks.on_game_save + 1] = function(...)
-  return mod.on_game_save_hook(...)
-end
+game.hooks.on_game_save[#game.hooks.on_game_save + 1] = function(...) return mod.on_game_save_hook(...) end

--- a/data/raw/generate_docs.lua
+++ b/data/raw/generate_docs.lua
@@ -7,11 +7,7 @@
 ]]
 --
 local sorted_by = function(t, f)
-  if not f then
-    f = function(a, b)
-      return (a.k < b.k)
-    end
-  end
+  if not f then f = function(a, b) return (a.k < b.k) end end
   local sorted = {}
   for k, v in pairs(t) do
     sorted[#sorted + 1] = { k = k, v = v }
@@ -35,23 +31,17 @@ end
 local fmt_arg_list = function(arg_list)
   local ret = ""
   local arg_list = remove_hidden_args(arg_list)
-  if #arg_list == 0 then
-    return ret
-  end
+  if #arg_list == 0 then return ret end
   local is_first = true
   for _, arg in pairs(arg_list) do
-    if not is_first then
-      ret = ret .. ","
-    end
+    if not is_first then ret = ret .. "," end
     ret = ret .. " " .. arg
     is_first = false
   end
   return ret .. " "
 end
 
-local fmt_one_constructor = function(typename, ctor)
-  return typename .. ".new(" .. fmt_arg_list(ctor) .. ")"
-end
+local fmt_one_constructor = function(typename, ctor) return typename .. ".new(" .. fmt_arg_list(ctor) .. ")" end
 
 local fmt_constructors = function(typename, ctors)
   if #ctors == 0 then
@@ -68,22 +58,16 @@ end
 local fmt_one_member = function(typename, member)
   local ret = "#### " .. tostring(member.name) .. "\n"
 
-  if member.comment then
-    ret = ret .. member.comment .. "\n"
-  end
+  if member.comment then ret = ret .. member.comment .. "\n" end
 
   if member.type == "var" then
     ret = ret .. "  Variable of type `" .. member.vartype .. "`"
-    if member.hasval then
-      ret = ret .. " value: `" .. tostring(member.varval) .. "`"
-    end
+    if member.hasval then ret = ret .. " value: `" .. tostring(member.varval) .. "`" end
     ret = ret .. "\n"
   elseif member.type == "func" then
     for _, overload in pairs(member.overloads) do
       ret = ret .. "  Function `(" .. fmt_arg_list(overload.args) .. ")"
-      if overload.retval ~= "nil" then
-        ret = ret .. " -> " .. overload.retval
-      end
+      if overload.retval ~= "nil" then ret = ret .. " -> " .. overload.retval end
       ret = ret .. "`\n"
     end
   else
@@ -129,14 +113,10 @@ local fmt_enum_entries = function(typename, entries)
     local entries_filtered = {}
     for k, v in pairs(entries) do
       -- TODO: this should not be needed
-      if type(v) ~= "table" and type(v) ~= "function" then
-        entries_filtered[k] = v
-      end
+      if type(v) ~= "table" and type(v) ~= "function" then entries_filtered[k] = v end
     end
 
-    local entries_sorted = sorted_by(entries_filtered, function(a, b)
-      return a.v < b.v
-    end)
+    local entries_sorted = sorted_by(entries_filtered, function(a, b) return a.v < b.v end)
     for _, it in pairs(entries_sorted) do
       ret = ret .. "- `" .. tostring(it.k) .. "` = `" .. tostring(it.v) .. "`\n"
     end
@@ -176,9 +156,7 @@ and should not be edited directly.
     local type_comment = dt_type.type_comment
     ret = ret .. "## " .. typename .. "\n"
 
-    if type_comment then
-      ret = ret .. type_comment .. "\n"
-    end
+    if type_comment then ret = ret .. type_comment .. "\n" end
 
     local bases = dt_type["#bases"]
     local ctors = dt_type["#construct"]
@@ -222,9 +200,7 @@ and should not be edited directly.
     local lib_comment = dt_lib.lib_comment
     ret = ret .. "## " .. typename .. "\n"
 
-    if lib_comment then
-      ret = ret .. lib_comment .. "\n"
-    end
+    if lib_comment then ret = ret .. lib_comment .. "\n" end
 
     local members = dt_lib["#member"]
 

--- a/data/raw/generate_types.lua
+++ b/data/raw/generate_types.lua
@@ -1,8 +1,6 @@
 ---@type fun (a: any, b: any): boolean
 function sort_by_tostring(a, b)
-  if a.k and b.k then
-    return tostring(a.k) < tostring(b.k)
-  end
+  if a.k and b.k then return tostring(a.k) < tostring(b.k) end
   return tostring(a) < tostring(b)
 end
 
@@ -14,9 +12,7 @@ Uses 'pairs' for iteration to be compatible with sol2 table/map proxies.
 ---@param f? fun(a:any, b:any):boolean
 ---@return table
 local sorted_by = function(t, f)
-  if not f then
-    f = sort_by_tostring
-  end
+  if not f then f = sort_by_tostring end
   local sorted = {}
   for k, v in pairs(t) do
     table.insert(sorted, { k = k, v = v })
@@ -33,9 +29,7 @@ end
 local remove_hidden_args = function(arg_list)
   local ret = {}
   for _, arg in ipairs(arg_list) do
-    if not string.match(arg, "^<.+>$") then
-      table.insert(ret, arg)
-    end
+    if not string.match(arg, "^<.+>$") then table.insert(ret, arg) end
   end
   return ret
 end
@@ -45,9 +39,7 @@ end
 ---@return string
 local map_cpp_type_to_lua = function(cpp_type)
   -- NOTE: This mapping might need refinement based on actual types used
-  if not cpp_type then
-    return "any"
-  end -- Handle nil input gracefully
+  if not cpp_type then return "any" end -- Handle nil input gracefully
   cpp_type = string.gsub(cpp_type, "const%s+", "") -- Remove const
   cpp_type = string.gsub(cpp_type, "%s+&", "") -- Remove references
   cpp_type = string.gsub(cpp_type, "%s+%*", "") -- Remove pointers (basic)
@@ -134,9 +126,7 @@ end
 ---@param comment? string
 ---@return string
 local fmt_comment_annotation = function(comment)
-  if not comment or comment == "" then
-    return ""
-  end
+  if not comment or comment == "" then return "" end
   local comment_lines = {}
   for line in string.gmatch(comment .. "\n", "([^\n]*)\n") do
     table.insert(comment_lines, "--- " .. line)
@@ -156,9 +146,7 @@ local fmt_function_signature = function(arg_list, ret_type, class_name, is_metho
   local params = {}
   local mapped_class_name = map_cpp_type_to_lua(class_name)
 
-  if is_method then
-    table.insert(params, "self: " .. mapped_class_name)
-  end
+  if is_method then table.insert(params, "self: " .. mapped_class_name) end
 
   local clean_arg_list = remove_hidden_args(arg_list)
   for i, arg_str in ipairs(clean_arg_list) do
@@ -175,9 +163,7 @@ local fmt_function_signature = function(arg_list, ret_type, class_name, is_metho
   local params_str = table.concat(params, ", ")
   local lua_ret_type = map_cpp_type_to_lua(ret_type)
   local ret_str = ""
-  if lua_ret_type ~= "nil" then
-    ret_str = ": " .. lua_ret_type
-  end
+  if lua_ret_type ~= "nil" then ret_str = ": " .. lua_ret_type end
 
   return "fun(" .. params_str .. ")" .. ret_str
 end
@@ -197,15 +183,11 @@ local fmt_variable_field = function(member, is_static)
   local lua_type = map_cpp_type_to_lua(member.vartype)
 
   ret = ret .. "---@field " .. member_name .. " " .. lua_type
-  if member.comment and member.comment ~= "" then
-    ret = ret .. " @" .. member.comment
-  end
+  if member.comment and member.comment ~= "" then ret = ret .. " @" .. member.comment end
   if member.hasval then
     -- Avoid overly long or complex value representations
     local val_str = tostring(member.varval)
-    if #val_str < 50 and not string.find(val_str, "\n") then
-      ret = ret .. " # value: " .. val_str
-    end
+    if #val_str < 50 and not string.find(val_str, "\n") then ret = ret .. " # value: " .. val_str end
   end
   ret = ret .. "\n"
   return ret
@@ -246,9 +228,7 @@ local fmt_function_field = function(member, class_name, is_method)
 
   local signature_union = table.concat(signatures, " | ")
   ret = ret .. "---@field " .. member_name .. " " .. signature_union
-  if member.comment and member.comment ~= "" then
-    ret = ret .. " @" .. member.comment
-  end
+  if member.comment and member.comment ~= "" then ret = ret .. " @" .. member.comment end
   return ret .. "\n"
 end
 
@@ -259,9 +239,7 @@ end
 ---@param ctors string[][] List of constructor argument lists
 ---@return string Field annotation string or ""
 local fmt_constructor_field = function(typename, ctors)
-  if not ctors or #ctors == 0 then
-    return ""
-  end
+  if not ctors or #ctors == 0 then return "" end
 
   local signatures = {}
   local mapped_typename = map_cpp_type_to_lua(typename)
@@ -308,9 +286,7 @@ game = {}
   local process_section = function(section_name, section_data, is_class)
     local ret = ""
     local section_sorted = sorted_by(section_data)
-    if #section_sorted == 0 then
-      return ""
-    end -- Skip empty sections
+    if #section_sorted == 0 then return "" end -- Skip empty sections
 
     ret = ret .. "--================---- " .. section_name .. " ----================\n\n"
 
@@ -325,9 +301,7 @@ game = {}
       -- Class/Lib Annotation Start
       local bases_str = is_class and fmt_bases_luals(bases) or ""
       local comment_annot = fmt_comment_annotation(comment)
-      if comment_annot ~= "" then
-        ret = ret .. comment_annot .. "\n"
-      end
+      if comment_annot ~= "" then ret = ret .. comment_annot .. "\n" end
       ret = ret .. "---@class " .. name .. bases_str .. "\n"
 
       -- Process Members (Variables and Functions)
@@ -368,9 +342,7 @@ game = {}
       end
 
       -- Add Constructor Field (only for classes)
-      if is_class then
-        ret = ret .. fmt_constructor_field(name, ctors)
-      end
+      if is_class then ret = ret .. fmt_constructor_field(name, ctors) end
 
       -- Placeholder table declaration
       ret = ret .. name .. " = {}\n\n"
@@ -385,9 +357,7 @@ game = {}
   -- Process Enums (Remain largely unchanged, ensure sorting/formatting is robust)
   local enums_table = dt["#enums"] or {}
   local enums_sorted = sorted_by(enums_table)
-  if #enums_sorted > 0 then
-    full_ret = full_ret .. "--=================---- Enums ----=================\n\n"
-  end
+  if #enums_sorted > 0 then full_ret = full_ret .. "--=================---- Enums ----=================\n\n" end
   for _, item in ipairs(enums_sorted) do
     local enumname = item.k
     local dt_enum = item.v or {}
@@ -395,9 +365,7 @@ game = {}
     local entries = dt_enum["entries"] or {}
 
     local comment_annot = fmt_comment_annotation(enum_comment)
-    if comment_annot ~= "" then
-      full_ret = full_ret .. comment_annot .. "\n"
-    end
+    if comment_annot ~= "" then full_ret = full_ret .. comment_annot .. "\n" end
 
     full_ret = full_ret .. "---@enum " .. enumname .. "\n"
     full_ret = full_ret .. enumname .. " = {\n"
@@ -420,9 +388,7 @@ game = {}
       end
     end
 
-    local entries_sorted_by_v = sorted_by(entries_filtered, function(a, b)
-      return a.v < b.v
-    end)
+    local entries_sorted_by_v = sorted_by(entries_filtered, function(a, b) return a.v < b.v end)
 
     local table_entries = {}
     for _, entry_item in ipairs(entries_sorted_by_v) do

--- a/dprint.json
+++ b/dprint.json
@@ -7,6 +7,9 @@
   "excludes": [
 
   ],
+  "stylua": {
+    "collapseSimpleStatement": "Always"
+  },
   "plugins": [
     "https://plugins.dprint.dev/RubixDev/stylua-v0.2.1.wasm"
   ]

--- a/tests/lua/called_from_cpp_test.lua
+++ b/tests/lua/called_from_cpp_test.lua
@@ -8,9 +8,7 @@ local func = function(i, s)
   -- Add to existing value
   test_data.out.i = test_data.out.i + i
   -- Append string, but only if string is passed
-  if s ~= nil then
-    test_data.out.s = test_data.out.s .. s
-  end
+  if s ~= nil then test_data.out.s = test_data.out.s .. s end
   -- Return some new integer value
   return i * 2
 end


### PR DESCRIPTION


## Purpose of change (The Why)

- save that vertical space!
- makes writing single-line lambda less painful than necessary

## Describe the solution (The How)

- set [`collapseSimpleStatement` as `Always`](https://github.com/RubixDev/dprint-plugin-stylua#configuration)
- apply changes

## Checklist



### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


