### PR TITLE
chore: better lua field annotations sorting

### DIFF
--- a/data/raw/generate_types.lua
+++ b/data/raw/generate_types.lua
@@ -8,11 +8,13 @@ end
 Helper function to sort a table by key or using a custom sort function.
 Uses 'pairs' for iteration to be compatible with sol2 table/map proxies.
 ]]
----@param t table
----@param f? fun(a:any, b:any):boolean
+---@generic T
+---@param t T[]
+---@param f? fun(a: T, b: T):boolean
 ---@return table
 local sorted_by = function(t, f)
   if not f then f = sort_by_tostring end
+  ---@type T[]
   local sorted = {}
   for k, v in pairs(t) do
     table.insert(sorted, { k = k, v = v })
@@ -256,6 +258,14 @@ local fmt_constructor_field = function(typename, ctors)
   return "---@field new " .. signature_union .. "\n"
 end
 
+---@param name string
+function field_sort_order(name)
+  if string.match(name, "^__") then return 3 end -- metamethods
+  if name == "deserialize" then return 2 end
+  if name == "serialize" then return 1 end
+  return 0
+end
+
 ---@diagnostic disable-next-line: undefined-global
 -- Main function to generate the LuaLS type definition file content.
 ---@return string
@@ -305,7 +315,13 @@ game = {}
       ret = ret .. "---@class " .. name .. bases_str .. "\n"
 
       -- Process Members (Variables and Functions)
-      local members_sorted = sorted_by(members)
+      local members_sorted = sorted_by(members, function(a, b)
+        local a_priority = field_sort_order(a.v.name)
+        local b_priority = field_sort_order(b.v.name)
+
+        if a_priority ~= b_priority then return a_priority < b_priority end
+        return a.v.name < b.v.name
+      end)
       for _, mem_item in ipairs(members_sorted) do
         local member = mem_item.v
         local member_name_str = tostring(member.name)

--- a/data/raw/generate_types.lua
+++ b/data/raw/generate_types.lua
@@ -258,11 +258,12 @@ local fmt_constructor_field = function(typename, ctors)
   return "---@field new " .. signature_union .. "\n"
 end
 
----@param name string
-function field_sort_order(name)
-  if string.match(name, "^__") then return 3 end -- metamethods
-  if name == "deserialize" then return 2 end
-  if name == "serialize" then return 1 end
+---@param member { name: string, type: "var" | "func" }
+function field_sort_order(member)
+  if string.match(member.name, "^__") then return 4 end -- metamethods
+  if member.name == "deserialize" then return 3 end
+  if member.name == "serialize" then return 2 end
+  if member.type == "func" then return 1 end
   return 0
 end
 
@@ -316,8 +317,8 @@ game = {}
 
       -- Process Members (Variables and Functions)
       local members_sorted = sorted_by(members, function(a, b)
-        local a_priority = field_sort_order(a.v.name)
-        local b_priority = field_sort_order(b.v.name)
+        local a_priority = field_sort_order(a.v)
+        local b_priority = field_sort_order(b.v)
 
         if a_priority ~= b_priority then return a_priority < b_priority end
         return a.v.name < b.v.name

--- a/lua_annotations.lua
+++ b/lua_annotations.lua
@@ -14,472 +14,472 @@ game = {}
 --================---- Classes ----================
 
 ---@class ActivityTypeId
----@field obj fun(arg1: ActivityTypeId): ActivityTypeRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: ActivityTypeId): boolean
 ---@field is_valid fun(arg1: ActivityTypeId): boolean
----@field str fun(arg1: ActivityTypeId): string
 ---@field NULL_ID fun(): ActivityTypeId
----@field __tostring fun(arg1: ActivityTypeId): string
+---@field obj fun(arg1: ActivityTypeId): ActivityTypeRaw
+---@field str fun(arg1: ActivityTypeId): string
 ---@field serialize fun(arg1: ActivityTypeId)
 ---@field deserialize fun(arg1: ActivityTypeId)
+---@field __tostring fun(arg1: ActivityTypeId): string
 ---@field new fun(): ActivityTypeId | fun(arg1: ActivityTypeId): ActivityTypeId | fun(arg1: string): ActivityTypeId
 ActivityTypeId = {}
 
 ---@class Angle
----@field from_radians fun(arg1: number): Angle
----@field to_radians fun(arg1: Angle): number
----@field from_degrees fun(arg1: number): Angle
----@field to_degrees fun(arg1: Angle): number
 ---@field from_arcmin fun(arg1: number): Angle
+---@field from_degrees fun(arg1: number): Angle
+---@field from_radians fun(arg1: number): Angle
 ---@field to_arcmin fun(arg1: Angle): number
+---@field to_degrees fun(arg1: Angle): number
+---@field to_radians fun(arg1: Angle): number
 ---@field __eq fun(arg1: Angle, arg2: Angle): boolean
----@field __lt fun(arg1: Angle, arg2: Angle): boolean
 ---@field __le fun(arg1: Angle, arg2: Angle): boolean
+---@field __lt fun(arg1: Angle, arg2: Angle): boolean
 Angle = {}
 
 ---@class Avatar : Player, Character, Creature
 Avatar = {}
 
 ---@class BionicDataId
----@field obj fun(arg1: BionicDataId): BionicDataRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: BionicDataId): boolean
 ---@field is_valid fun(arg1: BionicDataId): boolean
----@field str fun(arg1: BionicDataId): string
 ---@field NULL_ID fun(): BionicDataId
----@field __tostring fun(arg1: BionicDataId): string
+---@field obj fun(arg1: BionicDataId): BionicDataRaw
+---@field str fun(arg1: BionicDataId): string
 ---@field serialize fun(arg1: BionicDataId)
 ---@field deserialize fun(arg1: BionicDataId)
+---@field __tostring fun(arg1: BionicDataId): string
 ---@field new fun(): BionicDataId | fun(arg1: BionicDataId): BionicDataId | fun(arg1: string): BionicDataId
 BionicDataId = {}
 
 ---@class BodyPartTypeId
----@field obj fun(arg1: BodyPartTypeId): BodyPartTypeRaw
----@field deserialize fun(arg1: BodyPartTypeId)
----@field int_id fun(arg1: BodyPartTypeId): BodyPartTypeIntId
 ---@field implements_int_id fun(): boolean
+---@field int_id fun(arg1: BodyPartTypeId): BodyPartTypeIntId
 ---@field is_null fun(arg1: BodyPartTypeId): boolean
 ---@field is_valid fun(arg1: BodyPartTypeId): boolean
----@field str fun(arg1: BodyPartTypeId): string
 ---@field NULL_ID fun(): BodyPartTypeId
----@field __tostring fun(arg1: BodyPartTypeId): string
+---@field obj fun(arg1: BodyPartTypeId): BodyPartTypeRaw
+---@field str fun(arg1: BodyPartTypeId): string
 ---@field serialize fun(arg1: BodyPartTypeId)
+---@field deserialize fun(arg1: BodyPartTypeId)
+---@field __tostring fun(arg1: BodyPartTypeId): string
 ---@field new fun(): BodyPartTypeId | fun(arg1: BodyPartTypeId): BodyPartTypeId | fun(arg1: BodyPartTypeIntId): BodyPartTypeId | fun(arg1: string): BodyPartTypeId
 BodyPartTypeId = {}
 
 ---@class BodyPartTypeIntId
+---@field is_valid fun(arg1: BodyPartTypeIntId): boolean
 ---@field obj fun(arg1: BodyPartTypeIntId): BodyPartTypeRaw
 ---@field str_id fun(arg1: BodyPartTypeIntId): BodyPartTypeId
----@field is_valid fun(arg1: BodyPartTypeIntId): boolean
 ---@field __tostring fun(arg1: BodyPartTypeIntId): string
 ---@field new fun(): BodyPartTypeIntId | fun(arg1: BodyPartTypeIntId): BodyPartTypeIntId | fun(arg1: BodyPartTypeId): BodyPartTypeIntId
 BodyPartTypeIntId = {}
 
 ---@class Character : Creature
----@field name string
----@field get_dex fun(arg1: Character): integer
----@field global_sm_location fun(arg1: Character): Tripoint
----@field has_mabuff fun(arg1: Character, arg2: MartialArtsBuffId): boolean
----@field mabuff_tohit_bonus fun(arg1: Character): number
----@field mabuff_dodge_bonus fun(arg1: Character): number
----@field mabuff_block_bonus fun(arg1: Character): integer
----@field mabuff_speed_bonus fun(arg1: Character): integer
----@field mabuff_arpen_bonus fun(arg1: Character, arg2: DamageType): integer
----@field mabuff_damage_mult fun(arg1: Character, arg2: DamageType): number
----@field mabuff_damage_bonus fun(arg1: Character, arg2: DamageType): integer
----@field mabuff_attack_cost_penalty fun(arg1: Character): integer
----@field get_per fun(arg1: Character): integer
----@field mabuff_attack_cost_mult fun(arg1: Character): number
----@field mutation_effect fun(arg1: Character, arg2: MutationBranchId)
----@field mutation_loss_effect fun(arg1: Character, arg2: MutationBranchId)
----@field has_active_mutation fun(arg1: Character, arg2: MutationBranchId): boolean
----@field mutate fun(arg1: Character)
----@field mutation_ok fun(arg1: Character, arg2: MutationBranchId, arg3: boolean, arg4: boolean): boolean
----@field mutate_category fun(arg1: Character, arg2: MutationCategoryTraitId)
----@field mutate_towards fun(arg1: Character, arg2: any, arg3: integer): boolean
----@field mutate_towards fun(arg1: Character, arg2: MutationBranchId): boolean
----@field mutate_towards fun(arg1: Character, arg2: any, arg3: integer): boolean | fun(arg1: Character, arg2: MutationBranchId): boolean
----@field get_int fun(arg1: Character): integer
----@field remove_mutation fun(arg1: Character, arg2: MutationBranchId, arg3: boolean)
----@field has_child_flag fun(arg1: Character, arg2: MutationBranchId): boolean
----@field remove_child_flag fun(arg1: Character, arg2: MutationBranchId)
----@field get_highest_category fun(arg1: Character): MutationCategoryTraitId
----@field is_weak_to_water fun(arg1: Character): boolean
----@field mutation_armor fun(arg1: Character, arg2: BodyPartTypeIntId, arg3: DamageType): number
----@field get_bionics fun(arg1: Character): any
----@field has_bionic fun(arg1: Character, arg2: BionicDataId): boolean
----@field has_active_bionic fun(arg1: Character, arg2: BionicDataId): boolean
----@field has_any_bionic fun(arg1: Character): boolean
----@field get_str_base fun(arg1: Character): integer
----@field has_bionics fun(arg1: Character): boolean
----@field clear_bionics fun(arg1: Character)
----@field get_used_bionics_slots fun(arg1: Character, arg2: BodyPartTypeIntId): integer
----@field get_total_bionics_slots fun(arg1: Character, arg2: BodyPartTypeIntId): integer
----@field get_free_bionics_slots fun(arg1: Character, arg2: BodyPartTypeIntId): integer
----@field remove_bionic fun(arg1: Character, arg2: BionicDataId)
+---@field activate_mutation fun(arg1: Character, arg2: MutationBranchId)
+---@field add_addiction fun(arg1: Character, arg2: AddictionType, arg3: integer)
 ---@field add_bionic fun(arg1: Character, arg2: BionicDataId)
----@field get_power_level fun(arg1: Character): Energy
----@field get_max_power_level fun(arg1: Character): Energy
----@field mod_power_level fun(arg1: Character, arg2: Energy)
----@field get_dex_base fun(arg1: Character): integer
----@field mod_max_power_level fun(arg1: Character, arg2: Energy)
----@field set_power_level fun(arg1: Character, arg2: Energy)
----@field set_max_power_level fun(arg1: Character, arg2: Energy)
----@field is_max_power fun(arg1: Character): boolean
----@field has_power fun(arg1: Character): boolean
----@field has_max_power fun(arg1: Character): boolean
----@field is_worn fun(arg1: Character, arg2: Item): boolean
----@field weight_carried fun(arg1: Character): Mass
----@field volume_carried fun(arg1: Character): Volume
----@field volume_capacity fun(arg1: Character): Volume
----@field get_per_base fun(arg1: Character): integer
+---@field addiction_level fun(arg1: Character, arg2: AddictionType): integer
+---@field add_item_with_id fun(arg1: Character, arg2: ItypeId, arg3: integer) @Adds an item with the given id and amount
+---@field add_morale fun(arg1: Character, arg2: MoraleTypeDataId, arg3: integer, arg4: integer, arg5: TimeDuration, arg6: TimeDuration, arg7: boolean, arg8: ItypeRaw)
+---@field age fun(arg1: Character): integer
+---@field all_items fun(arg1: Character, arg2: boolean): any @Gets all items
+---@field all_items_with_flag fun(arg1: Character, arg2: JsonFlagId, arg3: boolean): any @Gets all items with the given flag
+---@field assign_activity fun(arg1: Character, arg2: ActivityTypeId, arg3: integer, arg4: integer, arg5: integer, arg6: string)
+---@field base_age fun(arg1: Character): integer
+---@field base_height fun(arg1: Character): integer
+---@field bionic_armor_bonus fun(arg1: Character, arg2: BodyPartTypeIntId, arg3: DamageType): number
+---@field bionics_weight fun(arg1: Character): Mass
+---@field blood_loss fun(arg1: Character, arg2: BodyPartTypeIntId): integer
+---@field blossoms fun(arg1: Character)
+---@field bodypart_exposure fun(arg1: Character): any
+---@field bodyweight fun(arg1: Character): Mass
+---@field cancel_activity fun(arg1: Character)
+---@field can_hear fun(arg1: Character, arg2: Tripoint, arg3: integer): boolean
+---@field can_mount fun(arg1: Character, arg2: Monster): boolean
 ---@field can_pick_volume fun(arg1: Character, arg2: Volume): boolean
 ---@field can_pick_weight fun(arg1: Character, arg2: Mass, arg3: boolean): boolean
----@field is_armed fun(arg1: Character): boolean
----@field can_wield fun(arg1: Character, arg2: Item): boolean
----@field wield fun(arg1: Character, arg2: Item): boolean
+---@field can_run fun(arg1: Character): boolean
 ---@field can_unwield fun(arg1: Character, arg2: Item): boolean
----@field unwield fun(arg1: Character): boolean
----@field is_wielding fun(arg1: Character, arg2: Item): boolean
----@field is_wearing fun(arg1: Character, arg2: Item): boolean
----@field is_wearing_on_bp fun(arg1: Character, arg2: ItypeId, arg3: BodyPartTypeIntId): boolean
----@field get_int_base fun(arg1: Character): integer
----@field worn_with_flag fun(arg1: Character, arg2: JsonFlagId, arg3: BodyPartTypeIntId): boolean
----@field worn_with_id fun(arg1: Character, arg2: ItypeId, arg3: BodyPartTypeIntId): boolean
----@field item_worn_with_flag fun(arg1: Character, arg2: JsonFlagId, arg3: BodyPartTypeIntId): Item
----@field item_worn_with_id fun(arg1: Character, arg2: ItypeId, arg3: BodyPartTypeIntId): Item
----@field get_skill_level fun(arg1: Character, arg2: SkillId): integer
----@field get_all_skills fun(arg1: Character): SkillLevelMap
----@field get_skill_level_object fun(arg1: Character, arg2: SkillId): SkillLevel
----@field set_skill_level fun(arg1: Character, arg2: SkillId, arg3: integer)
----@field mod_skill_level fun(arg1: Character, arg2: SkillId, arg3: integer)
----@field rust_rate fun(arg1: Character): integer
----@field get_str_bonus fun(arg1: Character): integer
----@field practice fun(arg1: Character, arg2: SkillId, arg3: integer, arg4: integer, arg5: boolean)
----@field read_speed fun(arg1: Character, arg2: boolean): integer
----@field get_time_died fun(arg1: Character): TimePoint
----@field is_rad_immune fun(arg1: Character): boolean
----@field is_throw_immune fun(arg1: Character): boolean
----@field rest_quality fun(arg1: Character): number
----@field healing_rate fun(arg1: Character, arg2: number): number
----@field healing_rate_medicine fun(arg1: Character, arg2: number, arg3: BodyPartTypeIntId): number
----@field mutation_value fun(arg1: Character, arg2: string): number
----@field get_base_traits fun(arg1: Character): any
----@field get_dex_bonus fun(arg1: Character): integer
----@field get_mutations fun(arg1: Character, arg2: boolean): any
----@field clear_skills fun(arg1: Character)
+---@field can_wield fun(arg1: Character, arg2: Item): boolean
+---@field cash integer
+---@field check_mount_is_spooked fun(arg1: Character): boolean
+---@field check_mount_will_move fun(arg1: Character, arg2: Tripoint): boolean
+---@field clear_bionics fun(arg1: Character)
+---@field clear_morale fun(arg1: Character)
 ---@field clear_mutations fun(arg1: Character)
+---@field clear_skills fun(arg1: Character)
+---@field cough fun(arg1: Character, arg2: boolean, arg3: integer)
 ---@field crossed_threshold fun(arg1: Character): boolean
----@field add_addiction fun(arg1: Character, arg2: AddictionType, arg3: integer)
----@field rem_addiction fun(arg1: Character, arg2: AddictionType)
----@field has_addiction fun(arg1: Character, arg2: AddictionType): boolean
----@field addiction_level fun(arg1: Character, arg2: AddictionType): integer
----@field is_hauling fun(arg1: Character): boolean
----@field add_item_with_id fun(arg1: Character, arg2: ItypeId, arg3: integer) @Adds an item with the given id and amount
----@field get_per_bonus fun(arg1: Character): integer
----@field has_item_with_id fun(arg1: Character, arg2: ItypeId, arg3: boolean): boolean @Checks for an item with the given id
----@field get_item_with_id fun(arg1: Character, arg2: ItypeId, arg3: boolean): Item @Gets the first occurrence of an item with the given id
----@field has_item_with_flag fun(arg1: Character, arg2: JsonFlagId, arg3: boolean): boolean @Checks for an item with the given flag
----@field all_items_with_flag fun(arg1: Character, arg2: JsonFlagId, arg3: boolean): any @Gets all items with the given flag
----@field all_items fun(arg1: Character, arg2: boolean): any @Gets all items
----@field assign_activity fun(arg1: Character, arg2: ActivityTypeId, arg3: integer, arg4: integer, arg5: integer, arg6: string)
----@field has_activity fun(arg1: Character, arg2: ActivityTypeId): boolean
----@field cancel_activity fun(arg1: Character)
----@field metabolic_rate fun(arg1: Character): number
----@field base_age fun(arg1: Character): integer
----@field male boolean
----@field get_int_bonus fun(arg1: Character): integer
----@field set_base_age fun(arg1: Character, arg2: integer)
----@field mod_base_age fun(arg1: Character, arg2: integer)
----@field age fun(arg1: Character): integer
----@field base_height fun(arg1: Character): integer
----@field set_base_height fun(arg1: Character, arg2: integer)
----@field mod_base_height fun(arg1: Character, arg2: integer)
----@field height fun(arg1: Character): integer
----@field bodyweight fun(arg1: Character): Mass
----@field bionics_weight fun(arg1: Character): Mass
+---@field deactivate_mutation fun(arg1: Character, arg2: MutationBranchId)
+---@field dismount fun(arg1: Character)
+---@field expose_to_disease fun(arg1: Character, arg2: DiseaseTypeId)
+---@field fall_asleep fun(arg1: Character) | fun(arg1: Character, arg2: TimeDuration)
+---@field focus_pool integer
+---@field follower_ids any
+---@field forced_dismount fun(arg1: Character)
+---@field get_all_skills fun(arg1: Character): SkillLevelMap
 ---@field get_armor_acid fun(arg1: Character, arg2: BodyPartTypeIntId): integer
----@field set_str_bonus fun(arg1: Character, arg2: integer)
----@field get_stim fun(arg1: Character): integer
----@field set_stim fun(arg1: Character, arg2: integer)
----@field mod_stim fun(arg1: Character, arg2: integer)
+---@field get_base_traits fun(arg1: Character): any
+---@field get_bionics fun(arg1: Character): any
+---@field get_dex fun(arg1: Character): integer
+---@field get_dex_base fun(arg1: Character): integer
+---@field get_dex_bonus fun(arg1: Character): integer
+---@field get_faction_id fun(arg1: Character): FactionId
+---@field get_fatigue fun(arg1: Character): integer
+---@field get_free_bionics_slots fun(arg1: Character, arg2: BodyPartTypeIntId): integer
+---@field get_healthy fun(arg1: Character): integer
+---@field get_healthy_mod fun(arg1: Character): integer
+---@field get_highest_category fun(arg1: Character): MutationCategoryTraitId
+---@field get_hostile_creatures fun(arg1: Character, arg2: integer): any
+---@field getID fun(arg1: Character): CharacterId
+---@field get_int fun(arg1: Character): integer
+---@field get_int_base fun(arg1: Character): integer
+---@field get_int_bonus fun(arg1: Character): integer
+---@field get_item_with_id fun(arg1: Character, arg2: ItypeId, arg3: boolean): Item @Gets the first occurrence of an item with the given id
+---@field get_kcal_percent fun(arg1: Character): number
+---@field get_lowest_hp fun(arg1: Character): integer
+---@field get_max_power_level fun(arg1: Character): Energy
+---@field get_morale fun(arg1: Character, arg2: MoraleTypeDataId): integer
+---@field get_morale_level fun(arg1: Character): integer
+---@field get_movement_mode fun(arg1: Character): CharacterMoveMode
+---@field get_mutations fun(arg1: Character, arg2: boolean): any
+---@field get_painkiller fun(arg1: Character): integer
+---@field get_part_encumbrance fun(arg1: Character, arg2: BodyPartTypeId): integer
+---@field get_part_temp_btu fun(arg1: Character, arg2: BodyPartTypeIntId): integer @Gets the current temperature of a specific body part (in Body Temperature Units).
+---@field get_per fun(arg1: Character): integer
+---@field get_per_base fun(arg1: Character): integer
+---@field get_per_bonus fun(arg1: Character): integer
+---@field get_power_level fun(arg1: Character): Energy
 ---@field get_rad fun(arg1: Character): integer
----@field set_rad fun(arg1: Character, arg2: integer)
----@field mod_rad fun(arg1: Character, arg2: integer)
+---@field get_shout_volume fun(arg1: Character): integer
+---@field get_skill_level fun(arg1: Character, arg2: SkillId): integer
+---@field get_skill_level_object fun(arg1: Character, arg2: SkillId): SkillLevel
+---@field get_sleep_deprivation fun(arg1: Character): integer
 ---@field get_stamina fun(arg1: Character): integer
 ---@field get_stamina_max fun(arg1: Character): integer
----@field set_stamina fun(arg1: Character, arg2: integer)
----@field mod_stamina fun(arg1: Character, arg2: integer)
----@field set_dex_bonus fun(arg1: Character, arg2: integer)
----@field wake_up fun(arg1: Character)
----@field get_shout_volume fun(arg1: Character): integer
----@field shout fun(arg1: Character, arg2: string, arg3: boolean)
----@field vomit fun(arg1: Character)
----@field restore_scent fun(arg1: Character)
----@field mod_painkiller fun(arg1: Character, arg2: integer)
----@field set_painkiller fun(arg1: Character, arg2: integer)
----@field get_painkiller fun(arg1: Character): integer
----@field spores fun(arg1: Character)
----@field blossoms fun(arg1: Character)
----@field set_per_bonus fun(arg1: Character, arg2: integer)
----@field rooted fun(arg1: Character)
----@field fall_asleep fun(arg1: Character) | fun(arg1: Character, arg2: TimeDuration)
----@field get_hostile_creatures fun(arg1: Character, arg2: integer): any
----@field get_visible_creatures fun(arg1: Character, arg2: integer): any
----@field wearing_something_on fun(arg1: Character, arg2: BodyPartTypeIntId): boolean
----@field is_wearing_helmet fun(arg1: Character): boolean
----@field get_morale_level fun(arg1: Character): integer
----@field add_morale fun(arg1: Character, arg2: MoraleTypeDataId, arg3: integer, arg4: integer, arg5: TimeDuration, arg6: TimeDuration, arg7: boolean, arg8: ItypeRaw)
----@field has_morale fun(arg1: Character, arg2: MoraleTypeDataId): boolean
----@field get_morale fun(arg1: Character, arg2: MoraleTypeDataId): integer
----@field set_int_bonus fun(arg1: Character, arg2: integer)
----@field rem_morale fun(arg1: Character, arg2: MoraleTypeDataId)
----@field clear_morale fun(arg1: Character)
----@field has_morale_to_read fun(arg1: Character): boolean
----@field has_morale_to_craft fun(arg1: Character): boolean
----@field knows_recipe fun(arg1: Character, arg2: RecipeId): boolean
----@field learn_recipe fun(arg1: Character, arg2: RecipeId)
----@field suffer fun(arg1: Character)
----@field irradiate fun(arg1: Character, arg2: number, arg3: boolean): boolean
----@field can_hear fun(arg1: Character, arg2: Tripoint, arg3: integer): boolean
----@field hearing_ability fun(arg1: Character): number
----@field mod_str_bonus fun(arg1: Character, arg2: integer)
----@field get_lowest_hp fun(arg1: Character): integer
----@field bodypart_exposure fun(arg1: Character): any
----@field mod_dex_bonus fun(arg1: Character, arg2: integer)
----@field mod_per_bonus fun(arg1: Character, arg2: integer)
----@field mod_int_bonus fun(arg1: Character, arg2: integer)
----@field get_healthy fun(arg1: Character): integer
----@field focus_pool integer
----@field get_healthy_mod fun(arg1: Character): integer
----@field mod_healthy fun(arg1: Character, arg2: integer)
----@field mod_healthy_mod fun(arg1: Character, arg2: integer, arg3: integer)
----@field set_healthy fun(arg1: Character, arg2: integer)
----@field set_healthy_mod fun(arg1: Character, arg2: integer)
+---@field get_stim fun(arg1: Character): integer
 ---@field get_stored_kcal fun(arg1: Character): integer
----@field max_stored_kcal fun(arg1: Character): integer
----@field get_kcal_percent fun(arg1: Character): number
----@field get_thirst fun(arg1: Character): integer
----@field get_fatigue fun(arg1: Character): integer
----@field cash integer
----@field get_sleep_deprivation fun(arg1: Character): integer
----@field mod_stored_kcal fun(arg1: Character, arg2: integer)
----@field mod_thirst fun(arg1: Character, arg2: integer)
----@field mod_fatigue fun(arg1: Character, arg2: integer)
----@field mod_sleep_deprivation fun(arg1: Character, arg2: integer)
----@field set_stored_kcal fun(arg1: Character, arg2: integer)
----@field set_thirst fun(arg1: Character, arg2: integer)
----@field set_fatigue fun(arg1: Character, arg2: integer)
----@field set_sleep_deprivation fun(arg1: Character, arg2: integer)
----@field get_faction_id fun(arg1: Character): FactionId
----@field follower_ids any
----@field set_faction_id fun(arg1: Character, arg2: FactionId)
----@field sight_impaired fun(arg1: Character): boolean
----@field has_alarm_clock fun(arg1: Character): boolean
----@field has_watch fun(arg1: Character): boolean
----@field get_part_temp_btu fun(arg1: Character, arg2: BodyPartTypeIntId): integer @Gets the current temperature of a specific body part (in Body Temperature Units).
----@field set_part_temp_btu fun(arg1: Character, arg2: BodyPartTypeIntId, arg3: integer) @Sets a specific body part to a given temperature (in Body Temperature Units).
----@field get_temp_btu fun(arg1: Character): any @Gets all bodyparts and their associated temperatures (in Body Temperature Units).
----@field set_temp_btu fun(arg1: Character, arg2: integer) @Sets ALL body parts on a creature to the given temperature (in Body Temperature Units).
----@field blood_loss fun(arg1: Character, arg2: BodyPartTypeIntId): integer
----@field get_part_encumbrance fun(arg1: Character, arg2: BodyPartTypeId): integer
----@field mutation_category_level any
----@field is_wearing_power_armor fun(arg1: Character, arg2: boolean): boolean
----@field is_wearing_active_power_armor fun(arg1: Character): boolean
----@field is_wearing_active_optcloak fun(arg1: Character): boolean
----@field in_climate_control fun(arg1: Character): boolean
----@field is_blind fun(arg1: Character): boolean
----@field is_invisible fun(arg1: Character): boolean
----@field get_movement_mode fun(arg1: Character): CharacterMoveMode
----@field set_movement_mode fun(arg1: Character, arg2: CharacterMoveMode)
----@field expose_to_disease fun(arg1: Character, arg2: DiseaseTypeId)
----@field is_quiet fun(arg1: Character): boolean
----@field getID fun(arg1: Character): CharacterId
----@field is_stealthy fun(arg1: Character): boolean
----@field cough fun(arg1: Character, arg2: boolean, arg3: integer)
----@field bionic_armor_bonus fun(arg1: Character, arg2: BodyPartTypeIntId, arg3: DamageType): number
----@field mabuff_armor_bonus fun(arg1: Character, arg2: DamageType): integer
----@field has_base_trait fun(arg1: Character, arg2: MutationBranchId): boolean
----@field has_trait_flag fun(arg1: Character, arg2: JsonTraitFlagId): boolean
----@field has_opposite_trait fun(arg1: Character, arg2: MutationBranchId): boolean
----@field set_mutation fun(arg1: Character, arg2: MutationBranchId)
----@field unset_mutation fun(arg1: Character, arg2: MutationBranchId)
----@field activate_mutation fun(arg1: Character, arg2: MutationBranchId)
----@field setID fun(arg1: Character, arg2: CharacterId, arg3: boolean)
----@field deactivate_mutation fun(arg1: Character, arg2: MutationBranchId)
----@field can_mount fun(arg1: Character, arg2: Monster): boolean
----@field mount_creature fun(arg1: Character, arg2: Monster)
----@field is_mounted fun(arg1: Character): boolean
----@field check_mount_will_move fun(arg1: Character, arg2: Tripoint): boolean
----@field check_mount_is_spooked fun(arg1: Character): boolean
----@field dismount fun(arg1: Character)
----@field forced_dismount fun(arg1: Character)
----@field is_deaf fun(arg1: Character): boolean
----@field has_two_arms fun(arg1: Character): boolean
 ---@field get_str fun(arg1: Character): integer
+---@field get_str_base fun(arg1: Character): integer
+---@field get_str_bonus fun(arg1: Character): integer
+---@field get_temp_btu fun(arg1: Character): any @Gets all bodyparts and their associated temperatures (in Body Temperature Units).
+---@field get_thirst fun(arg1: Character): integer
+---@field get_time_died fun(arg1: Character): TimePoint
+---@field get_total_bionics_slots fun(arg1: Character, arg2: BodyPartTypeIntId): integer
+---@field get_used_bionics_slots fun(arg1: Character, arg2: BodyPartTypeIntId): integer
+---@field get_visible_creatures fun(arg1: Character, arg2: integer): any
 ---@field get_working_arm_count fun(arg1: Character): integer
 ---@field get_working_leg_count fun(arg1: Character): integer
----@field is_limb_disabled fun(arg1: Character, arg2: BodyPartTypeIntId): boolean
----@field is_limb_broken fun(arg1: Character, arg2: BodyPartTypeIntId): boolean
----@field can_run fun(arg1: Character): boolean
----@field hurtall fun(arg1: Character, arg2: integer, arg3: Creature, arg4: boolean)
----@field hitall fun(arg1: Character, arg2: integer, arg3: integer, arg4: Creature): integer
+---@field global_sm_location fun(arg1: Character): Tripoint
+---@field global_square_location fun(arg1: Character): Tripoint
+---@field has_active_bionic fun(arg1: Character, arg2: BionicDataId): boolean
+---@field has_active_mutation fun(arg1: Character, arg2: MutationBranchId): boolean
+---@field has_activity fun(arg1: Character, arg2: ActivityTypeId): boolean
+---@field has_addiction fun(arg1: Character, arg2: AddictionType): boolean
+---@field has_alarm_clock fun(arg1: Character): boolean
+---@field has_any_bionic fun(arg1: Character): boolean
+---@field has_base_trait fun(arg1: Character, arg2: MutationBranchId): boolean
+---@field has_bionic fun(arg1: Character, arg2: BionicDataId): boolean
+---@field has_bionics fun(arg1: Character): boolean
+---@field has_child_flag fun(arg1: Character, arg2: MutationBranchId): boolean
+---@field has_item_with_flag fun(arg1: Character, arg2: JsonFlagId, arg3: boolean): boolean @Checks for an item with the given flag
+---@field has_item_with_id fun(arg1: Character, arg2: ItypeId, arg3: boolean): boolean @Checks for an item with the given id
+---@field has_mabuff fun(arg1: Character, arg2: MartialArtsBuffId): boolean
+---@field has_max_power fun(arg1: Character): boolean
+---@field has_morale fun(arg1: Character, arg2: MoraleTypeDataId): boolean
+---@field has_morale_to_craft fun(arg1: Character): boolean
+---@field has_morale_to_read fun(arg1: Character): boolean
+---@field has_opposite_trait fun(arg1: Character, arg2: MutationBranchId): boolean
+---@field has_power fun(arg1: Character): boolean
+---@field has_trait_flag fun(arg1: Character, arg2: JsonTraitFlagId): boolean
+---@field has_two_arms fun(arg1: Character): boolean
+---@field has_watch fun(arg1: Character): boolean
 ---@field heal fun(arg1: Character, arg2: BodyPartTypeIntId, arg3: integer)
 ---@field healall fun(arg1: Character, arg2: integer)
----@field global_square_location fun(arg1: Character): Tripoint
+---@field healing_rate fun(arg1: Character, arg2: number): number
+---@field healing_rate_medicine fun(arg1: Character, arg2: number, arg3: BodyPartTypeIntId): number
+---@field hearing_ability fun(arg1: Character): number
+---@field height fun(arg1: Character): integer
+---@field hitall fun(arg1: Character, arg2: integer, arg3: integer, arg4: Creature): integer
+---@field hurtall fun(arg1: Character, arg2: integer, arg3: Creature, arg4: boolean)
+---@field in_climate_control fun(arg1: Character): boolean
+---@field irradiate fun(arg1: Character, arg2: number, arg3: boolean): boolean
+---@field is_armed fun(arg1: Character): boolean
+---@field is_blind fun(arg1: Character): boolean
+---@field is_deaf fun(arg1: Character): boolean
+---@field is_hauling fun(arg1: Character): boolean
+---@field is_invisible fun(arg1: Character): boolean
+---@field is_limb_broken fun(arg1: Character, arg2: BodyPartTypeIntId): boolean
+---@field is_limb_disabled fun(arg1: Character, arg2: BodyPartTypeIntId): boolean
+---@field is_max_power fun(arg1: Character): boolean
+---@field is_mounted fun(arg1: Character): boolean
+---@field is_quiet fun(arg1: Character): boolean
+---@field is_rad_immune fun(arg1: Character): boolean
+---@field is_stealthy fun(arg1: Character): boolean
+---@field is_throw_immune fun(arg1: Character): boolean
+---@field is_weak_to_water fun(arg1: Character): boolean
+---@field is_wearing fun(arg1: Character, arg2: Item): boolean
+---@field is_wearing_active_optcloak fun(arg1: Character): boolean
+---@field is_wearing_active_power_armor fun(arg1: Character): boolean
+---@field is_wearing_helmet fun(arg1: Character): boolean
+---@field is_wearing_on_bp fun(arg1: Character, arg2: ItypeId, arg3: BodyPartTypeIntId): boolean
+---@field is_wearing_power_armor fun(arg1: Character, arg2: boolean): boolean
+---@field is_wielding fun(arg1: Character, arg2: Item): boolean
+---@field is_worn fun(arg1: Character, arg2: Item): boolean
+---@field item_worn_with_flag fun(arg1: Character, arg2: JsonFlagId, arg3: BodyPartTypeIntId): Item
+---@field item_worn_with_id fun(arg1: Character, arg2: ItypeId, arg3: BodyPartTypeIntId): Item
+---@field knows_recipe fun(arg1: Character, arg2: RecipeId): boolean
+---@field learn_recipe fun(arg1: Character, arg2: RecipeId)
+---@field mabuff_armor_bonus fun(arg1: Character, arg2: DamageType): integer
+---@field mabuff_arpen_bonus fun(arg1: Character, arg2: DamageType): integer
+---@field mabuff_attack_cost_mult fun(arg1: Character): number
+---@field mabuff_attack_cost_penalty fun(arg1: Character): integer
+---@field mabuff_block_bonus fun(arg1: Character): integer
+---@field mabuff_damage_bonus fun(arg1: Character, arg2: DamageType): integer
+---@field mabuff_damage_mult fun(arg1: Character, arg2: DamageType): number
+---@field mabuff_dodge_bonus fun(arg1: Character): number
+---@field mabuff_speed_bonus fun(arg1: Character): integer
+---@field mabuff_tohit_bonus fun(arg1: Character): number
+---@field male boolean
+---@field max_stored_kcal fun(arg1: Character): integer
+---@field metabolic_rate fun(arg1: Character): number
+---@field mod_base_age fun(arg1: Character, arg2: integer)
+---@field mod_base_height fun(arg1: Character, arg2: integer)
+---@field mod_dex_bonus fun(arg1: Character, arg2: integer)
+---@field mod_fatigue fun(arg1: Character, arg2: integer)
+---@field mod_healthy fun(arg1: Character, arg2: integer)
+---@field mod_healthy_mod fun(arg1: Character, arg2: integer, arg3: integer)
+---@field mod_int_bonus fun(arg1: Character, arg2: integer)
+---@field mod_max_power_level fun(arg1: Character, arg2: Energy)
+---@field mod_painkiller fun(arg1: Character, arg2: integer)
+---@field mod_per_bonus fun(arg1: Character, arg2: integer)
+---@field mod_power_level fun(arg1: Character, arg2: Energy)
+---@field mod_rad fun(arg1: Character, arg2: integer)
+---@field mod_skill_level fun(arg1: Character, arg2: SkillId, arg3: integer)
+---@field mod_sleep_deprivation fun(arg1: Character, arg2: integer)
+---@field mod_stamina fun(arg1: Character, arg2: integer)
+---@field mod_stim fun(arg1: Character, arg2: integer)
+---@field mod_stored_kcal fun(arg1: Character, arg2: integer)
+---@field mod_str_bonus fun(arg1: Character, arg2: integer)
+---@field mod_thirst fun(arg1: Character, arg2: integer)
+---@field mount_creature fun(arg1: Character, arg2: Monster)
+---@field mutate fun(arg1: Character)
+---@field mutate_category fun(arg1: Character, arg2: MutationCategoryTraitId)
+---@field mutate_towards fun(arg1: Character, arg2: MutationBranchId): boolean
+---@field mutate_towards fun(arg1: Character, arg2: any, arg3: integer): boolean | fun(arg1: Character, arg2: MutationBranchId): boolean
+---@field mutate_towards fun(arg1: Character, arg2: any, arg3: integer): boolean
+---@field mutation_armor fun(arg1: Character, arg2: BodyPartTypeIntId, arg3: DamageType): number
+---@field mutation_category_level any
+---@field mutation_effect fun(arg1: Character, arg2: MutationBranchId)
+---@field mutation_loss_effect fun(arg1: Character, arg2: MutationBranchId)
+---@field mutation_ok fun(arg1: Character, arg2: MutationBranchId, arg3: boolean, arg4: boolean): boolean
+---@field mutation_value fun(arg1: Character, arg2: string): number
+---@field name string
+---@field practice fun(arg1: Character, arg2: SkillId, arg3: integer, arg4: integer, arg5: boolean)
+---@field read_speed fun(arg1: Character, arg2: boolean): integer
+---@field rem_addiction fun(arg1: Character, arg2: AddictionType)
+---@field rem_morale fun(arg1: Character, arg2: MoraleTypeDataId)
+---@field remove_bionic fun(arg1: Character, arg2: BionicDataId)
+---@field remove_child_flag fun(arg1: Character, arg2: MutationBranchId)
+---@field remove_mutation fun(arg1: Character, arg2: MutationBranchId, arg3: boolean)
+---@field restore_scent fun(arg1: Character)
+---@field rest_quality fun(arg1: Character): number
+---@field rooted fun(arg1: Character)
+---@field rust_rate fun(arg1: Character): integer
+---@field set_base_age fun(arg1: Character, arg2: integer)
+---@field set_base_height fun(arg1: Character, arg2: integer)
+---@field set_dex_bonus fun(arg1: Character, arg2: integer)
+---@field set_faction_id fun(arg1: Character, arg2: FactionId)
+---@field set_fatigue fun(arg1: Character, arg2: integer)
+---@field set_healthy fun(arg1: Character, arg2: integer)
+---@field set_healthy_mod fun(arg1: Character, arg2: integer)
+---@field setID fun(arg1: Character, arg2: CharacterId, arg3: boolean)
+---@field set_int_bonus fun(arg1: Character, arg2: integer)
+---@field set_max_power_level fun(arg1: Character, arg2: Energy)
+---@field set_movement_mode fun(arg1: Character, arg2: CharacterMoveMode)
+---@field set_mutation fun(arg1: Character, arg2: MutationBranchId)
+---@field set_painkiller fun(arg1: Character, arg2: integer)
+---@field set_part_temp_btu fun(arg1: Character, arg2: BodyPartTypeIntId, arg3: integer) @Sets a specific body part to a given temperature (in Body Temperature Units).
+---@field set_per_bonus fun(arg1: Character, arg2: integer)
+---@field set_power_level fun(arg1: Character, arg2: Energy)
+---@field set_rad fun(arg1: Character, arg2: integer)
+---@field set_skill_level fun(arg1: Character, arg2: SkillId, arg3: integer)
+---@field set_sleep_deprivation fun(arg1: Character, arg2: integer)
+---@field set_stamina fun(arg1: Character, arg2: integer)
+---@field set_stim fun(arg1: Character, arg2: integer)
+---@field set_stored_kcal fun(arg1: Character, arg2: integer)
+---@field set_str_bonus fun(arg1: Character, arg2: integer)
+---@field set_temp_btu fun(arg1: Character, arg2: integer) @Sets ALL body parts on a creature to the given temperature (in Body Temperature Units).
+---@field set_thirst fun(arg1: Character, arg2: integer)
+---@field shout fun(arg1: Character, arg2: string, arg3: boolean)
+---@field sight_impaired fun(arg1: Character): boolean
+---@field spores fun(arg1: Character)
+---@field suffer fun(arg1: Character)
+---@field unset_mutation fun(arg1: Character, arg2: MutationBranchId)
+---@field unwield fun(arg1: Character): boolean
+---@field volume_capacity fun(arg1: Character): Volume
+---@field volume_carried fun(arg1: Character): Volume
+---@field vomit fun(arg1: Character)
+---@field wake_up fun(arg1: Character)
+---@field wearing_something_on fun(arg1: Character, arg2: BodyPartTypeIntId): boolean
+---@field weight_carried fun(arg1: Character): Mass
+---@field wield fun(arg1: Character, arg2: Item): boolean
+---@field worn_with_flag fun(arg1: Character, arg2: JsonFlagId, arg3: BodyPartTypeIntId): boolean
+---@field worn_with_id fun(arg1: Character, arg2: ItypeId, arg3: BodyPartTypeIntId): boolean
 Character = {}
 
 ---@class CharacterId
----@field is_valid fun(arg1: CharacterId): boolean
 ---@field get_value fun(arg1: CharacterId): integer
+---@field is_valid fun(arg1: CharacterId): boolean
 ---@field new fun(): CharacterId | fun(arg1: integer): CharacterId
 CharacterId = {}
 
 ---@class Creature
----@field get_name fun(arg1: Creature): string
----@field as_character fun(arg1: Creature): Character
----@field as_avatar fun(arg1: Creature): Avatar
----@field dodge_roll fun(arg1: Creature): number
----@field stability_roll fun(arg1: Creature): number
----@field attitude_to fun(arg1: Creature, arg2: Creature): Attitude
----@field sees fun(arg1: Creature, arg2: Creature): boolean
----@field sight_range fun(arg1: Creature, arg2: integer): integer
----@field power_rating fun(arg1: Creature): number
----@field speed_rating fun(arg1: Creature): number
----@field ranged_target_size fun(arg1: Creature): number
----@field disp_name fun(arg1: Creature, arg2: boolean, arg3: boolean): string
----@field knock_back_to fun(arg1: Creature, arg2: Tripoint)
----@field deal_damage fun(arg1: Creature, arg2: Creature, arg3: BodyPartTypeIntId, arg4: DamageInstance): DealtDamageInstance
+---@field add_effect fun(arg1: Creature, arg2: EffectTypeId, arg3: TimeDuration, arg4: any, arg5: any) @Effect type, duration, bodypart and intensity
 ---@field apply_damage fun(arg1: Creature, arg2: Creature, arg3: BodyPartTypeIntId, arg4: integer, arg5: boolean)
----@field size_melee_penalty fun(arg1: Creature): integer
+---@field as_avatar fun(arg1: Creature): Avatar
+---@field as_character fun(arg1: Creature): Character
+---@field as_monster fun(arg1: Creature): Monster
+---@field as_npc fun(arg1: Creature): Npc
+---@field attitude_to fun(arg1: Creature, arg2: Creature): Attitude
+---@field clear_effects fun(arg1: Creature)
+---@field deal_damage fun(arg1: Creature, arg2: Creature, arg3: BodyPartTypeIntId, arg4: DamageInstance): DealtDamageInstance
 ---@field digging fun(arg1: Creature): boolean
----@field is_on_ground fun(arg1: Creature): boolean
----@field is_underwater fun(arg1: Creature): boolean
----@field set_underwater fun(arg1: Creature, arg2: boolean)
----@field is_warm fun(arg1: Creature): boolean
----@field in_species fun(arg1: Creature, arg2: SpeciesTypeId): boolean
----@field skin_name fun(arg1: Creature): string
----@field has_weapon fun(arg1: Creature): boolean
----@field is_hallucination fun(arg1: Creature): boolean
----@field is_dead fun(arg1: Creature): boolean
----@field is_elec_immune fun(arg1: Creature): boolean
----@field is_immune_effect fun(arg1: Creature, arg2: EffectTypeId): boolean
----@field is_immune_damage fun(arg1: Creature, arg2: DamageType): boolean
----@field get_pos_ms fun(arg1: Creature): Tripoint
----@field set_pos_ms fun(arg1: Creature, arg2: Tripoint)
----@field has_effect fun(arg1: Creature, arg2: EffectTypeId, arg3: any): boolean
----@field has_effect_with_flag fun(arg1: Creature, arg2: JsonFlagId, arg3: any): boolean
----@field get_grammatical_genders fun(arg1: Creature): any
+---@field disp_name fun(arg1: Creature, arg2: boolean, arg3: boolean): string
+---@field dodge_roll fun(arg1: Creature): number
+---@field get_armor_bash fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
+---@field get_armor_bash_base fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
+---@field get_armor_bash_bonus fun(arg1: Creature): integer
+---@field get_armor_bullet fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
+---@field get_armor_bullet_base fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
+---@field get_armor_bullet_bonus fun(arg1: Creature): integer
+---@field get_armor_cut fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
+---@field get_armor_cut_base fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
+---@field get_armor_cut_bonus fun(arg1: Creature): integer
+---@field get_armor_type fun(arg1: Creature, arg2: DamageType, arg3: BodyPartTypeIntId): integer
+---@field get_block_bonus fun(arg1: Creature): integer
+---@field get_dodge fun(arg1: Creature): number
+---@field get_dodge_base fun(arg1: Creature): number
+---@field get_dodge_bonus fun(arg1: Creature): number
 ---@field get_effect_dur fun(arg1: Creature, arg2: EffectTypeId, arg3: any): TimeDuration
 ---@field get_effect_int fun(arg1: Creature, arg2: EffectTypeId, arg3: any): integer
----@field add_effect fun(arg1: Creature, arg2: EffectTypeId, arg3: TimeDuration, arg4: any, arg5: any) @Effect type, duration, bodypart and intensity
----@field remove_effect fun(arg1: Creature, arg2: EffectTypeId, arg3: any): boolean
----@field clear_effects fun(arg1: Creature)
----@field set_value fun(arg1: Creature, arg2: string, arg3: string)
----@field remove_value fun(arg1: Creature, arg2: string)
----@field get_value fun(arg1: Creature, arg2: string): string
----@field get_weight fun(arg1: Creature): Mass
----@field has_trait fun(arg1: Creature, arg2: MutationBranchId): boolean
----@field is_avatar fun(arg1: Creature): boolean
----@field mod_pain fun(arg1: Creature, arg2: integer)
----@field mod_pain_noresist fun(arg1: Creature, arg2: integer)
----@field set_pain fun(arg1: Creature, arg2: integer)
----@field get_pain fun(arg1: Creature): integer
----@field get_perceived_pain fun(arg1: Creature): integer
----@field get_moves fun(arg1: Creature): integer
----@field mod_moves fun(arg1: Creature, arg2: integer)
----@field set_moves fun(arg1: Creature, arg2: integer)
----@field get_num_blocks fun(arg1: Creature): integer
----@field get_num_dodges fun(arg1: Creature): integer
----@field is_npc fun(arg1: Creature): boolean
 ---@field get_env_resist fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
----@field get_armor_bash fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
----@field get_armor_cut fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
----@field get_armor_bullet fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
----@field get_armor_bash_base fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
----@field get_armor_cut_base fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
----@field get_armor_bullet_base fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
----@field get_armor_bash_bonus fun(arg1: Creature): integer
----@field get_armor_cut_bonus fun(arg1: Creature): integer
----@field get_armor_bullet_bonus fun(arg1: Creature): integer
----@field is_monster fun(arg1: Creature): boolean
----@field get_armor_type fun(arg1: Creature, arg2: DamageType, arg3: BodyPartTypeIntId): integer
----@field get_dodge fun(arg1: Creature): number
----@field get_melee fun(arg1: Creature): number
+---@field get_grammatical_genders fun(arg1: Creature): any
 ---@field get_hit fun(arg1: Creature): number
----@field get_speed fun(arg1: Creature): integer
----@field get_size fun(arg1: Creature): MonsterSize
+---@field get_hit_base fun(arg1: Creature): number
+---@field get_hit_bonus fun(arg1: Creature): number
 ---@field get_hp fun(arg1: Creature, arg2: any): integer
 ---@field get_hp_max fun(arg1: Creature, arg2: any): integer
----@field hp_percentage fun(arg1: Creature): integer
----@field has_flag fun(arg1: Creature, arg2: MonsterFlag): boolean
----@field as_monster fun(arg1: Creature): Monster
+---@field get_melee fun(arg1: Creature): number
+---@field get_moves fun(arg1: Creature): integer
+---@field get_name fun(arg1: Creature): string
+---@field get_num_blocks fun(arg1: Creature): integer
+---@field get_num_dodges fun(arg1: Creature): integer
+---@field get_pain fun(arg1: Creature): integer
+---@field get_part_healed_total fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
 ---@field get_part_hp_cur fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
 ---@field get_part_hp_max fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
----@field get_part_healed_total fun(arg1: Creature, arg2: BodyPartTypeIntId): integer
----@field set_part_hp_cur fun(arg1: Creature, arg2: BodyPartTypeIntId, arg3: integer)
----@field set_part_hp_max fun(arg1: Creature, arg2: BodyPartTypeIntId, arg3: integer)
----@field mod_part_hp_cur fun(arg1: Creature, arg2: BodyPartTypeIntId, arg3: integer)
----@field mod_part_hp_max fun(arg1: Creature, arg2: BodyPartTypeIntId, arg3: integer)
----@field set_all_parts_hp_cur fun(arg1: Creature, arg2: integer)
----@field set_all_parts_hp_to_max fun(arg1: Creature)
+---@field get_perceived_pain fun(arg1: Creature): integer
+---@field get_pos_ms fun(arg1: Creature): Tripoint
+---@field get_size fun(arg1: Creature): MonsterSize
+---@field get_speed fun(arg1: Creature): integer
 ---@field get_speed_base fun(arg1: Creature): integer
----@field as_npc fun(arg1: Creature): Npc
 ---@field get_speed_bonus fun(arg1: Creature): integer
 ---@field get_speed_mult fun(arg1: Creature): number
----@field get_block_bonus fun(arg1: Creature): integer
----@field get_dodge_base fun(arg1: Creature): number
----@field get_hit_base fun(arg1: Creature): number
----@field get_dodge_bonus fun(arg1: Creature): number
----@field get_hit_bonus fun(arg1: Creature): number
----@field has_grab_break_tec fun(arg1: Creature): boolean
+---@field get_value fun(arg1: Creature, arg2: string): string
+---@field get_weight fun(arg1: Creature): Mass
 ---@field get_weight_capacity fun(arg1: Creature): integer
+---@field has_effect fun(arg1: Creature, arg2: EffectTypeId, arg3: any): boolean
+---@field has_effect_with_flag fun(arg1: Creature, arg2: JsonFlagId, arg3: any): boolean
+---@field has_flag fun(arg1: Creature, arg2: MonsterFlag): boolean
+---@field has_grab_break_tec fun(arg1: Creature): boolean
+---@field has_trait fun(arg1: Creature, arg2: MutationBranchId): boolean
+---@field has_weapon fun(arg1: Creature): boolean
+---@field hp_percentage fun(arg1: Creature): integer
+---@field in_species fun(arg1: Creature, arg2: SpeciesTypeId): boolean
+---@field is_avatar fun(arg1: Creature): boolean
+---@field is_dead fun(arg1: Creature): boolean
+---@field is_elec_immune fun(arg1: Creature): boolean
+---@field is_hallucination fun(arg1: Creature): boolean
+---@field is_immune_damage fun(arg1: Creature, arg2: DamageType): boolean
+---@field is_immune_effect fun(arg1: Creature, arg2: EffectTypeId): boolean
+---@field is_monster fun(arg1: Creature): boolean
+---@field is_npc fun(arg1: Creature): boolean
+---@field is_on_ground fun(arg1: Creature): boolean
+---@field is_underwater fun(arg1: Creature): boolean
+---@field is_warm fun(arg1: Creature): boolean
+---@field knock_back_to fun(arg1: Creature, arg2: Tripoint)
+---@field mod_moves fun(arg1: Creature, arg2: integer)
+---@field mod_pain fun(arg1: Creature, arg2: integer)
+---@field mod_pain_noresist fun(arg1: Creature, arg2: integer)
+---@field mod_part_hp_cur fun(arg1: Creature, arg2: BodyPartTypeIntId, arg3: integer)
+---@field mod_part_hp_max fun(arg1: Creature, arg2: BodyPartTypeIntId, arg3: integer)
+---@field power_rating fun(arg1: Creature): number
+---@field ranged_target_size fun(arg1: Creature): number
+---@field remove_effect fun(arg1: Creature, arg2: EffectTypeId, arg3: any): boolean
+---@field remove_value fun(arg1: Creature, arg2: string)
+---@field sees fun(arg1: Creature, arg2: Creature): boolean
+---@field set_all_parts_hp_cur fun(arg1: Creature, arg2: integer)
+---@field set_all_parts_hp_to_max fun(arg1: Creature)
+---@field set_moves fun(arg1: Creature, arg2: integer)
+---@field set_pain fun(arg1: Creature, arg2: integer)
+---@field set_part_hp_cur fun(arg1: Creature, arg2: BodyPartTypeIntId, arg3: integer)
+---@field set_part_hp_max fun(arg1: Creature, arg2: BodyPartTypeIntId, arg3: integer)
+---@field set_pos_ms fun(arg1: Creature, arg2: Tripoint)
+---@field set_underwater fun(arg1: Creature, arg2: boolean)
+---@field set_value fun(arg1: Creature, arg2: string, arg3: string)
+---@field sight_range fun(arg1: Creature, arg2: integer): integer
+---@field size_melee_penalty fun(arg1: Creature): integer
+---@field skin_name fun(arg1: Creature): string
+---@field speed_rating fun(arg1: Creature): number
+---@field stability_roll fun(arg1: Creature): number
 Creature = {}
 
 --- new(damageType, amount, armorPen, remainingArmorMultiplier, damageMultiplier)
 ---@class DamageInstance
----@field damage_units any
----@field mult_damage fun(arg1: DamageInstance, arg2: number, arg3: boolean)
----@field type_damage fun(arg1: DamageInstance, arg2: DamageType): number
----@field total_damage fun(arg1: DamageInstance): number
----@field clear fun(arg1: DamageInstance)
----@field empty fun(arg1: DamageInstance): boolean
----@field add_damage fun(arg1: DamageInstance, arg2: DamageType, arg3: number, arg4: number, arg5: number, arg6: number)
 ---@field add fun(arg1: DamageInstance, arg2: DamageUnit)
+---@field add_damage fun(arg1: DamageInstance, arg2: DamageType, arg3: number, arg4: number, arg5: number, arg6: number)
+---@field clear fun(arg1: DamageInstance)
+---@field damage_units any
+---@field empty fun(arg1: DamageInstance): boolean
+---@field mult_damage fun(arg1: DamageInstance, arg2: number, arg3: boolean)
+---@field total_damage fun(arg1: DamageInstance): number
+---@field type_damage fun(arg1: DamageInstance, arg2: DamageType): number
 ---@field __eq fun(arg1: DamageInstance, arg2: DamageInstance): boolean
 ---@field new fun(): DamageInstance | fun(arg1: DamageType, arg2: number, arg3: number, arg4: number, arg5: number): DamageInstance
 DamageInstance = {}
 
 --- new(damageType, amount, armorPen, remainingArmorMultiplier, damageMultiplier)
 ---@class DamageUnit
----@field type DamageType
 ---@field amount number
----@field res_pen number
----@field res_mult number
 ---@field damage_multiplier number
+---@field res_mult number
+---@field res_pen number
+---@field type DamageType
 ---@field __eq fun(arg1: DamageUnit, arg2: DamageUnit): boolean
 ---@field new fun(arg1: DamageType, arg2: number, arg3: number, arg4: number, arg5: number): DamageUnit
 DamageUnit = {}
 
 --- Represents the final dealt damage
 ---@class DealtDamageInstance
----@field dealt_dams any
 ---@field bp_hit BodyPartTypeId
----@field type_damage fun(arg1: DealtDamageInstance, arg2: DamageType): integer
+---@field dealt_dams any
 ---@field total_damage fun(arg1: DealtDamageInstance): integer
+---@field type_damage fun(arg1: DealtDamageInstance, arg2: DamageType): integer
 DealtDamageInstance = {}
 
 ---@class DiseaseTypeId
----@field obj fun(arg1: DiseaseTypeId): DiseaseTypeRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: DiseaseTypeId): boolean
 ---@field is_valid fun(arg1: DiseaseTypeId): boolean
----@field str fun(arg1: DiseaseTypeId): string
 ---@field NULL_ID fun(): DiseaseTypeId
----@field __tostring fun(arg1: DiseaseTypeId): string
+---@field obj fun(arg1: DiseaseTypeId): DiseaseTypeRaw
+---@field str fun(arg1: DiseaseTypeId): string
 ---@field serialize fun(arg1: DiseaseTypeId)
 ---@field deserialize fun(arg1: DiseaseTypeId)
+---@field __tostring fun(arg1: DiseaseTypeId): string
 ---@field new fun(): DiseaseTypeId | fun(arg1: DiseaseTypeId): DiseaseTypeId | fun(arg1: string): DiseaseTypeId
 DiseaseTypeId = {}
 
@@ -493,38 +493,38 @@ DistributionGrid = {}
 DistributionGridTracker = {}
 
 ---@class EffectTypeId
----@field obj fun(arg1: EffectTypeId): EffectTypeRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: EffectTypeId): boolean
 ---@field is_valid fun(arg1: EffectTypeId): boolean
----@field str fun(arg1: EffectTypeId): string
 ---@field NULL_ID fun(): EffectTypeId
----@field __tostring fun(arg1: EffectTypeId): string
+---@field obj fun(arg1: EffectTypeId): EffectTypeRaw
+---@field str fun(arg1: EffectTypeId): string
 ---@field serialize fun(arg1: EffectTypeId)
 ---@field deserialize fun(arg1: EffectTypeId)
+---@field __tostring fun(arg1: EffectTypeId): string
 ---@field new fun(): EffectTypeId | fun(arg1: EffectTypeId): EffectTypeId | fun(arg1: string): EffectTypeId
 EffectTypeId = {}
 
 ---@class Energy
 ---@field from_joule fun(arg1: integer): Energy
----@field to_joule fun(arg1: Energy): integer
 ---@field from_kilojoule fun(arg1: integer): Energy
+---@field to_joule fun(arg1: Energy): integer
 ---@field to_kilojoule fun(arg1: Energy): integer
 ---@field __eq fun(arg1: Energy, arg2: Energy): boolean
----@field __lt fun(arg1: Energy, arg2: Energy): boolean
 ---@field __le fun(arg1: Energy, arg2: Energy): boolean
+---@field __lt fun(arg1: Energy, arg2: Energy): boolean
 Energy = {}
 
 ---@class FactionId
----@field obj fun(arg1: FactionId): FactionRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: FactionId): boolean
 ---@field is_valid fun(arg1: FactionId): boolean
----@field str fun(arg1: FactionId): string
 ---@field NULL_ID fun(): FactionId
----@field __tostring fun(arg1: FactionId): string
+---@field obj fun(arg1: FactionId): FactionRaw
+---@field str fun(arg1: FactionId): string
 ---@field serialize fun(arg1: FactionId)
 ---@field deserialize fun(arg1: FactionId)
+---@field __tostring fun(arg1: FactionId): string
 ---@field new fun(): FactionId | fun(arg1: FactionId): FactionId | fun(arg1: string): FactionId
 FactionId = {}
 
@@ -533,161 +533,165 @@ FactionId = {}
 FactionRaw = {}
 
 ---@class FieldTypeId
----@field obj fun(arg1: FieldTypeId): FieldTypeRaw
----@field deserialize fun(arg1: FieldTypeId)
----@field int_id fun(arg1: FieldTypeId): FieldTypeIntId
 ---@field implements_int_id fun(): boolean
+---@field int_id fun(arg1: FieldTypeId): FieldTypeIntId
 ---@field is_null fun(arg1: FieldTypeId): boolean
 ---@field is_valid fun(arg1: FieldTypeId): boolean
----@field str fun(arg1: FieldTypeId): string
 ---@field NULL_ID fun(): FieldTypeId
----@field __tostring fun(arg1: FieldTypeId): string
+---@field obj fun(arg1: FieldTypeId): FieldTypeRaw
+---@field str fun(arg1: FieldTypeId): string
 ---@field serialize fun(arg1: FieldTypeId)
+---@field deserialize fun(arg1: FieldTypeId)
+---@field __tostring fun(arg1: FieldTypeId): string
 ---@field new fun(): FieldTypeId | fun(arg1: FieldTypeId): FieldTypeId | fun(arg1: FieldTypeIntId): FieldTypeId | fun(arg1: string): FieldTypeId
 FieldTypeId = {}
 
 ---@class FieldTypeIntId
+---@field is_valid fun(arg1: FieldTypeIntId): boolean
 ---@field obj fun(arg1: FieldTypeIntId): FieldTypeRaw
 ---@field str_id fun(arg1: FieldTypeIntId): FieldTypeId
----@field is_valid fun(arg1: FieldTypeIntId): boolean
 ---@field __tostring fun(arg1: FieldTypeIntId): string
 ---@field new fun(): FieldTypeIntId | fun(arg1: FieldTypeIntId): FieldTypeIntId | fun(arg1: FieldTypeId): FieldTypeIntId
 FieldTypeIntId = {}
 
 ---@class FurnId
----@field obj fun(arg1: FurnId): FurnRaw
----@field deserialize fun(arg1: FurnId)
----@field int_id fun(arg1: FurnId): FurnIntId
 ---@field implements_int_id fun(): boolean
+---@field int_id fun(arg1: FurnId): FurnIntId
 ---@field is_null fun(arg1: FurnId): boolean
 ---@field is_valid fun(arg1: FurnId): boolean
----@field str fun(arg1: FurnId): string
 ---@field NULL_ID fun(): FurnId
----@field __tostring fun(arg1: FurnId): string
+---@field obj fun(arg1: FurnId): FurnRaw
+---@field str fun(arg1: FurnId): string
 ---@field serialize fun(arg1: FurnId)
+---@field deserialize fun(arg1: FurnId)
+---@field __tostring fun(arg1: FurnId): string
 ---@field new fun(): FurnId | fun(arg1: FurnId): FurnId | fun(arg1: FurnIntId): FurnId | fun(arg1: string): FurnId
 FurnId = {}
 
 ---@class FurnIntId
+---@field is_valid fun(arg1: FurnIntId): boolean
 ---@field obj fun(arg1: FurnIntId): FurnRaw
 ---@field str_id fun(arg1: FurnIntId): FurnId
----@field is_valid fun(arg1: FurnIntId): boolean
 ---@field __tostring fun(arg1: FurnIntId): string
 ---@field new fun(): FurnIntId | fun(arg1: FurnIntId): FurnIntId | fun(arg1: FurnId): FurnIntId
 FurnIntId = {}
 
 ---@class FurnRaw
----@field str_id fun(arg1: FurnRaw): FurnId
+---@field close FurnId
 ---@field int_id fun(arg1: FurnRaw): FurnIntId
 ---@field open FurnId
----@field close FurnId
+---@field str_id fun(arg1: FurnRaw): FurnId
 ---@field transforms_into FurnId
 FurnRaw = {}
 
 ---@class Item
----@field get_type fun(arg1: Item): ItypeId
----@field is_sided fun(arg1: Item): boolean
----@field get_var_tri fun(arg1: Item, arg2: string, arg3: Tripoint): Tripoint @Get variable as tripoint
----@field set_var_str fun(arg1: Item, arg2: string, arg3: string)
----@field set_var_num fun(arg1: Item, arg2: string, arg3: number)
----@field set_var_tri fun(arg1: Item, arg2: string, arg3: Tripoint)
----@field is_power_armor fun(arg1: Item): boolean
----@field is_money fun(arg1: Item): boolean
----@field is_gun fun(arg1: Item): boolean
----@field is_firearm fun(arg1: Item): boolean
----@field is_silent fun(arg1: Item): boolean
----@field is_gunmod fun(arg1: Item): boolean
----@field is_bionic fun(arg1: Item): boolean
----@field is_ammo_belt fun(arg1: Item): boolean
----@field is_bandolier fun(arg1: Item): boolean
----@field get_mtype fun(arg1: Item): MtypeId @Almost for a corpse.
----@field is_holster fun(arg1: Item): boolean
----@field is_ammo fun(arg1: Item): boolean
----@field is_comestible fun(arg1: Item): boolean
----@field is_food fun(arg1: Item): boolean
----@field is_medication fun(arg1: Item): boolean
----@field is_brewable fun(arg1: Item): boolean
----@field is_food_container fun(arg1: Item): boolean
----@field is_med_container fun(arg1: Item): boolean
----@field is_corpse fun(arg1: Item): boolean
----@field is_ammo_container fun(arg1: Item): boolean
----@field tname fun(arg1: Item, arg2: integer, arg3: boolean, arg4: integer): string @Translated item name with prefixes
----@field is_armor fun(arg1: Item): boolean
----@field is_book fun(arg1: Item): boolean
----@field is_map fun(arg1: Item): boolean
----@field is_container fun(arg1: Item): boolean
----@field is_watertight_container fun(arg1: Item): boolean
----@field is_non_resealable_container fun(arg1: Item): boolean
----@field is_bucket fun(arg1: Item): boolean
----@field is_bucket_nonempty fun(arg1: Item): boolean
----@field is_engine fun(arg1: Item): boolean
----@field is_wheel fun(arg1: Item): boolean
----@field display_name fun(arg1: Item, arg2: integer): string @Display name with all bells and whistles like ammo and prefixes
----@field is_fuel fun(arg1: Item): boolean
----@field is_toolmod fun(arg1: Item): boolean
----@field is_faulty fun(arg1: Item): boolean
----@field is_irremovable fun(arg1: Item): boolean
----@field is_container_empty fun(arg1: Item): boolean
----@field is_salvageable fun(arg1: Item): boolean
----@field is_craft fun(arg1: Item): boolean
----@field is_emissive fun(arg1: Item): boolean
----@field is_deployable fun(arg1: Item): boolean
----@field is_tool fun(arg1: Item): boolean
----@field has_var fun(arg1: Item, arg2: string): boolean @Check for variable of any type
----@field is_transformable fun(arg1: Item): boolean
----@field is_artifact fun(arg1: Item): boolean
----@field is_relic fun(arg1: Item): boolean
----@field is_seed fun(arg1: Item): boolean
----@field is_dangerous fun(arg1: Item): boolean
----@field is_tainted fun(arg1: Item): boolean
----@field is_soft fun(arg1: Item): boolean
----@field is_reloadable fun(arg1: Item): boolean
----@field is_filthy fun(): boolean @DEPRECATED: Items are no longer filthy
----@field is_active fun(arg1: Item): boolean
----@field erase_var fun(arg1: Item, arg2: string) @Erase variable
----@field is_upgrade fun(arg1: Item): boolean
----@field is_melee fun(arg1: Item, arg2: DamageType): boolean @Is this item an effective melee weapon for the given damage type?
----@field is_magazine fun(arg1: Item): boolean @Is this a magazine? (batteries are magazines)
----@field is_battery fun(arg1: Item): boolean @DEPRECATED: Is this a battery? (spoiler: it isn't)
----@field conductive fun(arg1: Item): boolean
----@field charges integer
----@field energy_remaining fun(arg1: Item): Energy
----@field has_infinite_charges fun(arg1: Item): boolean
----@field mod_charges fun(arg1: Item, arg2: integer)
----@field get_rot fun(arg1: Item): TimeDuration @Gets the TimeDuration until this item rots
----@field clear_vars fun(arg1: Item) @Erase all variables
----@field get_category_id fun(arg1: Item): string @Gets the category id this item is in
----@field get_owner fun(arg1: Item): FactionId @Gets the faction id that owns this item
----@field set_owner fun(arg1: Item, arg2: FactionId) @Sets the ownership of this item to a faction
----@field set_owner fun(arg1: Item, arg2: Character) @Sets the ownership of this item to a character
----@field get_owner_name fun(arg1: Item): string
----@field is_owned_by fun(arg1: Item, arg2: Character, arg3: boolean): boolean @Checks if this item owned by a character
----@field can_contain fun(arg1: Item, arg2: Item): boolean @Checks if this item can contain another
----@field remaining_capacity_for_id fun(arg1: Item, arg2: ItypeId, arg3: boolean): integer @Gets the remaining space available for a type of liquid
----@field total_capacity fun(arg1: Item): Volume @Gets maximum volume this item can hold (liquids, ammo, etc)
----@field current_magazine fun(arg1: Item): Item @Gets the current magazine
----@field is_null fun(arg1: Item): boolean
+---@field add_item_with_id fun(arg1: Item, arg2: ItypeId, arg3: integer) @Adds an item(s) to contents
+---@field add_technique fun(arg1: Item, arg2: MartialArtsTechniqueId) @Adds the technique. It isn't treated original, but additional.
 ---@field ammo_capacity fun(arg1: Item, arg2: boolean): integer @Gets the maximum capacity of a magazine
----@field ammo_remaining fun(arg1: Item): integer @Get remaining ammo, works with batteries & stuff too
----@field ammo_data fun(arg1: Item): ItypeRaw
----@field ammo_required fun(arg1: Item): integer
----@field ammo_current fun(arg1: Item): ItypeId
 ---@field ammo_consume fun(arg1: Item, arg2: integer, arg3: Tripoint): integer
+---@field ammo_current fun(arg1: Item): ItypeId
+---@field ammo_data fun(arg1: Item): ItypeRaw
+---@field ammo_remaining fun(arg1: Item): integer @Get remaining ammo, works with batteries & stuff too
+---@field ammo_required fun(arg1: Item): integer
 ---@field ammo_set fun(arg1: Item, arg2: ItypeId, arg3: integer)
 ---@field ammo_unset fun(arg1: Item)
----@field get_reload_time fun(arg1: Item): integer
----@field add_item_with_id fun(arg1: Item, arg2: ItypeId, arg3: integer) @Adds an item(s) to contents
----@field is_unarmed_weapon fun(arg1: Item): boolean
----@field has_item_with_id fun(arg1: Item, arg2: ItypeId): boolean @Checks item contents for a given item id
+---@field can_contain fun(arg1: Item, arg2: Item): boolean @Checks if this item can contain another
+---@field charges integer
+---@field clear_vars fun(arg1: Item) @Erase all variables
+---@field conductive fun(arg1: Item): boolean
 ---@field covers fun(arg1: Item, arg2: BodyPartTypeIntId): boolean @Checks if the item covers a bodypart
----@field set_flag fun(arg1: Item, arg2: JsonFlagId)
----@field unset_flag fun(arg1: Item, arg2: JsonFlagId)
----@field has_flag fun(arg1: Item, arg2: JsonFlagId): boolean
----@field has_own_flag fun(arg1: Item, arg2: JsonFlagId): boolean
----@field set_flag_recursive fun(arg1: Item, arg2: JsonFlagId)
----@field unset_flags fun(arg1: Item)
----@field get_var_str fun(arg1: Item, arg2: string, arg3: string): string @Get variable as string
+---@field current_magazine fun(arg1: Item): Item @Gets the current magazine
+---@field display_name fun(arg1: Item, arg2: integer): string @Display name with all bells and whistles like ammo and prefixes
+---@field energy_remaining fun(arg1: Item): Energy
+---@field erase_var fun(arg1: Item, arg2: string) @Erase variable
+---@field get_category_id fun(arg1: Item): string @Gets the category id this item is in
+---@field get_mtype fun(arg1: Item): MtypeId @Almost for a corpse.
+---@field get_owner fun(arg1: Item): FactionId @Gets the faction id that owns this item
+---@field get_owner_name fun(arg1: Item): string
+---@field get_reload_time fun(arg1: Item): integer
+---@field get_rot fun(arg1: Item): TimeDuration @Gets the TimeDuration until this item rots
+---@field get_techniques fun(arg1: Item): any @Gets all techniques. Including original techniques.
+---@field get_type fun(arg1: Item): ItypeId
 ---@field get_var_num fun(arg1: Item, arg2: string, arg3: number): number @Get variable as float number
+---@field get_var_str fun(arg1: Item, arg2: string, arg3: string): string @Get variable as string
+---@field get_var_tri fun(arg1: Item, arg2: string, arg3: Tripoint): Tripoint @Get variable as tripoint
+---@field has_flag fun(arg1: Item, arg2: JsonFlagId): boolean
+---@field has_infinite_charges fun(arg1: Item): boolean
+---@field has_item_with_id fun(arg1: Item, arg2: ItypeId): boolean @Checks item contents for a given item id
+---@field has_own_flag fun(arg1: Item, arg2: JsonFlagId): boolean
+---@field has_technique fun(arg1: Item, arg2: MartialArtsTechniqueId): boolean @Checks if this item has the technique as an addition. Doesn't check original techniques.
+---@field has_var fun(arg1: Item, arg2: string): boolean @Check for variable of any type
+---@field is_active fun(arg1: Item): boolean
+---@field is_ammo fun(arg1: Item): boolean
+---@field is_ammo_belt fun(arg1: Item): boolean
+---@field is_ammo_container fun(arg1: Item): boolean
+---@field is_armor fun(arg1: Item): boolean
+---@field is_artifact fun(arg1: Item): boolean
+---@field is_bandolier fun(arg1: Item): boolean
+---@field is_battery fun(arg1: Item): boolean @DEPRECATED: Is this a battery? (spoiler: it isn't)
+---@field is_bionic fun(arg1: Item): boolean
+---@field is_book fun(arg1: Item): boolean
+---@field is_brewable fun(arg1: Item): boolean
+---@field is_bucket fun(arg1: Item): boolean
+---@field is_bucket_nonempty fun(arg1: Item): boolean
+---@field is_comestible fun(arg1: Item): boolean
+---@field is_container fun(arg1: Item): boolean
+---@field is_container_empty fun(arg1: Item): boolean
+---@field is_corpse fun(arg1: Item): boolean
+---@field is_craft fun(arg1: Item): boolean
+---@field is_dangerous fun(arg1: Item): boolean
+---@field is_deployable fun(arg1: Item): boolean
+---@field is_emissive fun(arg1: Item): boolean
+---@field is_engine fun(arg1: Item): boolean
+---@field is_faulty fun(arg1: Item): boolean
+---@field is_filthy fun(): boolean @DEPRECATED: Items are no longer filthy
+---@field is_firearm fun(arg1: Item): boolean
+---@field is_food fun(arg1: Item): boolean
+---@field is_food_container fun(arg1: Item): boolean
+---@field is_fuel fun(arg1: Item): boolean
+---@field is_gun fun(arg1: Item): boolean
+---@field is_gunmod fun(arg1: Item): boolean
+---@field is_holster fun(arg1: Item): boolean
+---@field is_irremovable fun(arg1: Item): boolean
+---@field is_magazine fun(arg1: Item): boolean @Is this a magazine? (batteries are magazines)
+---@field is_map fun(arg1: Item): boolean
+---@field is_med_container fun(arg1: Item): boolean
+---@field is_medication fun(arg1: Item): boolean
+---@field is_melee fun(arg1: Item, arg2: DamageType): boolean @Is this item an effective melee weapon for the given damage type?
+---@field is_money fun(arg1: Item): boolean
+---@field is_non_resealable_container fun(arg1: Item): boolean
+---@field is_null fun(arg1: Item): boolean
+---@field is_owned_by fun(arg1: Item, arg2: Character, arg3: boolean): boolean @Checks if this item owned by a character
+---@field is_power_armor fun(arg1: Item): boolean
+---@field is_relic fun(arg1: Item): boolean
+---@field is_reloadable fun(arg1: Item): boolean
+---@field is_salvageable fun(arg1: Item, arg2: boolean): boolean
+---@field is_seed fun(arg1: Item): boolean
+---@field is_sided fun(arg1: Item): boolean
+---@field is_silent fun(arg1: Item): boolean
+---@field is_soft fun(arg1: Item): boolean
+---@field is_tainted fun(arg1: Item): boolean
+---@field is_tool fun(arg1: Item): boolean
+---@field is_toolmod fun(arg1: Item): boolean
+---@field is_transformable fun(arg1: Item): boolean
+---@field is_unarmed_weapon fun(arg1: Item): boolean
+---@field is_upgrade fun(arg1: Item): boolean
+---@field is_watertight_container fun(arg1: Item): boolean
+---@field is_wheel fun(arg1: Item): boolean
+---@field mod_charges fun(arg1: Item, arg2: integer)
+---@field remaining_capacity_for_id fun(arg1: Item, arg2: ItypeId, arg3: boolean): integer @Gets the remaining space available for a type of liquid
+---@field remove_technique fun(arg1: Item, arg2: MartialArtsTechniqueId) @Removes the additional technique. Doesn't affect originial techniques.
+---@field set_flag fun(arg1: Item, arg2: JsonFlagId)
+---@field set_flag_recursive fun(arg1: Item, arg2: JsonFlagId)
+---@field set_owner fun(arg1: Item, arg2: Character) @Sets the ownership of this item to a character
+---@field set_owner fun(arg1: Item, arg2: FactionId) @Sets the ownership of this item to a faction
+---@field set_var_num fun(arg1: Item, arg2: string, arg3: number)
+---@field set_var_str fun(arg1: Item, arg2: string, arg3: string)
+---@field set_var_tri fun(arg1: Item, arg2: string, arg3: Tripoint)
+---@field tname fun(arg1: Item, arg2: integer, arg3: boolean, arg4: integer): string @Translated item name with prefixes
+---@field total_capacity fun(arg1: Item): Volume @Gets maximum volume this item can hold (liquids, ammo, etc)
+---@field unset_flag fun(arg1: Item, arg2: JsonFlagId)
+---@field unset_flags fun(arg1: Item)
 Item = {}
 
 --- Iterate over this using pairs()
@@ -696,70 +700,70 @@ Item = {}
 ItemStack = {}
 
 ---@class ItypeId
----@field obj fun(arg1: ItypeId): ItypeRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: ItypeId): boolean
 ---@field is_valid fun(arg1: ItypeId): boolean
----@field str fun(arg1: ItypeId): string
 ---@field NULL_ID fun(): ItypeId
----@field __tostring fun(arg1: ItypeId): string
+---@field obj fun(arg1: ItypeId): ItypeRaw
+---@field str fun(arg1: ItypeId): string
 ---@field serialize fun(arg1: ItypeId)
 ---@field deserialize fun(arg1: ItypeId)
+---@field __tostring fun(arg1: ItypeId): string
 ---@field new fun(): ItypeId | fun(arg1: ItypeId): ItypeId | fun(arg1: string): ItypeId
 ItypeId = {}
 
 ---@class JsonFlagId
----@field obj fun(arg1: JsonFlagId): JsonFlagRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: JsonFlagId): boolean
 ---@field is_valid fun(arg1: JsonFlagId): boolean
----@field str fun(arg1: JsonFlagId): string
 ---@field NULL_ID fun(): JsonFlagId
----@field __tostring fun(arg1: JsonFlagId): string
+---@field obj fun(arg1: JsonFlagId): JsonFlagRaw
+---@field str fun(arg1: JsonFlagId): string
 ---@field serialize fun(arg1: JsonFlagId)
 ---@field deserialize fun(arg1: JsonFlagId)
+---@field __tostring fun(arg1: JsonFlagId): string
 ---@field new fun(): JsonFlagId | fun(arg1: JsonFlagId): JsonFlagId | fun(arg1: string): JsonFlagId
 JsonFlagId = {}
 
 ---@class JsonTraitFlagId
----@field obj fun(arg1: JsonTraitFlagId): JsonTraitFlagRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: JsonTraitFlagId): boolean
 ---@field is_valid fun(arg1: JsonTraitFlagId): boolean
----@field str fun(arg1: JsonTraitFlagId): string
 ---@field NULL_ID fun(): JsonTraitFlagId
----@field __tostring fun(arg1: JsonTraitFlagId): string
+---@field obj fun(arg1: JsonTraitFlagId): JsonTraitFlagRaw
+---@field str fun(arg1: JsonTraitFlagId): string
 ---@field serialize fun(arg1: JsonTraitFlagId)
 ---@field deserialize fun(arg1: JsonTraitFlagId)
+---@field __tostring fun(arg1: JsonTraitFlagId): string
 ---@field new fun(): JsonTraitFlagId | fun(arg1: JsonTraitFlagId): JsonTraitFlagId | fun(arg1: string): JsonTraitFlagId
 JsonTraitFlagId = {}
 
 ---@class Map
----@field get_abs_ms fun(arg1: Map, arg2: Tripoint): Tripoint @Convert local ms -> absolute ms
----@field set_ter_at fun(arg1: Map, arg2: Tripoint, arg3: TerIntId): boolean
----@field get_furn_at fun(arg1: Map, arg2: Tripoint): FurnIntId
----@field set_furn_at fun(arg1: Map, arg2: Tripoint, arg3: FurnIntId)
----@field has_field_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId): boolean
----@field get_field_int_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId): integer
----@field get_field_age_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId): TimeDuration
----@field mod_field_int_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId, arg4: integer): integer
----@field mod_field_age_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId, arg4: TimeDuration): TimeDuration
----@field set_field_int_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId, arg4: integer, arg5: boolean): integer
----@field set_field_age_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId, arg4: TimeDuration, arg5: boolean): TimeDuration
----@field get_local_ms fun(arg1: Map, arg2: Tripoint): Tripoint @Convert absolute ms -> local ms
 ---@field add_field_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId, arg4: integer, arg5: TimeDuration): boolean
----@field remove_field_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId)
----@field get_trap_at fun(arg1: Map, arg2: Tripoint): TrapIntId
----@field set_trap_at fun(arg1: Map, arg2: Tripoint, arg3: TrapIntId) @Set a trap at a position on the map. It can also replace existing trap, even with `trap_null`.
----@field disarm_trap_at fun(arg1: Map, arg2: Tripoint) @Disarms a trap using your skills and stats, with consequences depending on success or failure.
----@field remove_trap_at fun(arg1: Map, arg2: Tripoint) @Simpler version of `set_trap_at` with `trap_null`.
----@field get_map_size_in_submaps fun(arg1: Map): integer
----@field get_map_size fun(arg1: Map): integer @In map squares
----@field create_item_at fun(arg1: Map, arg2: Tripoint, arg3: ItypeId, arg4: integer) @Creates a new item(s) at a position on the map.
 ---@field create_corpse_at fun(arg1: Map, arg2: Tripoint, arg3: any, arg4: any, arg5: any, arg6: any) @Creates a new corpse at a position on the map. You can skip `Opt` ones by omitting them or passing `nil`. `MtypeId` specifies which monster's body it is, `TimePoint` indicates when it died, `string` gives it a custom name, and `int` determines the revival time if the monster has the `REVIVES` flag.
----@field has_items_at fun(arg1: Map, arg2: Tripoint): boolean
+---@field create_item_at fun(arg1: Map, arg2: Tripoint, arg3: ItypeId, arg4: integer) @Creates a new item(s) at a position on the map.
+---@field disarm_trap_at fun(arg1: Map, arg2: Tripoint) @Disarms a trap using your skills and stats, with consequences depending on success or failure.
+---@field get_abs_ms fun(arg1: Map, arg2: Tripoint): Tripoint @Convert local ms -> absolute ms
+---@field get_field_age_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId): TimeDuration
+---@field get_field_int_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId): integer
+---@field get_furn_at fun(arg1: Map, arg2: Tripoint): FurnIntId
 ---@field get_items_at fun(arg1: Map, arg2: Tripoint): any
+---@field get_local_ms fun(arg1: Map, arg2: Tripoint): Tripoint @Convert absolute ms -> local ms
+---@field get_map_size fun(arg1: Map): integer @In map squares
+---@field get_map_size_in_submaps fun(arg1: Map): integer
 ---@field get_ter_at fun(arg1: Map, arg2: Tripoint): TerIntId
+---@field get_trap_at fun(arg1: Map, arg2: Tripoint): TrapIntId
+---@field has_field_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId): boolean
+---@field has_items_at fun(arg1: Map, arg2: Tripoint): boolean
+---@field mod_field_age_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId, arg4: TimeDuration): TimeDuration
+---@field mod_field_int_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId, arg4: integer): integer
+---@field remove_field_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId)
+---@field remove_trap_at fun(arg1: Map, arg2: Tripoint) @Simpler version of `set_trap_at` with `trap_null`.
+---@field set_field_age_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId, arg4: TimeDuration, arg5: boolean): TimeDuration
+---@field set_field_int_at fun(arg1: Map, arg2: Tripoint, arg3: FieldTypeIntId, arg4: integer, arg5: boolean): integer
+---@field set_furn_at fun(arg1: Map, arg2: Tripoint, arg3: FurnIntId)
+---@field set_ter_at fun(arg1: Map, arg2: Tripoint, arg3: TerIntId): boolean
+---@field set_trap_at fun(arg1: Map, arg2: Tripoint, arg3: TrapIntId) @Set a trap at a position on the map. It can also replace existing trap, even with `trap_null`.
 Map = {}
 
 ---@class MapStack : ItemStack
@@ -767,280 +771,293 @@ Map = {}
 MapStack = {}
 
 ---@class MartialArtsBuffId
----@field obj fun(arg1: MartialArtsBuffId): MartialArtsBuffRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: MartialArtsBuffId): boolean
 ---@field is_valid fun(arg1: MartialArtsBuffId): boolean
----@field str fun(arg1: MartialArtsBuffId): string
 ---@field NULL_ID fun(): MartialArtsBuffId
----@field __tostring fun(arg1: MartialArtsBuffId): string
+---@field obj fun(arg1: MartialArtsBuffId): MartialArtsBuffRaw
+---@field str fun(arg1: MartialArtsBuffId): string
 ---@field serialize fun(arg1: MartialArtsBuffId)
 ---@field deserialize fun(arg1: MartialArtsBuffId)
+---@field __tostring fun(arg1: MartialArtsBuffId): string
 ---@field new fun(): MartialArtsBuffId | fun(arg1: MartialArtsBuffId): MartialArtsBuffId | fun(arg1: string): MartialArtsBuffId
 MartialArtsBuffId = {}
 
+---@class MartialArtsTechniqueId
+---@field implements_int_id fun(): boolean
+---@field is_null fun(arg1: MartialArtsTechniqueId): boolean
+---@field is_valid fun(arg1: MartialArtsTechniqueId): boolean
+---@field NULL_ID fun(): MartialArtsTechniqueId
+---@field obj fun(arg1: MartialArtsTechniqueId): MartialArtsTechniqueRaw
+---@field str fun(arg1: MartialArtsTechniqueId): string
+---@field serialize fun(arg1: MartialArtsTechniqueId)
+---@field deserialize fun(arg1: MartialArtsTechniqueId)
+---@field __tostring fun(arg1: MartialArtsTechniqueId): string
+---@field new fun(): MartialArtsTechniqueId | fun(arg1: MartialArtsTechniqueId): MartialArtsTechniqueId | fun(arg1: string): MartialArtsTechniqueId
+MartialArtsTechniqueId = {}
+
 ---@class Mass
----@field from_milligram fun(arg1: integer): Mass
----@field __lt fun(arg1: Mass, arg2: Mass): boolean
----@field __le fun(arg1: Mass, arg2: Mass): boolean
----@field to_milligram fun(arg1: Mass): integer
 ---@field from_gram fun(arg1: integer): Mass
----@field to_gram fun(arg1: Mass): integer
 ---@field from_kilogram fun(arg1: integer): Mass
----@field to_kilogram fun(arg1: Mass): integer
+---@field from_milligram fun(arg1: integer): Mass
 ---@field from_newton fun(arg1: integer): Mass
+---@field to_gram fun(arg1: Mass): integer
+---@field to_kilogram fun(arg1: Mass): integer
+---@field to_milligram fun(arg1: Mass): integer
 ---@field to_newton fun(arg1: Mass): integer
 ---@field __eq fun(arg1: Mass, arg2: Mass): boolean
+---@field __le fun(arg1: Mass, arg2: Mass): boolean
+---@field __lt fun(arg1: Mass, arg2: Mass): boolean
 Mass = {}
 
 ---@class Monster : Creature
----@field friendly integer
----@field get_upgrade_time fun(arg1: Monster): integer
----@field try_upgrade fun(arg1: Monster, arg2: boolean)
----@field try_reproduce fun(arg1: Monster)
----@field refill_udders fun(arg1: Monster)
----@field spawn fun(arg1: Monster, arg2: Tripoint)
----@field name fun(arg1: Monster, arg2: integer): string
----@field name_with_armor fun(arg1: Monster): string
----@field can_see fun(arg1: Monster): boolean
----@field can_hear fun(arg1: Monster): boolean
----@field can_submerge fun(arg1: Monster): boolean
 ---@field anger integer
----@field can_drown fun(arg1: Monster): boolean
+---@field attitude fun(arg1: Monster, arg2: Character): MonsterAttitude
 ---@field can_climb fun(arg1: Monster): boolean
 ---@field can_dig fun(arg1: Monster): boolean
----@field digs fun(arg1: Monster): boolean
----@field flies fun(arg1: Monster): boolean
----@field climbs fun(arg1: Monster): boolean
----@field swims fun(arg1: Monster): boolean
----@field move_target fun(arg1: Monster): Tripoint
----@field is_wandering fun(arg1: Monster): boolean
----@field wander_to fun(arg1: Monster, arg2: Tripoint, arg3: integer)
----@field morale integer
----@field move_to fun(arg1: Monster, arg2: Tripoint, arg3: boolean, arg4: boolean, arg5: number): boolean
----@field attitude fun(arg1: Monster, arg2: Character): MonsterAttitude
----@field heal fun(arg1: Monster, arg2: integer, arg3: boolean): integer
----@field set_hp fun(arg1: Monster, arg2: integer)
----@field make_fungus fun(arg1: Monster): boolean
----@field make_friendly fun(arg1: Monster)
----@field make_ally fun(arg1: Monster, arg2: Monster)
----@field faction MonsterFactionIntId
----@field death_drops boolean
----@field unique_name string
----@field get_type fun(arg1: Monster): MtypeId
+---@field can_drown fun(arg1: Monster): boolean
+---@field can_hear fun(arg1: Monster): boolean
+---@field can_see fun(arg1: Monster): boolean
+---@field can_submerge fun(arg1: Monster): boolean
 ---@field can_upgrade fun(arg1: Monster): boolean
+---@field climbs fun(arg1: Monster): boolean
+---@field death_drops boolean
+---@field digs fun(arg1: Monster): boolean
+---@field faction MonsterFactionIntId
+---@field flies fun(arg1: Monster): boolean
+---@field friendly integer
+---@field get_type fun(arg1: Monster): MtypeId
+---@field get_upgrade_time fun(arg1: Monster): integer
 ---@field hasten_upgrade fun(arg1: Monster)
+---@field heal fun(arg1: Monster, arg2: integer, arg3: boolean): integer
+---@field is_wandering fun(arg1: Monster): boolean
+---@field make_ally fun(arg1: Monster, arg2: Monster)
+---@field make_friendly fun(arg1: Monster)
+---@field make_fungus fun(arg1: Monster): boolean
+---@field morale integer
+---@field move_target fun(arg1: Monster): Tripoint
+---@field move_to fun(arg1: Monster, arg2: Tripoint, arg3: boolean, arg4: boolean, arg5: number): boolean
+---@field name fun(arg1: Monster, arg2: integer): string
+---@field name_with_armor fun(arg1: Monster): string
+---@field refill_udders fun(arg1: Monster)
+---@field set_hp fun(arg1: Monster, arg2: integer)
+---@field spawn fun(arg1: Monster, arg2: Tripoint)
+---@field swims fun(arg1: Monster): boolean
+---@field try_reproduce fun(arg1: Monster)
+---@field try_upgrade fun(arg1: Monster, arg2: boolean)
+---@field unique_name string
+---@field wander_to fun(arg1: Monster, arg2: Tripoint, arg3: integer)
 Monster = {}
 
 ---@class MonsterFactionId
----@field obj fun(arg1: MonsterFactionId): MonsterFactionRaw
----@field deserialize fun(arg1: MonsterFactionId)
----@field int_id fun(arg1: MonsterFactionId): MonsterFactionIntId
 ---@field implements_int_id fun(): boolean
+---@field int_id fun(arg1: MonsterFactionId): MonsterFactionIntId
 ---@field is_null fun(arg1: MonsterFactionId): boolean
 ---@field is_valid fun(arg1: MonsterFactionId): boolean
----@field str fun(arg1: MonsterFactionId): string
 ---@field NULL_ID fun(): MonsterFactionId
----@field __tostring fun(arg1: MonsterFactionId): string
+---@field obj fun(arg1: MonsterFactionId): MonsterFactionRaw
+---@field str fun(arg1: MonsterFactionId): string
 ---@field serialize fun(arg1: MonsterFactionId)
+---@field deserialize fun(arg1: MonsterFactionId)
+---@field __tostring fun(arg1: MonsterFactionId): string
 ---@field new fun(): MonsterFactionId | fun(arg1: MonsterFactionId): MonsterFactionId | fun(arg1: MonsterFactionIntId): MonsterFactionId | fun(arg1: string): MonsterFactionId
 MonsterFactionId = {}
 
 ---@class MonsterFactionIntId
+---@field is_valid fun(arg1: MonsterFactionIntId): boolean
 ---@field obj fun(arg1: MonsterFactionIntId): MonsterFactionRaw
 ---@field str_id fun(arg1: MonsterFactionIntId): MonsterFactionId
----@field is_valid fun(arg1: MonsterFactionIntId): boolean
 ---@field __tostring fun(arg1: MonsterFactionIntId): string
 ---@field new fun(): MonsterFactionIntId | fun(arg1: MonsterFactionIntId): MonsterFactionIntId | fun(arg1: MonsterFactionId): MonsterFactionIntId
 MonsterFactionIntId = {}
 
 ---@class MoraleTypeDataId
----@field obj fun(arg1: MoraleTypeDataId): MoraleTypeDataRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: MoraleTypeDataId): boolean
 ---@field is_valid fun(arg1: MoraleTypeDataId): boolean
----@field str fun(arg1: MoraleTypeDataId): string
 ---@field NULL_ID fun(): MoraleTypeDataId
----@field __tostring fun(arg1: MoraleTypeDataId): string
+---@field obj fun(arg1: MoraleTypeDataId): MoraleTypeDataRaw
+---@field str fun(arg1: MoraleTypeDataId): string
 ---@field serialize fun(arg1: MoraleTypeDataId)
 ---@field deserialize fun(arg1: MoraleTypeDataId)
+---@field __tostring fun(arg1: MoraleTypeDataId): string
 ---@field new fun(): MoraleTypeDataId | fun(arg1: MoraleTypeDataId): MoraleTypeDataId | fun(arg1: string): MoraleTypeDataId
 MoraleTypeDataId = {}
 
 ---@class MtypeId
----@field obj fun(arg1: MtypeId): MtypeRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: MtypeId): boolean
 ---@field is_valid fun(arg1: MtypeId): boolean
----@field str fun(arg1: MtypeId): string
 ---@field NULL_ID fun(): MtypeId
----@field __tostring fun(arg1: MtypeId): string
+---@field obj fun(arg1: MtypeId): MtypeRaw
+---@field str fun(arg1: MtypeId): string
 ---@field serialize fun(arg1: MtypeId)
 ---@field deserialize fun(arg1: MtypeId)
+---@field __tostring fun(arg1: MtypeId): string
 ---@field new fun(): MtypeId | fun(arg1: MtypeId): MtypeId | fun(arg1: string): MtypeId
 MtypeId = {}
 
 ---@class MutationBranchId
----@field obj fun(arg1: MutationBranchId): MutationBranchRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: MutationBranchId): boolean
 ---@field is_valid fun(arg1: MutationBranchId): boolean
----@field str fun(arg1: MutationBranchId): string
 ---@field NULL_ID fun(): MutationBranchId
----@field __tostring fun(arg1: MutationBranchId): string
+---@field obj fun(arg1: MutationBranchId): MutationBranchRaw
+---@field str fun(arg1: MutationBranchId): string
 ---@field serialize fun(arg1: MutationBranchId)
 ---@field deserialize fun(arg1: MutationBranchId)
+---@field __tostring fun(arg1: MutationBranchId): string
 ---@field new fun(): MutationBranchId | fun(arg1: MutationBranchId): MutationBranchId | fun(arg1: string): MutationBranchId
 MutationBranchId = {}
 
 ---@class MutationBranchRaw
----@field id MutationBranchId
 ---@field activated boolean @Whether this mutation can be activated at will.
----@field starts_active boolean @Whether a mutation activates when granted.
+---@field addition_mutations fun(arg1: MutationBranchRaw): any
 ---@field allow_soft_gear boolean @Mutation allows soft gear to be worn over otherwise-restricted parts.
----@field fatigue boolean @Mutation causes fatigue when used.
----@field hunger boolean @Mutation deducts calories when used.
----@field thirst boolean @Mutation dehydrates when used.
----@field points integer @Point cost in character creation(?).
----@field visibility integer @How visible the mutation is to others.
----@field ugliness integer @How physically unappealing the mutation is. Can be negative.
----@field cost integer
----@field valid boolean @Whether this mutation is available through generic mutagen.
----@field cooldown integer @Costs are incurred every 'cooldown' turns.
----@field bodytemp_min_btu integer
----@field bodytemp_max_btu integer
----@field bodytemp_sleep_btu integer
----@field pain_recovery number @Pain recovery per turn from mutation.
----@field healing_awake number @Healing per turn from mutation.
----@field healing_resting number @Healing per turn from mutation, while asleep.
----@field mending_modifier number @Multiplier applied to broken limb regeneration. Normally 0.25; clamped to 0.25..1.0.
----@field hp_modifier number @Bonus HP multiplier. 1.0 doubles HP; -0.5 halves it.
----@field hp_modifier_secondary number @Secondary HP multiplier; stacks with the other one. 1.0 doubles HP; -0.5 halves it.
----@field purifiable boolean @Whether this mutation is possible to remove through Purifier. False for 'special' mutations.
----@field hp_adjustment number @Flat adjustment to HP.
----@field str_modifier number @Adjustment to Strength that doesn't affect HP.
----@field dodge_modifier number
----@field speed_modifier number
----@field movecost_modifier number
----@field movecost_flatground_modifier number
----@field movecost_obstacle_modifier number
 ---@field attackcost_modifier number
----@field falling_damage_multiplier number
----@field max_stamina_modifier number
----@field threshold boolean @Whether this is a Threshold mutation, and thus especially difficult to mutate. One per character.
----@field weight_capacity_modifier number
----@field hearing_modifier number
----@field movecost_swim_modifier number
----@field noise_modifier number
----@field scent_modifier number
 ---@field bleed_resist number
----@field healthy_rate number @How quickly health (not HP) trends toward healthy_mod.
----@field stealth_modifier number
----@field night_vision_range number
----@field temperature_speed_modifier number
----@field profession boolean @Whether this trait is ONLY gained through professional training/experience (and/or quests).
----@field metabolism_modifier number
----@field thirst_modifier number
----@field fatigue_modifier number
----@field fatigue_regen_modifier number
----@field stamina_regen_modifier number
----@field overmap_sight number
----@field overmap_multiplier number
----@field reading_speed_multiplier number
----@field skill_rust_multiplier number
----@field name fun(arg1: MutationBranchRaw): string
+---@field bodytemp_max_btu integer
+---@field bodytemp_min_btu integer
+---@field bodytemp_sleep_btu integer
+---@field categories fun(arg1: MutationBranchRaw): any @Lists the categories this mutation belongs to.
+---@field conflicts_with fun(arg1: MutationBranchRaw): any @Lists conflicting mutations.
+---@field cooldown integer @Costs are incurred every 'cooldown' turns.
+---@field cost integer
 ---@field debug boolean @Whether or not this mutation is limited to debug use.
 ---@field desc fun(arg1: MutationBranchRaw): string
+---@field dodge_modifier number
+---@field falling_damage_multiplier number
+---@field fatigue boolean @Mutation causes fatigue when used.
+---@field fatigue_modifier number
+---@field fatigue_regen_modifier number
 ---@field get_all fun(): any @Returns a (long) list of every mutation in the game.
----@field __tostring fun(arg1: MutationBranchRaw): string
----@field prerequisites fun(arg1: MutationBranchRaw): any @Lists the primary mutation(s) needed to gain this mutation.
----@field other_prerequisites fun(arg1: MutationBranchRaw): any @Lists the secondary mutation(s) needed to gain this mutation.
----@field thresh_requirements fun(arg1: MutationBranchRaw): any @Lists the threshold mutation(s) required to gain this mutation.
----@field mutation_types fun(arg1: MutationBranchRaw): any @Lists the type(s) of this mutation. Mutations of a given type are mutually exclusive.
----@field conflicts_with fun(arg1: MutationBranchRaw): any @Lists conflicting mutations.
----@field replaced_by fun(arg1: MutationBranchRaw): any @Lists mutations that replace (e.g. evolve from) this one.
----@field addition_mutations fun(arg1: MutationBranchRaw): any
----@field player_display boolean @Whether or not this mutation shows up in the status (`@`) menu.
----@field categories fun(arg1: MutationBranchRaw): any @Lists the categories this mutation belongs to.
+---@field healing_awake number @Healing per turn from mutation.
+---@field healing_resting number @Healing per turn from mutation, while asleep.
+---@field healthy_rate number @How quickly health (not HP) trends toward healthy_mod.
+---@field hearing_modifier number
+---@field hp_adjustment number @Flat adjustment to HP.
+---@field hp_modifier number @Bonus HP multiplier. 1.0 doubles HP; -0.5 halves it.
+---@field hp_modifier_secondary number @Secondary HP multiplier; stacks with the other one. 1.0 doubles HP; -0.5 halves it.
+---@field hunger boolean @Mutation deducts calories when used.
+---@field id MutationBranchId
+---@field max_stamina_modifier number
+---@field mending_modifier number @Multiplier applied to broken limb regeneration. Normally 0.25; clamped to 0.25..1.0.
+---@field metabolism_modifier number
 ---@field mixed_effect boolean @Whether this mutation has positive /and/ negative effects.
+---@field movecost_flatground_modifier number
+---@field movecost_modifier number
+---@field movecost_obstacle_modifier number
+---@field movecost_swim_modifier number
+---@field mutation_types fun(arg1: MutationBranchRaw): any @Lists the type(s) of this mutation. Mutations of a given type are mutually exclusive.
+---@field name fun(arg1: MutationBranchRaw): string
+---@field night_vision_range number
+---@field noise_modifier number
+---@field other_prerequisites fun(arg1: MutationBranchRaw): any @Lists the secondary mutation(s) needed to gain this mutation.
+---@field overmap_multiplier number
+---@field overmap_sight number
+---@field pain_recovery number @Pain recovery per turn from mutation.
+---@field player_display boolean @Whether or not this mutation shows up in the status (`@`) menu.
+---@field points integer @Point cost in character creation(?).
+---@field prerequisites fun(arg1: MutationBranchRaw): any @Lists the primary mutation(s) needed to gain this mutation.
+---@field profession boolean @Whether this trait is ONLY gained through professional training/experience (and/or quests).
+---@field purifiable boolean @Whether this mutation is possible to remove through Purifier. False for 'special' mutations.
+---@field reading_speed_multiplier number
+---@field replaced_by fun(arg1: MutationBranchRaw): any @Lists mutations that replace (e.g. evolve from) this one.
+---@field scent_modifier number
+---@field skill_rust_multiplier number
+---@field speed_modifier number
+---@field stamina_regen_modifier number
 ---@field starting_trait boolean @Whether this trait can normally be taken during character generation.
+---@field starts_active boolean @Whether a mutation activates when granted.
+---@field stealth_modifier number
+---@field str_modifier number @Adjustment to Strength that doesn't affect HP.
+---@field temperature_speed_modifier number
+---@field thirst boolean @Mutation dehydrates when used.
+---@field thirst_modifier number
+---@field threshold boolean @Whether this is a Threshold mutation, and thus especially difficult to mutate. One per character.
+---@field thresh_requirements fun(arg1: MutationBranchRaw): any @Lists the threshold mutation(s) required to gain this mutation.
+---@field ugliness integer @How physically unappealing the mutation is. Can be negative.
+---@field valid boolean @Whether this mutation is available through generic mutagen.
+---@field visibility integer @How visible the mutation is to others.
+---@field weight_capacity_modifier number
+---@field __tostring fun(arg1: MutationBranchRaw): string
 MutationBranchRaw = {}
 
 ---@class MutationCategoryTraitId
----@field obj fun(arg1: MutationCategoryTraitId): MutationCategoryTraitRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: MutationCategoryTraitId): boolean
 ---@field is_valid fun(arg1: MutationCategoryTraitId): boolean
----@field str fun(arg1: MutationCategoryTraitId): string
 ---@field NULL_ID fun(): MutationCategoryTraitId
----@field __tostring fun(arg1: MutationCategoryTraitId): string
+---@field obj fun(arg1: MutationCategoryTraitId): MutationCategoryTraitRaw
+---@field str fun(arg1: MutationCategoryTraitId): string
 ---@field serialize fun(arg1: MutationCategoryTraitId)
 ---@field deserialize fun(arg1: MutationCategoryTraitId)
+---@field __tostring fun(arg1: MutationCategoryTraitId): string
 ---@field new fun(): MutationCategoryTraitId | fun(arg1: MutationCategoryTraitId): MutationCategoryTraitId | fun(arg1: string): MutationCategoryTraitId
 MutationCategoryTraitId = {}
 
 ---@class Npc : Player, Character, Creature
+---@field can_move_to fun(arg1: Npc, arg2: Tripoint, arg3: boolean): boolean
+---@field can_open_door fun(arg1: Npc, arg2: Tripoint, arg3: boolean): boolean
+---@field complain fun(arg1: Npc): boolean
+---@field complain_about fun(arg1: Npc, arg2: string, arg3: TimeDuration, arg4: string, arg5: any): boolean
 ---@field current_activity_id ActivityTypeId
+---@field current_ally fun(arg1: Npc): Creature
+---@field current_target fun(arg1: Npc): Creature
+---@field danger_assessment fun(arg1: Npc): number
+---@field evaluate_enemy fun(arg1: Npc, arg2: Creature): number
+---@field follow_distance fun(arg1: Npc): integer
+---@field get_attitude fun(arg1: Npc): NpcAttitude
+---@field get_monster_faction fun(arg1: Npc): MonsterFactionIntId
+---@field guaranteed_hostile fun(arg1: Npc): boolean
+---@field has_activity fun(arg1: Npc): boolean
+---@field has_omt_destination fun(arg1: Npc): boolean
+---@field has_player_activity fun(arg1: Npc): boolean
+---@field hit_by_player boolean
 ---@field hostile_anger_level fun(arg1: Npc): integer
----@field make_angry fun(arg1: Npc)
+---@field is_ally fun(arg1: Npc, arg2: Character): boolean
 ---@field is_enemy fun(arg1: Npc): boolean
 ---@field is_following fun(arg1: Npc): boolean
----@field is_obeying fun(arg1: Npc, arg2: Character): boolean
 ---@field is_friendly fun(arg1: Npc, arg2: Character): boolean
----@field is_leader fun(arg1: Npc): boolean
----@field is_walking_with fun(arg1: Npc): boolean
----@field is_ally fun(arg1: Npc, arg2: Character): boolean
----@field is_player_ally fun(arg1: Npc): boolean
----@field personality NpcPersonality
----@field is_stationary fun(arg1: Npc, arg2: boolean): boolean
 ---@field is_guarding fun(arg1: Npc): boolean
----@field is_patrolling fun(arg1: Npc): boolean
----@field has_player_activity fun(arg1: Npc): boolean
----@field is_travelling fun(arg1: Npc): boolean
+---@field is_leader fun(arg1: Npc): boolean
 ---@field is_minion fun(arg1: Npc): boolean
----@field guaranteed_hostile fun(arg1: Npc): boolean
----@field mutiny fun(arg1: Npc)
----@field get_monster_faction fun(arg1: Npc): MonsterFactionIntId
----@field follow_distance fun(arg1: Npc): integer
----@field op_of_u NpcOpinion
----@field current_target fun(arg1: Npc): Creature
----@field current_ally fun(arg1: Npc): Creature
----@field danger_assessment fun(arg1: Npc): number
----@field say fun(arg1: Npc, arg2: string)
----@field smash_ability fun(arg1: Npc): integer
----@field complain_about fun(arg1: Npc, arg2: string, arg3: TimeDuration, arg4: string, arg5: any): boolean
----@field warn_about fun(arg1: Npc, arg2: string, arg3: TimeDuration, arg4: string, arg5: integer, arg6: Tripoint)
----@field complain fun(arg1: Npc): boolean
----@field evaluate_enemy fun(arg1: Npc, arg2: Creature): number
----@field can_open_door fun(arg1: Npc, arg2: Tripoint, arg3: boolean): boolean
----@field patience integer
----@field can_move_to fun(arg1: Npc, arg2: Tripoint, arg3: boolean): boolean
----@field saw_player_recently fun(arg1: Npc): boolean
----@field has_omt_destination fun(arg1: Npc): boolean
----@field get_attitude fun(arg1: Npc): NpcAttitude
----@field set_attitude fun(arg1: Npc, arg2: NpcAttitude)
----@field has_activity fun(arg1: Npc): boolean
+---@field is_obeying fun(arg1: Npc, arg2: Character): boolean
+---@field is_patrolling fun(arg1: Npc): boolean
+---@field is_player_ally fun(arg1: Npc): boolean
+---@field is_stationary fun(arg1: Npc, arg2: boolean): boolean
+---@field is_travelling fun(arg1: Npc): boolean
+---@field is_walking_with fun(arg1: Npc): boolean
+---@field make_angry fun(arg1: Npc)
 ---@field marked_for_death boolean
----@field hit_by_player boolean
+---@field mutiny fun(arg1: Npc)
 ---@field needs any
+---@field op_of_u NpcOpinion
+---@field patience integer
+---@field personality NpcPersonality
+---@field saw_player_recently fun(arg1: Npc): boolean
+---@field say fun(arg1: Npc, arg2: string)
+---@field set_attitude fun(arg1: Npc, arg2: NpcAttitude)
 ---@field set_faction_id fun(arg1: Npc, arg2: FactionId)
+---@field smash_ability fun(arg1: Npc): integer
 ---@field turned_hostile fun(arg1: Npc): boolean
+---@field warn_about fun(arg1: Npc, arg2: string, arg3: TimeDuration, arg4: string, arg5: integer, arg6: Tripoint)
 Npc = {}
 
 ---@class NpcOpinion
----@field trust integer
----@field fear integer
----@field value integer
 ---@field anger integer
+---@field fear integer
 ---@field owed integer
+---@field trust integer
+---@field value integer
 ---@field new fun(): NpcOpinion | fun(arg1: integer, arg2: integer, arg3: integer, arg4: integer, arg5: integer): NpcOpinion
 NpcOpinion = {}
 
 ---@class NpcPersonality
 ---@field aggression integer
+---@field altruism integer
 ---@field bravery integer
 ---@field collector integer
----@field altruism integer
 ---@field new fun(): NpcPersonality
 NpcPersonality = {}
 
@@ -1048,36 +1065,36 @@ NpcPersonality = {}
 Player = {}
 
 ---@class Point
----@field x integer
----@field __add fun(arg1: Point, arg2: Point): Point
----@field __sub fun(arg1: Point, arg2: Point): Point
----@field __mul fun(arg1: Point, arg2: integer): Point
----@field __div fun(arg1: Point, arg2: integer): Point
----@field __idiv fun(arg1: Point, arg2: integer): Point
----@field __unm fun(arg1: Point): Point
----@field y integer
 ---@field abs fun(arg1: Point): Point
 ---@field rotate fun(arg1: Point, arg2: integer, arg3: Point): Point
+---@field x integer
+---@field y integer
 ---@field serialize fun(arg1: Point)
 ---@field deserialize fun(arg1: Point)
----@field __tostring fun(arg1: Point): string
+---@field __add fun(arg1: Point, arg2: Point): Point
+---@field __div fun(arg1: Point, arg2: integer): Point
 ---@field __eq fun(arg1: Point, arg2: Point): boolean
+---@field __idiv fun(arg1: Point, arg2: integer): Point
 ---@field __lt fun(arg1: Point, arg2: Point): boolean
+---@field __mul fun(arg1: Point, arg2: integer): Point
+---@field __sub fun(arg1: Point, arg2: Point): Point
+---@field __tostring fun(arg1: Point): string
+---@field __unm fun(arg1: Point): Point
 ---@field new fun(): Point | fun(arg1: Point): Point | fun(arg1: integer, arg2: integer): Point
 Point = {}
 
 ---@class PopupInputStr
----@field title fun(arg1: PopupInputStr, arg2: string) @`title` is on the left of input field.
 ---@field desc fun(arg1: PopupInputStr, arg2: string) @`desc` is above input field.
----@field query_str fun(arg1: PopupInputStr): string @Returns your input.
 ---@field query_int fun(arg1: PopupInputStr): integer @Returns your input, but allows numbers only.
+---@field query_str fun(arg1: PopupInputStr): string @Returns your input.
+---@field title fun(arg1: PopupInputStr, arg2: string) @`title` is on the left of input field.
 ---@field new fun(): PopupInputStr
 PopupInputStr = {}
 
 ---@class QueryPopup
+---@field allow_any_key fun(arg1: QueryPopup, arg2: boolean) @Set whether to allow any key
 ---@field message fun(arg1: QueryPopup, arg2: any)
 ---@field message_color fun(arg1: QueryPopup, arg2: Color)
----@field allow_any_key fun(arg1: QueryPopup, arg2: boolean) @Set whether to allow any key
 ---@field query fun(arg1: QueryPopup): string @Returns selected action
 ---@field query_yn fun(arg1: QueryPopup): string @Returns `YES` or `NO`. If ESC pressed, returns `NO`.
 ---@field query_ynq fun(arg1: QueryPopup): string @Returns `YES`, `NO` or `QUIT`. If ESC pressed, returns `QUIT`.
@@ -1085,216 +1102,216 @@ PopupInputStr = {}
 QueryPopup = {}
 
 ---@class RecipeId
----@field obj fun(arg1: RecipeId): RecipeRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: RecipeId): boolean
 ---@field is_valid fun(arg1: RecipeId): boolean
----@field str fun(arg1: RecipeId): string
 ---@field NULL_ID fun(): RecipeId
----@field __tostring fun(arg1: RecipeId): string
+---@field obj fun(arg1: RecipeId): RecipeRaw
+---@field str fun(arg1: RecipeId): string
 ---@field serialize fun(arg1: RecipeId)
 ---@field deserialize fun(arg1: RecipeId)
+---@field __tostring fun(arg1: RecipeId): string
 ---@field new fun(): RecipeId | fun(arg1: RecipeId): RecipeId | fun(arg1: string): RecipeId
 RecipeId = {}
 
 ---@class SkillId
----@field obj fun(arg1: SkillId): SkillRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: SkillId): boolean
 ---@field is_valid fun(arg1: SkillId): boolean
----@field str fun(arg1: SkillId): string
 ---@field NULL_ID fun(): SkillId
----@field __tostring fun(arg1: SkillId): string
+---@field obj fun(arg1: SkillId): SkillRaw
+---@field str fun(arg1: SkillId): string
 ---@field serialize fun(arg1: SkillId)
 ---@field deserialize fun(arg1: SkillId)
+---@field __tostring fun(arg1: SkillId): string
 ---@field new fun(): SkillId | fun(arg1: SkillId): SkillId | fun(arg1: string): SkillId
 SkillId = {}
 
 ---@class SkillLevel
+---@field can_train fun(arg1: SkillLevel): boolean
+---@field highest_level fun(arg1: SkillLevel): integer
 ---@field is_training fun(arg1: SkillLevel): boolean
 ---@field level fun(arg1: SkillLevel): integer
----@field highest_level fun(arg1: SkillLevel): integer
 ---@field train fun(arg1: SkillLevel, arg2: integer, arg3: boolean)
----@field can_train fun(arg1: SkillLevel): boolean
 SkillLevel = {}
 
 ---@class SkillLevelMap : any
----@field mod_skill_level fun(arg1: SkillLevelMap, arg2: SkillId, arg3: integer)
 ---@field get_skill_level fun(arg1: SkillLevelMap, arg2: SkillId): integer
 ---@field get_skill_level_object fun(arg1: SkillLevelMap, arg2: SkillId): SkillLevel
+---@field mod_skill_level fun(arg1: SkillLevelMap, arg2: SkillId, arg3: integer)
 SkillLevelMap = {}
 
 ---@class SpeciesTypeId
----@field obj fun(arg1: SpeciesTypeId): SpeciesTypeRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: SpeciesTypeId): boolean
 ---@field is_valid fun(arg1: SpeciesTypeId): boolean
----@field str fun(arg1: SpeciesTypeId): string
 ---@field NULL_ID fun(): SpeciesTypeId
----@field __tostring fun(arg1: SpeciesTypeId): string
+---@field obj fun(arg1: SpeciesTypeId): SpeciesTypeRaw
+---@field str fun(arg1: SpeciesTypeId): string
 ---@field serialize fun(arg1: SpeciesTypeId)
 ---@field deserialize fun(arg1: SpeciesTypeId)
+---@field __tostring fun(arg1: SpeciesTypeId): string
 ---@field new fun(): SpeciesTypeId | fun(arg1: SpeciesTypeId): SpeciesTypeId | fun(arg1: string): SpeciesTypeId
 SpeciesTypeId = {}
 
 --- The class used for spells that *a player* knows, casts, and gains experience for using. If a given spell is not supposed to be directly cast by a player, consider using SpellSimple instead.
 ---@class Spell
----@field id SpellTypeId
 ---@field cast fun(arg1: Spell, arg2: Creature, arg3: Tripoint) @Cast this spell, as well as any sub-spells.
 ---@field cast_single_effect fun(arg1: Spell, arg2: Creature, arg3: Tripoint) @Cast *only* this spell's main effects. Generally, cast() should be used instead.
----@field xp fun(arg1: Spell): integer
----@field gain_exp fun(arg1: Spell, arg2: integer)
----@field set_exp fun(arg1: Spell, arg2: integer)
----@field gain_levels fun(arg1: Spell, arg2: integer)
----@field set_level fun(arg1: Spell, arg2: integer)
----@field get_level fun(arg1: Spell): integer
----@field name fun(arg1: Spell): string
 ---@field desc fun(arg1: Spell): string
+---@field gain_exp fun(arg1: Spell, arg2: integer)
+---@field gain_levels fun(arg1: Spell, arg2: integer)
+---@field get_level fun(arg1: Spell): integer
+---@field id SpellTypeId
+---@field name fun(arg1: Spell): string
+---@field set_exp fun(arg1: Spell, arg2: integer)
+---@field set_level fun(arg1: Spell, arg2: integer)
+---@field xp fun(arg1: Spell): integer
 ---@field new fun(arg1: SpellTypeId, arg2: integer): Spell
 Spell = {}
 
 --- The type for basic spells. If you don't need to track XP from casting (e.g., if a spell is intended to be cast by anything *other than* a player), this is likely the appropriate type. Otherwise, see the Spell type.
 ---@class SpellSimple
----@field __tostring fun(arg1: SpellSimple): string
----@field id SpellTypeId
----@field max_level fun(arg1: SpellSimple): integer @Returns the defined maximum level of this SpellSimple instance, if defined. Otherwise, returns 0.
----@field level integer
----@field force_target_source boolean @Whether or not the target point is *locked* to the source's location.
----@field trigger_once_in integer @Used for enchantments; the spell's *chance* to trigger every turn.
 ---@field cast fun(arg1: SpellSimple, arg2: Creature, arg3: Tripoint, arg4: any)
+---@field force_target_source boolean @Whether or not the target point is *locked* to the source's location.
+---@field id SpellTypeId
+---@field level integer
+---@field max_level fun(arg1: SpellSimple): integer @Returns the defined maximum level of this SpellSimple instance, if defined. Otherwise, returns 0.
 ---@field prompt_cast fun(arg1: SpellTypeId, arg2: Tripoint, arg3: any): SpellSimple @Static function: Creates and immediately casts a SimpleSpell, then returns the new spell for potential reuse. If the given tripoint is the player's location, the spell will be locked to the player. (This does not necessarily cause friendly fire!) If an integer is specified, the spell will be cast at that level.
+---@field trigger_once_in integer @Used for enchantments; the spell's *chance* to trigger every turn.
+---@field __tostring fun(arg1: SpellSimple): string
 ---@field new fun(arg1: SpellTypeId, arg2: boolean): SpellSimple | fun(arg1: SpellTypeId, arg2: boolean, arg3: integer): SpellSimple
 SpellSimple = {}
 
 ---@class SpellTypeId
----@field obj fun(arg1: SpellTypeId): SpellTypeRaw
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: SpellTypeId): boolean
 ---@field is_valid fun(arg1: SpellTypeId): boolean
----@field str fun(arg1: SpellTypeId): string
 ---@field NULL_ID fun(): SpellTypeId
----@field __tostring fun(arg1: SpellTypeId): string
+---@field obj fun(arg1: SpellTypeId): SpellTypeRaw
+---@field str fun(arg1: SpellTypeId): string
 ---@field serialize fun(arg1: SpellTypeId)
 ---@field deserialize fun(arg1: SpellTypeId)
+---@field __tostring fun(arg1: SpellTypeId): string
 ---@field new fun(): SpellTypeId | fun(arg1: SpellTypeId): SpellTypeId | fun(arg1: string): SpellTypeId
 SpellTypeId = {}
 
 --- The 'raw' type for storing the information defining every spell in the game. It's not possible to cast directly from this type; check SpellSimple and Spell.
 ---@class SpellTypeRaw
----@field __tostring fun(arg1: SpellTypeRaw): string
----@field min_damage integer
+---@field additional_spells fun(arg1: SpellTypeRaw): any @Other spells cast by this spell.
+---@field aoe_increment number
+---@field base_casting_time integer
+---@field base_energy_cost integer
+---@field casting_time_increment number
 ---@field damage_increment number
+---@field difficulty integer
+---@field dot_increment number
+---@field duration_increment integer
+---@field effect_name string @The name of the primary effect this spell will enact.
+---@field effect_str string @Specifics about the effect this spell will enact.
+---@field energy_increment number
+---@field field_chance integer
+---@field field_intensity_increment number
+---@field field_intensity_variance number
+---@field final_casting_time integer
+---@field final_energy_cost integer
+---@field get_all fun(): any @Returns a (long) list of every spell in the game.
+---@field id SpellTypeId
+---@field max_aoe integer
 ---@field max_damage integer
----@field min_range integer
----@field range_increment number
+---@field max_dot integer
+---@field max_duration integer
+---@field max_field_intensity integer
+---@field max_level integer
 ---@field max_range integer
 ---@field min_aoe integer
----@field aoe_increment number
----@field max_aoe integer
+---@field min_damage integer
 ---@field min_dot integer
----@field id SpellTypeId
----@field dot_increment number
----@field max_dot integer
 ---@field min_duration integer
----@field duration_increment integer
----@field max_duration integer
----@field base_energy_cost integer
----@field energy_increment number
----@field final_energy_cost integer
----@field difficulty integer
----@field max_level integer
----@field effect_name string @The name of the primary effect this spell will enact.
----@field base_casting_time integer
----@field casting_time_increment number
----@field final_casting_time integer
----@field additional_spells fun(arg1: SpellTypeRaw): any @Other spells cast by this spell.
----@field get_all fun(): any @Returns a (long) list of every spell in the game.
----@field effect_str string @Specifics about the effect this spell will enact.
----@field field_chance integer
 ---@field min_field_intensity integer
----@field field_intensity_increment number
----@field max_field_intensity integer
----@field field_intensity_variance number
+---@field min_range integer
+---@field range_increment number
+---@field __tostring fun(arg1: SpellTypeRaw): string
 SpellTypeRaw = {}
 
 ---@class TerId
----@field obj fun(arg1: TerId): TerRaw
----@field deserialize fun(arg1: TerId)
----@field int_id fun(arg1: TerId): TerIntId
 ---@field implements_int_id fun(): boolean
+---@field int_id fun(arg1: TerId): TerIntId
 ---@field is_null fun(arg1: TerId): boolean
 ---@field is_valid fun(arg1: TerId): boolean
----@field str fun(arg1: TerId): string
 ---@field NULL_ID fun(): TerId
----@field __tostring fun(arg1: TerId): string
+---@field obj fun(arg1: TerId): TerRaw
+---@field str fun(arg1: TerId): string
 ---@field serialize fun(arg1: TerId)
+---@field deserialize fun(arg1: TerId)
+---@field __tostring fun(arg1: TerId): string
 ---@field new fun(): TerId | fun(arg1: TerId): TerId | fun(arg1: TerIntId): TerId | fun(arg1: string): TerId
 TerId = {}
 
 ---@class TerIntId
+---@field is_valid fun(arg1: TerIntId): boolean
 ---@field obj fun(arg1: TerIntId): TerRaw
 ---@field str_id fun(arg1: TerIntId): TerId
----@field is_valid fun(arg1: TerIntId): boolean
 ---@field __tostring fun(arg1: TerIntId): string
 ---@field new fun(): TerIntId | fun(arg1: TerIntId): TerIntId | fun(arg1: TerId): TerIntId
 TerIntId = {}
 
 ---@class TerRaw
----@field str_id fun(arg1: TerRaw): TerId
+---@field close TerId
+---@field heat_radiation integer
 ---@field int_id fun(arg1: TerRaw): TerIntId
 ---@field open TerId
----@field close TerId
----@field trap_id_str string
----@field transforms_into TerId
 ---@field roof TerId
----@field heat_radiation integer
+---@field str_id fun(arg1: TerRaw): TerId
+---@field transforms_into TerId
+---@field trap_id_str string
 TerRaw = {}
 
 --- Represent duration between 2 fixed points in time
 ---@class TimeDuration
+---@field from_days fun(arg1: integer): TimeDuration
+---@field from_hours fun(arg1: integer): TimeDuration
+---@field from_minutes fun(arg1: integer): TimeDuration
+---@field from_seconds fun(arg1: integer): TimeDuration
 ---@field from_turns fun(arg1: integer): TimeDuration
----@field to_minutes fun(arg1: TimeDuration): integer
----@field to_hours fun(arg1: TimeDuration): integer
+---@field from_weeks fun(arg1: integer): TimeDuration
+---@field make_random fun(arg1: TimeDuration, arg2: TimeDuration): TimeDuration
 ---@field to_days fun(arg1: TimeDuration): integer
+---@field to_hours fun(arg1: TimeDuration): integer
+---@field to_minutes fun(arg1: TimeDuration): integer
+---@field to_seconds fun(arg1: TimeDuration): integer
+---@field to_turns fun(arg1: TimeDuration): integer
 ---@field to_weeks fun(arg1: TimeDuration): integer
 ---@field serialize fun(arg1: TimeDuration)
 ---@field deserialize fun(arg1: TimeDuration)
----@field __tostring fun(arg1: TimeDuration): string
 ---@field __add fun(arg1: TimeDuration, arg2: TimeDuration): TimeDuration
----@field __sub fun(arg1: TimeDuration, arg2: TimeDuration): TimeDuration
----@field __mul fun(arg1: TimeDuration, arg2: integer): TimeDuration
----@field from_seconds fun(arg1: integer): TimeDuration
 ---@field __div fun(arg1: TimeDuration, arg2: integer): TimeDuration
+---@field __mul fun(arg1: TimeDuration, arg2: integer): TimeDuration
+---@field __sub fun(arg1: TimeDuration, arg2: TimeDuration): TimeDuration
+---@field __tostring fun(arg1: TimeDuration): string
 ---@field __unm fun(arg1: TimeDuration): TimeDuration
----@field from_minutes fun(arg1: integer): TimeDuration
----@field from_hours fun(arg1: integer): TimeDuration
----@field from_days fun(arg1: integer): TimeDuration
----@field from_weeks fun(arg1: integer): TimeDuration
----@field make_random fun(arg1: TimeDuration, arg2: TimeDuration): TimeDuration
----@field to_turns fun(arg1: TimeDuration): integer
----@field to_seconds fun(arg1: TimeDuration): integer
 ---@field new fun(): TimeDuration
 TimeDuration = {}
 
 --- Represent fixed point in time
 ---@class TimePoint
 ---@field from_turn fun(arg1: integer): TimePoint
----@field serialize fun(arg1: TimePoint)
----@field deserialize fun(arg1: TimePoint)
----@field to_string_time_of_day fun(arg1: TimePoint): string
----@field __tostring fun(arg1: TimePoint): string
----@field __eq fun(arg1: TimePoint, arg2: TimePoint): boolean
----@field __lt fun(arg1: TimePoint, arg2: TimePoint): boolean
----@field __add fun(arg1: TimePoint, arg2: TimeDuration): TimePoint
----@field __sub fun(arg1: TimePoint, arg2: TimePoint): TimeDuration | fun(arg1: TimePoint, arg2: TimeDuration): TimePoint
----@field to_turn fun(arg1: TimePoint): integer
----@field is_night fun(arg1: TimePoint): boolean
+---@field hour_of_day fun(arg1: TimePoint): integer
+---@field is_dawn fun(arg1: TimePoint): boolean
 ---@field is_day fun(arg1: TimePoint): boolean
 ---@field is_dusk fun(arg1: TimePoint): boolean
----@field is_dawn fun(arg1: TimePoint): boolean
----@field second_of_minute fun(arg1: TimePoint): integer
+---@field is_night fun(arg1: TimePoint): boolean
 ---@field minute_of_hour fun(arg1: TimePoint): integer
----@field hour_of_day fun(arg1: TimePoint): integer
+---@field second_of_minute fun(arg1: TimePoint): integer
+---@field to_string_time_of_day fun(arg1: TimePoint): string
+---@field to_turn fun(arg1: TimePoint): integer
+---@field serialize fun(arg1: TimePoint)
+---@field deserialize fun(arg1: TimePoint)
+---@field __add fun(arg1: TimePoint, arg2: TimeDuration): TimePoint
+---@field __eq fun(arg1: TimePoint, arg2: TimePoint): boolean
+---@field __lt fun(arg1: TimePoint, arg2: TimePoint): boolean
+---@field __sub fun(arg1: TimePoint, arg2: TimePoint): TimeDuration | fun(arg1: TimePoint, arg2: TimeDuration): TimePoint
+---@field __tostring fun(arg1: TimePoint): string
 ---@field new fun(): TimePoint
 TimePoint = {}
 
@@ -1302,162 +1319,162 @@ TimePoint = {}
 Tinymap = {}
 
 ---@class TrapId
----@field obj fun(arg1: TrapId): TrapRaw
----@field deserialize fun(arg1: TrapId)
----@field int_id fun(arg1: TrapId): TrapIntId
 ---@field implements_int_id fun(): boolean
+---@field int_id fun(arg1: TrapId): TrapIntId
 ---@field is_null fun(arg1: TrapId): boolean
 ---@field is_valid fun(arg1: TrapId): boolean
----@field str fun(arg1: TrapId): string
 ---@field NULL_ID fun(): TrapId
----@field __tostring fun(arg1: TrapId): string
+---@field obj fun(arg1: TrapId): TrapRaw
+---@field str fun(arg1: TrapId): string
 ---@field serialize fun(arg1: TrapId)
+---@field deserialize fun(arg1: TrapId)
+---@field __tostring fun(arg1: TrapId): string
 ---@field new fun(): TrapId | fun(arg1: TrapId): TrapId | fun(arg1: TrapIntId): TrapId | fun(arg1: string): TrapId
 TrapId = {}
 
 ---@class TrapIntId
+---@field is_valid fun(arg1: TrapIntId): boolean
 ---@field obj fun(arg1: TrapIntId): TrapRaw
 ---@field str_id fun(arg1: TrapIntId): TrapId
----@field is_valid fun(arg1: TrapIntId): boolean
 ---@field __tostring fun(arg1: TrapIntId): string
 ---@field new fun(): TrapIntId | fun(arg1: TrapIntId): TrapIntId | fun(arg1: TrapId): TrapIntId
 TrapIntId = {}
 
 ---@class Tripoint
+---@field abs fun(arg1: Tripoint): Tripoint
+---@field rotate_2d fun(arg1: Tripoint, arg2: integer, arg3: Point): Tripoint
 ---@field x integer
----@field __eq fun(arg1: Tripoint, arg2: Tripoint): boolean
----@field __lt fun(arg1: Tripoint, arg2: Tripoint): boolean
----@field __add fun(arg1: Tripoint, arg2: Tripoint): Tripoint | fun(arg1: Tripoint, arg2: Point): Tripoint
----@field __sub fun(arg1: Tripoint, arg2: Tripoint): Tripoint | fun(arg1: Tripoint, arg2: Point): Tripoint
----@field __mul fun(arg1: Tripoint, arg2: integer): Tripoint
----@field __div fun(arg1: Tripoint, arg2: integer): Tripoint
----@field __idiv fun(arg1: Tripoint, arg2: integer): Tripoint
----@field __unm fun(arg1: Tripoint): Tripoint
+---@field xy fun(arg1: Tripoint): Point
 ---@field y integer
 ---@field z integer
----@field abs fun(arg1: Tripoint): Tripoint
----@field xy fun(arg1: Tripoint): Point
----@field rotate_2d fun(arg1: Tripoint, arg2: integer, arg3: Point): Tripoint
 ---@field serialize fun(arg1: Tripoint)
 ---@field deserialize fun(arg1: Tripoint)
+---@field __add fun(arg1: Tripoint, arg2: Tripoint): Tripoint | fun(arg1: Tripoint, arg2: Point): Tripoint
+---@field __div fun(arg1: Tripoint, arg2: integer): Tripoint
+---@field __eq fun(arg1: Tripoint, arg2: Tripoint): boolean
+---@field __idiv fun(arg1: Tripoint, arg2: integer): Tripoint
+---@field __lt fun(arg1: Tripoint, arg2: Tripoint): boolean
+---@field __mul fun(arg1: Tripoint, arg2: integer): Tripoint
+---@field __sub fun(arg1: Tripoint, arg2: Tripoint): Tripoint | fun(arg1: Tripoint, arg2: Point): Tripoint
 ---@field __tostring fun(arg1: Tripoint): string
+---@field __unm fun(arg1: Tripoint): Tripoint
 ---@field new fun(): Tripoint | fun(arg1: Point, arg2: integer): Tripoint | fun(arg1: Tripoint): Tripoint | fun(arg1: integer, arg2: integer, arg3: integer): Tripoint
 Tripoint = {}
 
 ---@class UiList
----@field title fun(arg1: UiList, arg2: string) @Sets title which is on the top line.
----@field text_color fun(arg1: UiList, arg2: Color) @Changes the color. Default color is `c_light_gray`.
----@field title_color fun(arg1: UiList, arg2: Color) @Changes the color. Default color is `c_green`.
+---@field add fun(arg1: UiList, arg2: integer, arg3: string) @Adds an entry. `string` is its name, and `int` is what it returns. If `int` is `-1`, the number is decided orderly.
+---@field add_w_col fun(arg1: UiList, arg2: integer, arg3: string, arg4: string, arg5: string) @Adds an entry with desc and col(third `string`). col is additional text on the right of the entry name.
+---@field add_w_desc fun(arg1: UiList, arg2: integer, arg3: string, arg4: string) @Adds an entry with desc(second `string`). `desc_enabled(true)` is required for showing desc.
+---@field border_color fun(arg1: UiList, arg2: Color) @Changes the color. Default color is `c_magenta`.
+---@field desc_enabled fun(arg1: UiList, arg2: boolean) @Puts a lower box. Footer or entry desc appears on it.
+---@field entries any @Entries from uilist. Remember, in lua, the first element of vector is `entries[1]`, not `entries[0]`.
+---@field footer fun(arg1: UiList, arg2: string) @Sets footer text which is in lower box. It overwrites descs of entries unless is empty.
 ---@field hilight_color fun(arg1: UiList, arg2: Color) @Changes the color. Default color is `h_white`.
 ---@field hotkey_color fun(arg1: UiList, arg2: Color) @Changes the color. Default color is `c_light_green`.
 ---@field query fun(arg1: UiList): integer @Returns retval for selected entry, or a negative number on fail/cancel
 ---@field text fun(arg1: UiList, arg2: string) @Sets text which is in upper box.
----@field footer fun(arg1: UiList, arg2: string) @Sets footer text which is in lower box. It overwrites descs of entries unless is empty.
----@field desc_enabled fun(arg1: UiList, arg2: boolean) @Puts a lower box. Footer or entry desc appears on it.
----@field add fun(arg1: UiList, arg2: integer, arg3: string) @Adds an entry. `string` is its name, and `int` is what it returns. If `int` is `-1`, the number is decided orderly.
----@field add_w_desc fun(arg1: UiList, arg2: integer, arg3: string, arg4: string) @Adds an entry with desc(second `string`). `desc_enabled(true)` is required for showing desc.
----@field add_w_col fun(arg1: UiList, arg2: integer, arg3: string, arg4: string, arg5: string) @Adds an entry with desc and col(third `string`). col is additional text on the right of the entry name.
----@field entries any @Entries from uilist. Remember, in lua, the first element of vector is `entries[1]`, not `entries[0]`.
----@field border_color fun(arg1: UiList, arg2: Color) @Changes the color. Default color is `c_magenta`.
+---@field text_color fun(arg1: UiList, arg2: Color) @Changes the color. Default color is `c_light_gray`.
+---@field title fun(arg1: UiList, arg2: string) @Sets title which is on the top line.
+---@field title_color fun(arg1: UiList, arg2: Color) @Changes the color. Default color is `c_green`.
 ---@field new fun(): UiList
 UiList = {}
 
 --- This type came from UiList.
 ---@class UiListEntry
+---@field ctxt string @Entry text of column.
+---@field desc string @Entry description
 ---@field enable boolean @Entry whether it's enabled or not. Default is `true`.
 ---@field txt string @Entry text
----@field desc string @Entry description
----@field ctxt string @Entry text of column.
----@field txt_color any @Entry text color. Its default color is `c_red_red`, which makes color of the entry same as what `uilist` decides. So if you want to make color different, choose one except `c_red_red`.
+---@field txt_color fun(arg1: UiListEntry, arg2: Color) @Entry text color. Its default color is `c_red_red`, which makes color of the entry same as what `uilist` decides. So if you want to make color different, choose one except `c_red_red`.
 UiListEntry = {}
 
 ---@class Volume
----@field from_milliliter fun(arg1: integer): Volume
 ---@field from_liter fun(arg1: integer): Volume
----@field to_milliliter fun(arg1: Volume): integer
+---@field from_milliliter fun(arg1: integer): Volume
 ---@field to_liter fun(arg1: Volume): number
+---@field to_milliliter fun(arg1: Volume): integer
 ---@field __eq fun(arg1: Volume, arg2: Volume): boolean
----@field __lt fun(arg1: Volume, arg2: Volume): boolean
 ---@field __le fun(arg1: Volume, arg2: Volume): boolean
+---@field __lt fun(arg1: Volume, arg2: Volume): boolean
 Volume = {}
 
 --================---- Libraries ----================
 
 --- Various game constants
 ---@class const
+---@field OM_MS_SIZE integer # value: 4320
 ---@field OM_OMT_SIZE integer # value: 180
 ---@field OM_SM_SIZE integer # value: 360
----@field OM_MS_SIZE integer # value: 4320
----@field OMT_SM_SIZE integer # value: 2
 ---@field OMT_MS_SIZE integer # value: 24
+---@field OMT_SM_SIZE integer # value: 2
 ---@field SM_MS_SIZE integer # value: 12
 const = {}
 
 --- Methods for manipulating coord systems and calculating distance
 ---@class coords
----@field ms_to_sm fun(arg1: Tripoint): any
----@field ms_to_omt fun(arg1: Tripoint): any
 ---@field ms_to_om fun(arg1: Tripoint): any
----@field sm_to_ms fun(arg1: Tripoint, arg2: any): Tripoint
----@field omt_to_ms fun(arg1: Tripoint, arg2: any): Tripoint
+---@field ms_to_omt fun(arg1: Tripoint): any
+---@field ms_to_sm fun(arg1: Tripoint): any
 ---@field om_to_ms fun(arg1: Point, arg2: any): Tripoint
+---@field omt_to_ms fun(arg1: Tripoint, arg2: any): Tripoint
 ---@field rl_dist fun(arg1: Tripoint, arg2: Tripoint): integer | fun(arg1: Point, arg2: Point): integer
----@field trig_dist fun(arg1: Tripoint, arg2: Tripoint): number | fun(arg1: Point, arg2: Point): number
+---@field sm_to_ms fun(arg1: Tripoint, arg2: any): Tripoint
 ---@field square_dist fun(arg1: Tripoint, arg2: Tripoint): integer | fun(arg1: Point, arg2: Point): integer
+---@field trig_dist fun(arg1: Tripoint, arg2: Tripoint): number | fun(arg1: Point, arg2: Point): number
 coords = {}
 
 --- Global game methods
 ---@class gapi
----@field get_avatar fun(): Avatar
+---@field add_msg fun(arg1: MsgType, arg2: any) | fun(arg1: any)
+---@field add_npc_follower fun(arg1: Npc)
 ---@field add_on_every_x_hook fun(arg1: TimeDuration, arg2: function)
----@field create_item fun(arg1: ItypeId, arg2: integer): any
----@field get_creature_at fun(arg1: Tripoint, arg2: any): Creature
----@field get_monster_at fun(arg1: Tripoint, arg2: any): Monster
----@field place_monster_at fun(arg1: MtypeId, arg2: Tripoint): Monster
----@field get_character_at fun(arg1: Tripoint, arg2: any): Character
----@field get_npc_at fun(arg1: Tripoint, arg2: any): Npc
+---@field before_time_starts fun(): TimePoint
 ---@field choose_adjacent fun(arg1: string, arg2: any): any
 ---@field choose_direction fun(arg1: string, arg2: any): any
----@field look_around fun(): any
----@field get_map fun(): Map
----@field play_variant_sound fun(arg1: string, arg2: string, arg3: integer) | fun(arg1: string, arg2: string, arg3: integer, arg4: Angle, arg5: number, arg6: number)
----@field play_ambient_variant_sound fun(arg1: string, arg2: string, arg3: integer, arg4: SfxChannel, arg5: integer, arg6: number, arg7: integer)
----@field add_npc_follower fun(arg1: Npc)
----@field remove_npc_follower fun(arg1: Npc)
----@field get_distribution_grid_tracker fun(): DistributionGridTracker
----@field add_msg fun(arg1: MsgType, arg2: any) | fun(arg1: any)
----@field place_player_overmap_at fun(arg1: Tripoint)
+---@field create_item fun(arg1: ItypeId, arg2: integer): any
 ---@field current_turn fun(): TimePoint
----@field turn_zero fun(): TimePoint
----@field before_time_starts fun(): TimePoint
+---@field get_avatar fun(): Avatar
+---@field get_character_at fun(arg1: Tripoint, arg2: any): Character
+---@field get_creature_at fun(arg1: Tripoint, arg2: any): Creature
+---@field get_distribution_grid_tracker fun(): DistributionGridTracker
+---@field get_map fun(): Map
+---@field get_monster_at fun(arg1: Tripoint, arg2: any): Monster
+---@field get_npc_at fun(arg1: Tripoint, arg2: any): Npc
+---@field look_around fun(): any
+---@field place_monster_at fun(arg1: MtypeId, arg2: Tripoint): Monster
+---@field place_player_overmap_at fun(arg1: Tripoint)
+---@field play_ambient_variant_sound fun(arg1: string, arg2: string, arg3: integer, arg4: SfxChannel, arg5: integer, arg6: number, arg7: integer)
+---@field play_variant_sound fun(arg1: string, arg2: string, arg3: integer) | fun(arg1: string, arg2: string, arg3: integer, arg4: Angle, arg5: number, arg6: number)
+---@field remove_npc_follower fun(arg1: Npc)
 ---@field rng fun(arg1: integer, arg2: integer): integer
+---@field turn_zero fun(): TimePoint
 gapi = {}
 
 --- Debugging and logging API.
 ---@class gdebug
+---@field clear_lua_log fun()
+---@field debugmsg fun(arg1: any)
+---@field log_error fun(arg1: any)
 ---@field log_info fun(arg1: any)
 ---@field log_warn fun(arg1: any)
----@field log_error fun(arg1: any)
----@field debugmsg fun(arg1: any)
----@field clear_lua_log fun()
----@field set_log_capacity fun(arg1: integer)
 ---@field reload_lua_code fun()
 ---@field save_game fun(): boolean
+---@field set_log_capacity fun(arg1: integer)
 gdebug = {}
 
 --- Documentation for hooks
 ---@class hooks
----@field on_game_save fun() @Called when game is about to save
----@field on_game_load fun() @Called right after game has loaded
 ---@field on_every_x fun() @Called every in-game period
+---@field on_game_load fun() @Called right after game has loaded
+---@field on_game_save fun() @Called when game is about to save
 ---@field on_mapgen_postprocess fun(arg1: Map, arg2: Tripoint, arg3: TimePoint) @Called right after mapgen has completed. Map argument is the tinymap that represents 24x24 area (2x2 submaps, or 1x1 omt), tripoint is the absolute omt pos, and time_point is the current time (for time-based effects).
 hooks = {}
 
 --- Localization API.
 ---@class locale
 ---@field gettext fun(arg1: string): string @Expects english source string, returns translated string.
----@field vgettext fun(arg1: string, arg2: string): string @First is english singular string, second is english plural string. Number is amount to translate for.
 ---@field pgettext fun(arg1: string, arg2: string): string @First is context string. Second is english source string.
+---@field vgettext fun(arg1: string, arg2: string): string @First is english singular string, second is english plural string. Number is amount to translate for.
 ---@field vpgettext fun(arg1: string, arg2: string, arg3: string): string @First is context string. Second is english singular string. third is english plural. Number is amount to translate for.
 locale = {}
 

--- a/lua_annotations.lua
+++ b/lua_annotations.lua
@@ -77,6 +77,12 @@ BodyPartTypeId = {}
 BodyPartTypeIntId = {}
 
 ---@class Character : Creature
+---@field cash integer
+---@field focus_pool integer
+---@field follower_ids any
+---@field male boolean
+---@field mutation_category_level any
+---@field name string
 ---@field activate_mutation fun(arg1: Character, arg2: MutationBranchId)
 ---@field add_addiction fun(arg1: Character, arg2: AddictionType, arg3: integer)
 ---@field add_bionic fun(arg1: Character, arg2: BionicDataId)
@@ -103,7 +109,6 @@ BodyPartTypeIntId = {}
 ---@field can_run fun(arg1: Character): boolean
 ---@field can_unwield fun(arg1: Character, arg2: Item): boolean
 ---@field can_wield fun(arg1: Character, arg2: Item): boolean
----@field cash integer
 ---@field check_mount_is_spooked fun(arg1: Character): boolean
 ---@field check_mount_will_move fun(arg1: Character, arg2: Tripoint): boolean
 ---@field clear_bionics fun(arg1: Character)
@@ -116,8 +121,6 @@ BodyPartTypeIntId = {}
 ---@field dismount fun(arg1: Character)
 ---@field expose_to_disease fun(arg1: Character, arg2: DiseaseTypeId)
 ---@field fall_asleep fun(arg1: Character) | fun(arg1: Character, arg2: TimeDuration)
----@field focus_pool integer
----@field follower_ids any
 ---@field forced_dismount fun(arg1: Character)
 ---@field get_all_skills fun(arg1: Character): SkillLevelMap
 ---@field get_armor_acid fun(arg1: Character, arg2: BodyPartTypeIntId): integer
@@ -242,7 +245,6 @@ BodyPartTypeIntId = {}
 ---@field mabuff_dodge_bonus fun(arg1: Character): number
 ---@field mabuff_speed_bonus fun(arg1: Character): integer
 ---@field mabuff_tohit_bonus fun(arg1: Character): number
----@field male boolean
 ---@field max_stored_kcal fun(arg1: Character): integer
 ---@field metabolic_rate fun(arg1: Character): number
 ---@field mod_base_age fun(arg1: Character, arg2: integer)
@@ -267,16 +269,14 @@ BodyPartTypeIntId = {}
 ---@field mount_creature fun(arg1: Character, arg2: Monster)
 ---@field mutate fun(arg1: Character)
 ---@field mutate_category fun(arg1: Character, arg2: MutationCategoryTraitId)
----@field mutate_towards fun(arg1: Character, arg2: MutationBranchId): boolean
 ---@field mutate_towards fun(arg1: Character, arg2: any, arg3: integer): boolean | fun(arg1: Character, arg2: MutationBranchId): boolean
+---@field mutate_towards fun(arg1: Character, arg2: MutationBranchId): boolean
 ---@field mutate_towards fun(arg1: Character, arg2: any, arg3: integer): boolean
 ---@field mutation_armor fun(arg1: Character, arg2: BodyPartTypeIntId, arg3: DamageType): number
----@field mutation_category_level any
 ---@field mutation_effect fun(arg1: Character, arg2: MutationBranchId)
 ---@field mutation_loss_effect fun(arg1: Character, arg2: MutationBranchId)
 ---@field mutation_ok fun(arg1: Character, arg2: MutationBranchId, arg3: boolean, arg4: boolean): boolean
 ---@field mutation_value fun(arg1: Character, arg2: string): number
----@field name string
 ---@field practice fun(arg1: Character, arg2: SkillId, arg3: integer, arg4: integer, arg5: boolean)
 ---@field read_speed fun(arg1: Character, arg2: boolean): integer
 ---@field rem_addiction fun(arg1: Character, arg2: AddictionType)
@@ -439,10 +439,10 @@ Creature = {}
 
 --- new(damageType, amount, armorPen, remainingArmorMultiplier, damageMultiplier)
 ---@class DamageInstance
+---@field damage_units any
 ---@field add fun(arg1: DamageInstance, arg2: DamageUnit)
 ---@field add_damage fun(arg1: DamageInstance, arg2: DamageType, arg3: number, arg4: number, arg5: number, arg6: number)
 ---@field clear fun(arg1: DamageInstance)
----@field damage_units any
 ---@field empty fun(arg1: DamageInstance): boolean
 ---@field mult_damage fun(arg1: DamageInstance, arg2: number, arg3: boolean)
 ---@field total_damage fun(arg1: DamageInstance): number
@@ -578,13 +578,14 @@ FurnIntId = {}
 
 ---@class FurnRaw
 ---@field close FurnId
----@field int_id fun(arg1: FurnRaw): FurnIntId
 ---@field open FurnId
----@field str_id fun(arg1: FurnRaw): FurnId
 ---@field transforms_into FurnId
+---@field int_id fun(arg1: FurnRaw): FurnIntId
+---@field str_id fun(arg1: FurnRaw): FurnId
 FurnRaw = {}
 
 ---@class Item
+---@field charges integer
 ---@field add_item_with_id fun(arg1: Item, arg2: ItypeId, arg3: integer) @Adds an item(s) to contents
 ---@field add_technique fun(arg1: Item, arg2: MartialArtsTechniqueId) @Adds the technique. It isn't treated original, but additional.
 ---@field ammo_capacity fun(arg1: Item, arg2: boolean): integer @Gets the maximum capacity of a magazine
@@ -596,7 +597,6 @@ FurnRaw = {}
 ---@field ammo_set fun(arg1: Item, arg2: ItypeId, arg3: integer)
 ---@field ammo_unset fun(arg1: Item)
 ---@field can_contain fun(arg1: Item, arg2: Item): boolean @Checks if this item can contain another
----@field charges integer
 ---@field clear_vars fun(arg1: Item) @Erase all variables
 ---@field conductive fun(arg1: Item): boolean
 ---@field covers fun(arg1: Item, arg2: BodyPartTypeIntId): boolean @Checks if the item covers a bodypart
@@ -812,6 +812,11 @@ Mass = {}
 
 ---@class Monster : Creature
 ---@field anger integer
+---@field death_drops boolean
+---@field faction MonsterFactionIntId
+---@field friendly integer
+---@field morale integer
+---@field unique_name string
 ---@field attitude fun(arg1: Monster, arg2: Character): MonsterAttitude
 ---@field can_climb fun(arg1: Monster): boolean
 ---@field can_dig fun(arg1: Monster): boolean
@@ -821,11 +826,8 @@ Mass = {}
 ---@field can_submerge fun(arg1: Monster): boolean
 ---@field can_upgrade fun(arg1: Monster): boolean
 ---@field climbs fun(arg1: Monster): boolean
----@field death_drops boolean
 ---@field digs fun(arg1: Monster): boolean
----@field faction MonsterFactionIntId
 ---@field flies fun(arg1: Monster): boolean
----@field friendly integer
 ---@field get_type fun(arg1: Monster): MtypeId
 ---@field get_upgrade_time fun(arg1: Monster): integer
 ---@field hasten_upgrade fun(arg1: Monster)
@@ -834,7 +836,6 @@ Mass = {}
 ---@field make_ally fun(arg1: Monster, arg2: Monster)
 ---@field make_friendly fun(arg1: Monster)
 ---@field make_fungus fun(arg1: Monster): boolean
----@field morale integer
 ---@field move_target fun(arg1: Monster): Tripoint
 ---@field move_to fun(arg1: Monster, arg2: Tripoint, arg3: boolean, arg4: boolean, arg5: number): boolean
 ---@field name fun(arg1: Monster, arg2: integer): string
@@ -845,7 +846,6 @@ Mass = {}
 ---@field swims fun(arg1: Monster): boolean
 ---@field try_reproduce fun(arg1: Monster)
 ---@field try_upgrade fun(arg1: Monster, arg2: boolean)
----@field unique_name string
 ---@field wander_to fun(arg1: Monster, arg2: Tripoint, arg3: integer)
 Monster = {}
 
@@ -912,25 +912,20 @@ MutationBranchId = {}
 
 ---@class MutationBranchRaw
 ---@field activated boolean @Whether this mutation can be activated at will.
----@field addition_mutations fun(arg1: MutationBranchRaw): any
 ---@field allow_soft_gear boolean @Mutation allows soft gear to be worn over otherwise-restricted parts.
 ---@field attackcost_modifier number
 ---@field bleed_resist number
 ---@field bodytemp_max_btu integer
 ---@field bodytemp_min_btu integer
 ---@field bodytemp_sleep_btu integer
----@field categories fun(arg1: MutationBranchRaw): any @Lists the categories this mutation belongs to.
----@field conflicts_with fun(arg1: MutationBranchRaw): any @Lists conflicting mutations.
 ---@field cooldown integer @Costs are incurred every 'cooldown' turns.
 ---@field cost integer
 ---@field debug boolean @Whether or not this mutation is limited to debug use.
----@field desc fun(arg1: MutationBranchRaw): string
 ---@field dodge_modifier number
 ---@field falling_damage_multiplier number
 ---@field fatigue boolean @Mutation causes fatigue when used.
 ---@field fatigue_modifier number
 ---@field fatigue_regen_modifier number
----@field get_all fun(): any @Returns a (long) list of every mutation in the game.
 ---@field healing_awake number @Healing per turn from mutation.
 ---@field healing_resting number @Healing per turn from mutation, while asleep.
 ---@field healthy_rate number @How quickly health (not HP) trends toward healthy_mod.
@@ -948,21 +943,16 @@ MutationBranchId = {}
 ---@field movecost_modifier number
 ---@field movecost_obstacle_modifier number
 ---@field movecost_swim_modifier number
----@field mutation_types fun(arg1: MutationBranchRaw): any @Lists the type(s) of this mutation. Mutations of a given type are mutually exclusive.
----@field name fun(arg1: MutationBranchRaw): string
 ---@field night_vision_range number
 ---@field noise_modifier number
----@field other_prerequisites fun(arg1: MutationBranchRaw): any @Lists the secondary mutation(s) needed to gain this mutation.
 ---@field overmap_multiplier number
 ---@field overmap_sight number
 ---@field pain_recovery number @Pain recovery per turn from mutation.
 ---@field player_display boolean @Whether or not this mutation shows up in the status (`@`) menu.
 ---@field points integer @Point cost in character creation(?).
----@field prerequisites fun(arg1: MutationBranchRaw): any @Lists the primary mutation(s) needed to gain this mutation.
 ---@field profession boolean @Whether this trait is ONLY gained through professional training/experience (and/or quests).
 ---@field purifiable boolean @Whether this mutation is possible to remove through Purifier. False for 'special' mutations.
 ---@field reading_speed_multiplier number
----@field replaced_by fun(arg1: MutationBranchRaw): any @Lists mutations that replace (e.g. evolve from) this one.
 ---@field scent_modifier number
 ---@field skill_rust_multiplier number
 ---@field speed_modifier number
@@ -975,11 +965,21 @@ MutationBranchId = {}
 ---@field thirst boolean @Mutation dehydrates when used.
 ---@field thirst_modifier number
 ---@field threshold boolean @Whether this is a Threshold mutation, and thus especially difficult to mutate. One per character.
----@field thresh_requirements fun(arg1: MutationBranchRaw): any @Lists the threshold mutation(s) required to gain this mutation.
 ---@field ugliness integer @How physically unappealing the mutation is. Can be negative.
 ---@field valid boolean @Whether this mutation is available through generic mutagen.
 ---@field visibility integer @How visible the mutation is to others.
 ---@field weight_capacity_modifier number
+---@field addition_mutations fun(arg1: MutationBranchRaw): any
+---@field categories fun(arg1: MutationBranchRaw): any @Lists the categories this mutation belongs to.
+---@field conflicts_with fun(arg1: MutationBranchRaw): any @Lists conflicting mutations.
+---@field desc fun(arg1: MutationBranchRaw): string
+---@field get_all fun(): any @Returns a (long) list of every mutation in the game.
+---@field mutation_types fun(arg1: MutationBranchRaw): any @Lists the type(s) of this mutation. Mutations of a given type are mutually exclusive.
+---@field name fun(arg1: MutationBranchRaw): string
+---@field other_prerequisites fun(arg1: MutationBranchRaw): any @Lists the secondary mutation(s) needed to gain this mutation.
+---@field prerequisites fun(arg1: MutationBranchRaw): any @Lists the primary mutation(s) needed to gain this mutation.
+---@field replaced_by fun(arg1: MutationBranchRaw): any @Lists mutations that replace (e.g. evolve from) this one.
+---@field thresh_requirements fun(arg1: MutationBranchRaw): any @Lists the threshold mutation(s) required to gain this mutation.
 ---@field __tostring fun(arg1: MutationBranchRaw): string
 MutationBranchRaw = {}
 
@@ -997,11 +997,17 @@ MutationBranchRaw = {}
 MutationCategoryTraitId = {}
 
 ---@class Npc : Player, Character, Creature
+---@field current_activity_id ActivityTypeId
+---@field hit_by_player boolean
+---@field marked_for_death boolean
+---@field needs any
+---@field op_of_u NpcOpinion
+---@field patience integer
+---@field personality NpcPersonality
 ---@field can_move_to fun(arg1: Npc, arg2: Tripoint, arg3: boolean): boolean
 ---@field can_open_door fun(arg1: Npc, arg2: Tripoint, arg3: boolean): boolean
 ---@field complain fun(arg1: Npc): boolean
 ---@field complain_about fun(arg1: Npc, arg2: string, arg3: TimeDuration, arg4: string, arg5: any): boolean
----@field current_activity_id ActivityTypeId
 ---@field current_ally fun(arg1: Npc): Creature
 ---@field current_target fun(arg1: Npc): Creature
 ---@field danger_assessment fun(arg1: Npc): number
@@ -1013,7 +1019,6 @@ MutationCategoryTraitId = {}
 ---@field has_activity fun(arg1: Npc): boolean
 ---@field has_omt_destination fun(arg1: Npc): boolean
 ---@field has_player_activity fun(arg1: Npc): boolean
----@field hit_by_player boolean
 ---@field hostile_anger_level fun(arg1: Npc): integer
 ---@field is_ally fun(arg1: Npc, arg2: Character): boolean
 ---@field is_enemy fun(arg1: Npc): boolean
@@ -1029,12 +1034,7 @@ MutationCategoryTraitId = {}
 ---@field is_travelling fun(arg1: Npc): boolean
 ---@field is_walking_with fun(arg1: Npc): boolean
 ---@field make_angry fun(arg1: Npc)
----@field marked_for_death boolean
 ---@field mutiny fun(arg1: Npc)
----@field needs any
----@field op_of_u NpcOpinion
----@field patience integer
----@field personality NpcPersonality
 ---@field saw_player_recently fun(arg1: Npc): boolean
 ---@field say fun(arg1: Npc, arg2: string)
 ---@field set_attitude fun(arg1: Npc, arg2: NpcAttitude)
@@ -1065,10 +1065,10 @@ NpcPersonality = {}
 Player = {}
 
 ---@class Point
----@field abs fun(arg1: Point): Point
----@field rotate fun(arg1: Point, arg2: integer, arg3: Point): Point
 ---@field x integer
 ---@field y integer
+---@field abs fun(arg1: Point): Point
+---@field rotate fun(arg1: Point, arg2: integer, arg3: Point): Point
 ---@field serialize fun(arg1: Point)
 ---@field deserialize fun(arg1: Point)
 ---@field __add fun(arg1: Point, arg2: Point): Point
@@ -1156,13 +1156,13 @@ SpeciesTypeId = {}
 
 --- The class used for spells that *a player* knows, casts, and gains experience for using. If a given spell is not supposed to be directly cast by a player, consider using SpellSimple instead.
 ---@class Spell
+---@field id SpellTypeId
 ---@field cast fun(arg1: Spell, arg2: Creature, arg3: Tripoint) @Cast this spell, as well as any sub-spells.
 ---@field cast_single_effect fun(arg1: Spell, arg2: Creature, arg3: Tripoint) @Cast *only* this spell's main effects. Generally, cast() should be used instead.
 ---@field desc fun(arg1: Spell): string
 ---@field gain_exp fun(arg1: Spell, arg2: integer)
 ---@field gain_levels fun(arg1: Spell, arg2: integer)
 ---@field get_level fun(arg1: Spell): integer
----@field id SpellTypeId
 ---@field name fun(arg1: Spell): string
 ---@field set_exp fun(arg1: Spell, arg2: integer)
 ---@field set_level fun(arg1: Spell, arg2: integer)
@@ -1172,13 +1172,13 @@ Spell = {}
 
 --- The type for basic spells. If you don't need to track XP from casting (e.g., if a spell is intended to be cast by anything *other than* a player), this is likely the appropriate type. Otherwise, see the Spell type.
 ---@class SpellSimple
----@field cast fun(arg1: SpellSimple, arg2: Creature, arg3: Tripoint, arg4: any)
 ---@field force_target_source boolean @Whether or not the target point is *locked* to the source's location.
 ---@field id SpellTypeId
 ---@field level integer
+---@field trigger_once_in integer @Used for enchantments; the spell's *chance* to trigger every turn.
+---@field cast fun(arg1: SpellSimple, arg2: Creature, arg3: Tripoint, arg4: any)
 ---@field max_level fun(arg1: SpellSimple): integer @Returns the defined maximum level of this SpellSimple instance, if defined. Otherwise, returns 0.
 ---@field prompt_cast fun(arg1: SpellTypeId, arg2: Tripoint, arg3: any): SpellSimple @Static function: Creates and immediately casts a SimpleSpell, then returns the new spell for potential reuse. If the given tripoint is the player's location, the spell will be locked to the player. (This does not necessarily cause friendly fire!) If an integer is specified, the spell will be cast at that level.
----@field trigger_once_in integer @Used for enchantments; the spell's *chance* to trigger every turn.
 ---@field __tostring fun(arg1: SpellSimple): string
 ---@field new fun(arg1: SpellTypeId, arg2: boolean): SpellSimple | fun(arg1: SpellTypeId, arg2: boolean, arg3: integer): SpellSimple
 SpellSimple = {}
@@ -1198,7 +1198,6 @@ SpellTypeId = {}
 
 --- The 'raw' type for storing the information defining every spell in the game. It's not possible to cast directly from this type; check SpellSimple and Spell.
 ---@class SpellTypeRaw
----@field additional_spells fun(arg1: SpellTypeRaw): any @Other spells cast by this spell.
 ---@field aoe_increment number
 ---@field base_casting_time integer
 ---@field base_energy_cost integer
@@ -1215,7 +1214,6 @@ SpellTypeId = {}
 ---@field field_intensity_variance number
 ---@field final_casting_time integer
 ---@field final_energy_cost integer
----@field get_all fun(): any @Returns a (long) list of every spell in the game.
 ---@field id SpellTypeId
 ---@field max_aoe integer
 ---@field max_damage integer
@@ -1231,6 +1229,8 @@ SpellTypeId = {}
 ---@field min_field_intensity integer
 ---@field min_range integer
 ---@field range_increment number
+---@field additional_spells fun(arg1: SpellTypeRaw): any @Other spells cast by this spell.
+---@field get_all fun(): any @Returns a (long) list of every spell in the game.
 ---@field __tostring fun(arg1: SpellTypeRaw): string
 SpellTypeRaw = {}
 
@@ -1259,12 +1259,12 @@ TerIntId = {}
 ---@class TerRaw
 ---@field close TerId
 ---@field heat_radiation integer
----@field int_id fun(arg1: TerRaw): TerIntId
 ---@field open TerId
 ---@field roof TerId
----@field str_id fun(arg1: TerRaw): TerId
 ---@field transforms_into TerId
 ---@field trap_id_str string
+---@field int_id fun(arg1: TerRaw): TerIntId
+---@field str_id fun(arg1: TerRaw): TerId
 TerRaw = {}
 
 --- Represent duration between 2 fixed points in time
@@ -1341,12 +1341,12 @@ TrapId = {}
 TrapIntId = {}
 
 ---@class Tripoint
----@field abs fun(arg1: Tripoint): Tripoint
----@field rotate_2d fun(arg1: Tripoint, arg2: integer, arg3: Point): Tripoint
 ---@field x integer
----@field xy fun(arg1: Tripoint): Point
 ---@field y integer
 ---@field z integer
+---@field abs fun(arg1: Tripoint): Tripoint
+---@field rotate_2d fun(arg1: Tripoint, arg2: integer, arg3: Point): Tripoint
+---@field xy fun(arg1: Tripoint): Point
 ---@field serialize fun(arg1: Tripoint)
 ---@field deserialize fun(arg1: Tripoint)
 ---@field __add fun(arg1: Tripoint, arg2: Tripoint): Tripoint | fun(arg1: Tripoint, arg2: Point): Tripoint
@@ -1362,12 +1362,12 @@ TrapIntId = {}
 Tripoint = {}
 
 ---@class UiList
+---@field entries any @Entries from uilist. Remember, in lua, the first element of vector is `entries[1]`, not `entries[0]`.
 ---@field add fun(arg1: UiList, arg2: integer, arg3: string) @Adds an entry. `string` is its name, and `int` is what it returns. If `int` is `-1`, the number is decided orderly.
 ---@field add_w_col fun(arg1: UiList, arg2: integer, arg3: string, arg4: string, arg5: string) @Adds an entry with desc and col(third `string`). col is additional text on the right of the entry name.
 ---@field add_w_desc fun(arg1: UiList, arg2: integer, arg3: string, arg4: string) @Adds an entry with desc(second `string`). `desc_enabled(true)` is required for showing desc.
 ---@field border_color fun(arg1: UiList, arg2: Color) @Changes the color. Default color is `c_magenta`.
 ---@field desc_enabled fun(arg1: UiList, arg2: boolean) @Puts a lower box. Footer or entry desc appears on it.
----@field entries any @Entries from uilist. Remember, in lua, the first element of vector is `entries[1]`, not `entries[0]`.
 ---@field footer fun(arg1: UiList, arg2: string) @Sets footer text which is in lower box. It overwrites descs of entries unless is empty.
 ---@field hilight_color fun(arg1: UiList, arg2: Color) @Changes the color. Default color is `h_white`.
 ---@field hotkey_color fun(arg1: UiList, arg2: Color) @Changes the color. Default color is `c_light_green`.


### PR DESCRIPTION

## Purpose of change (The Why)

as shown in #6541 fields sorting weren't stable, causing unnecessary diffs

## Describe the solution (The How)

sort fields alphanumerically in following order:
- variables
- methods
- `serialize`
- `deserialize`
- [metamethods](https://www.lua.org/pil/13.html)

## Checklist



### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


