### PR TITLE
feat: remove the road connection of two urban locations

### DIFF
--- a/data/json/overmap/multitile_city_buildings.json
+++ b/data/json/overmap/multitile_city_buildings.json
@@ -802,9 +802,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "urban_26_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_26_3_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_26_4_south" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 2, 0, 0 ], "overmap": "road_ns" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_26_5_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_26_6_south" },
       { "point": [ 1, 0, 2 ], "overmap": "urban_26_7_south" },
@@ -816,8 +813,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ 1, 1, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
       { "point": [ -1, 0, -1 ], "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] }
     ],
@@ -905,8 +900,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "urban_30_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_30_3_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_30_4_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_30_5_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_30_6_south" },
       { "point": [ 1, 0, 2 ], "overmap": "urban_30_7_south" },
@@ -916,8 +909,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ 2, 0, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
       { "point": [ -1, 0, -1 ], "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] },
       { "point": [ 0, 2, -2 ], "connection": "subway_tunnel", "from": [ 0, 1, -2 ] },


### PR DESCRIPTION
## Purpose of change (The Why)
Same as https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6539
## Describe the solution (The How)
In the file multitile_city_buildings.json delete the static road and road connection of the following `city_building`:
"urban_26_dense_club" and "urban_30_dense_subway"
## Describe alternatives you've considered
none
## Testing
No errors when starting a new game.
I make my character appear in the game at the concerned locations via a scenario.
The buildings after these changes appear against the road in town, just like any other town building.
## Additional context
none
## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.