### PR TITLE
fix: fix typo in robotic workbench looks_like

### DIFF
--- a/data/json/furniture_and_terrain/furniture-surfaces.json
+++ b/data/json/furniture_and_terrain/furniture-surfaces.json
@@ -180,7 +180,7 @@
     "move_cost_mod": 2,
     "coverage": 50,
     "required_str": 10,
-    "looks_like": "machinery_heavy",
+    "looks_like": "t_machinery_heavy",
     "flags": [ "TRANSPARENT", "PLACE_ITEM", "MOUNTABLE", "FLAT_SURF", "EASY_DECONSTRUCT" ],
     "deconstruct": { "items": [ { "item": "robobench", "count": 1 } ] },
     "bash": {


### PR DESCRIPTION
## Purpose of change (The Why)

typo was made.

## Describe the solution (The How)

typo was fixed

## Describe alternatives you've considered

## Testing

Well I did on my local copy when I fixed it for unrelated testing reasons to isolate a different bug.

## Additional context

none

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.