### PR TITLE
fix(mods): some bugs of e-reader mod

### DIFF
--- a/data/mods/ebook_lua/main.lua
+++ b/data/mods/ebook_lua/main.lua
@@ -101,7 +101,7 @@ mod.item_funeral = function()
   local YOU = gapi.get_avatar()
   local NOW = gapi.current_turn() - gapi.turn_zero()
   gdebug.log_info(string.format("[%d] Call the Requiem for the unmaterialized one.", NOW:to_turns()))
-  if storage.hook_assuarance[NOW:to_turns()] and ( YOU:has_activity(ACT_READ) or YOU:has_activity(ACT_CRAFT) ) then
+  if storage.hook_assuarance[NOW:to_turns()] and (YOU:has_activity(ACT_READ) or YOU:has_activity(ACT_CRAFT)) then
     -- For more precise, what you read is needed... but I don't know how to get.
     YOU:cancel_activity()
     mod.poppin(locale.gettext("Your e-copy is degrading!"))
@@ -314,10 +314,16 @@ mod.ebook_load = function(reader, device)
         end
 
         local the_when = gapi.current_turn() + mod.from_turns(lifetime - 1)
-        book_in_real:set_var_num("its_fate_time", the_when:to_turn() )
+        book_in_real:set_var_num("its_fate_time", the_when:to_turn())
         mod.turntimer_hook(lifetime - 1, mod.item_funeral)
 
-        local msg = string.format(locale.gettext( "You printed a physical copy of %s.\nIt’s virtually weightless and will degrade naturally in about \n[%d minutes.]\nYou can return it to the device to recover some energy." ), selected.name, mod.from_turns(lifetime):to_minutes() )
+        local msg = string.format(
+          locale.gettext(
+            "You printed a physical copy of %s.\nIt’s virtually weightless and will degrade naturally in about \n[%d minutes.]\nYou can return it to the device to recover some energy."
+          ),
+          selected.name,
+          mod.from_turns(lifetime):to_minutes()
+        )
         mod.poppin(msg)
         reader:mod_moves(-100)
         return minute
@@ -357,7 +363,7 @@ mod.ebook_return = function(reader, device)
     local it = virtual_books[sel_return]
     local ammo_type = device:ammo_current()
     device:ammo_set(ammo_type, device.charges + math.floor(it:get_var_num("ethereal", 0) / 60))
-    local the_when = math.floor(it:get_var_num("its_fate_time", 0 ))
+    local the_when = math.floor(it:get_var_num("its_fate_time", 0))
     storage.hook_assuarance[the_when] = nil
     it:set_var_num("ethereal", 0)
     --DON'T READ VANISHING ITEM EVER!!!

--- a/data/mods/ebook_lua/main.lua
+++ b/data/mods/ebook_lua/main.lua
@@ -101,7 +101,7 @@ mod.item_funeral = function()
   local YOU = gapi.get_avatar()
   local NOW = gapi.current_turn() - gapi.turn_zero()
   gdebug.log_info(string.format("[%d] Call the Requiem for the unmaterialized one.", NOW:to_turns()))
-  if YOU:has_activity(ACT_READ) or YOU:has_activity(ACT_CRAFT) then
+  if storage.hook_assuarance[NOW:to_turns()] and ( YOU:has_activity(ACT_READ) or YOU:has_activity(ACT_CRAFT) ) then
     -- For more precise, what you read is needed... but I don't know how to get.
     YOU:cancel_activity()
     mod.poppin(locale.gettext("Your e-copy is degrading!"))
@@ -280,7 +280,15 @@ mod.ebook_load = function(reader, device)
         --You got the book on the real world!
         reader:add_item_with_id(selected.type, 1)
         --Then lemme see it.
-        local book_in_real = reader:get_item_with_id(selected.type, false)
+        local book_in_real
+        for _, it in pairs(reader:all_items(false)) do
+          if it:get_type() == selected.type then
+            if it:get_var_str("aspect", "real") == "real" then
+              book_in_real = it
+              break
+            end
+          end
+        end
 
         --The book should be labeled.
         book_in_real:set_var_str(
@@ -293,7 +301,7 @@ mod.ebook_load = function(reader, device)
         book_in_real:set_var_num("volume", 0)
         --The book should be gone.
         book_in_real:set_flag(flag_ETHEREAL_ITEM)
-        lifetime = lifetime * minute
+        lifetime = lifetime * minute + 1
         book_in_real:set_var_num("ethereal", lifetime)
         --The book should be untradable. But it looks not effective.
         book_in_real:set_flag(flag_TRADER_AVOID)
@@ -305,20 +313,13 @@ mod.ebook_load = function(reader, device)
           book_in_real.charges = 0
         end
 
+        local the_when = gapi.current_turn() + mod.from_turns(lifetime - 1)
+        book_in_real:set_var_num("its_fate_time", the_when:to_turn() )
         mod.turntimer_hook(lifetime - 1, mod.item_funeral)
 
-        local qp = QueryPopup.new()
-        qp:message(
-          string.format(
-            locale.gettext(
-              "You printed a physical copy of %s.\nIt’s virtually weightless and will degrade naturally in about \n[%d minutes.]\nYou can return it to the device to recover some energy."
-            ),
-            selected.name,
-            mod.from_turns(lifetime):to_minutes()
-          )
-        )
-        qp:allow_any_key(true)
-        qp:query()
+        local msg = string.format(locale.gettext( "You printed a physical copy of %s.\nIt’s virtually weightless and will degrade naturally in about \n[%d minutes.]\nYou can return it to the device to recover some energy." ), selected.name, mod.from_turns(lifetime):to_minutes() )
+        mod.poppin(msg)
+        reader:mod_moves(-100)
         return minute
       end
     end
@@ -356,6 +357,8 @@ mod.ebook_return = function(reader, device)
     local it = virtual_books[sel_return]
     local ammo_type = device:ammo_current()
     device:ammo_set(ammo_type, device.charges + math.floor(it:get_var_num("ethereal", 0) / 60))
+    local the_when = math.floor(it:get_var_num("its_fate_time", 0 ))
+    storage.hook_assuarance[the_when] = nil
     it:set_var_num("ethereal", 0)
     --DON'T READ VANISHING ITEM EVER!!!
     reader:mod_moves(-250)


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
Fix bugs below:
- interrupting user to say degrading, even when it isn't (https://discordapp.com/channels/830879262763909202/830916451517857894/1373685002730082394)
- showing left turns of an e-book as `(xx.000000 turns)`
- sometimes an e-book is loaded as a real book
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Edit main.lua
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
:(

## Testing

Now the message doesn't interrupt you to say the e-book disappears which is reloaded already.
Loading a book spawns an e-book properly and `xx turns` instead `xx.000000 turns`.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
