### PR TITLE
feat: remove the road connection of multiple urban locations

### DIFF
--- a/data/json/overmap/multitile_city_buildings.json
+++ b/data/json/overmap/multitile_city_buildings.json
@@ -928,8 +928,6 @@
       { "point": [ 0, 1, 0 ], "overmap": "urban_31_6_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_31_7_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_31_8_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 1, 1 ], "overmap": "urban_31_9_south" },
       { "point": [ 0, 1, 1 ], "overmap": "urban_31_10_south" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_31_11_south" },
@@ -942,8 +940,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ 0, 2, 0 ], "connection": "local_road", "from": [ 0, 1, 0 ] },
       { "point": [ 0, 2, -1 ], "connection": "sewer_tunnel", "from": [ 0, 1, -1 ] }
     ],
@@ -999,8 +995,6 @@
       { "point": [ 1, 0, 0 ], "overmap": "urban_33_7_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_33_8_south" },
       { "point": [ 1, 1, 1 ], "overmap": "urban_33_9_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 0, 1, 1 ], "overmap": "urban_33_10_south" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_33_11_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_33_12_south" },
@@ -1029,11 +1023,7 @@
       { "point": [ 0, 0, 7 ], "overmap": "urban_33_36_south" }
     ],
     "locations": [ "land" ],
-    "connections": [
-      { "point": [ 2, 1, -1 ], "connection": "sewer_tunnel", "from": [ 1, 1, -1 ] },
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] }
-    ],
+    "connections": [ { "point": [ 2, 1, -1 ], "connection": "sewer_tunnel", "from": [ 1, 1, -1 ] } ],
     "flags": [ "CLASSIC", "URBAN" ]
   },
   {
@@ -1046,8 +1036,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "urban_34_4_south" },
       { "point": [ 1, 1, 0 ], "overmap": "urban_34_5_south" },
       { "point": [ 0, 1, 0 ], "overmap": "urban_34_6_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_34_7_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_34_8_south" },
       { "point": [ 1, 1, 1 ], "overmap": "urban_34_9_south" },
@@ -1062,10 +1050,6 @@
       { "point": [ 1, 0, 3 ], "overmap": "urban_34_19_south" }
     ],
     "locations": [ "land" ],
-    "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] }
-    ],
     "flags": [ "CLASSIC", "URBAN" ]
   },
   {
@@ -1117,8 +1101,6 @@
       { "point": [ 1, 0, 0 ], "overmap": "urban_36_7_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_36_8_south" },
       { "point": [ 1, 1, 1 ], "overmap": "urban_36_9_south" },
-      { "point": [ 0, 2, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, 2, 0 ], "overmap": "road_ew" },
       { "point": [ 0, 1, 1 ], "overmap": "urban_36_10_south" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_36_11_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_36_12_south" },
@@ -1144,11 +1126,7 @@
       { "point": [ 0, 0, 6 ], "overmap": "urban_36_32_south" }
     ],
     "locations": [ "land" ],
-    "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, 2, 0 ] },
-      { "point": [ 2, 2, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
-      { "point": [ 2, 0, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] }
-    ],
+    "connections": [ { "point": [ 2, 0, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] } ],
     "flags": [ "CLASSIC", "URBAN" ]
   },
   {
@@ -1163,8 +1141,6 @@
       { "point": [ 0, 1, 0 ], "overmap": "urban_37_6_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_37_7_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_37_8_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 1, 1 ], "overmap": "urban_37_9_south" },
       { "point": [ 0, 1, 1 ], "overmap": "urban_37_10_south" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_37_11_south" },
@@ -1196,8 +1172,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ 1, 2, 0 ], "connection": "local_road", "from": [ 1, 1, 0 ] },
       { "point": [ -1, 1, -1 ], "connection": "sewer_tunnel", "from": [ 0, 1, -1 ] }
     ],
@@ -1211,8 +1185,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "urban_38_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_38_3_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_38_4_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_38_5_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_38_6_south" },
       { "point": [ 1, 0, 2 ], "overmap": "urban_38_7_south" },
@@ -1224,8 +1196,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ 2, 0, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
       { "point": [ -1, 0, -1 ], "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] }
     ],
@@ -1242,8 +1212,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "urban_39_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_39_3_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_39_4_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_39_5_south" },
       { "point": [ 0, 0, 1 ], "overmap": "urban_39_6_south" },
       { "point": [ 1, 0, 2 ], "overmap": "urban_39_7_south" },
@@ -1253,8 +1221,6 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] },
       { "point": [ 2, 0, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
       { "point": [ -1, 0, -1 ], "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] },
       { "point": [ 1, 2, -2 ], "connection": "subway_tunnel", "from": [ 1, 1, -2 ] },
@@ -1285,8 +1251,6 @@
       { "point": [ 0, 1, 0 ], "overmap": "urban_41_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_41_3_south" },
       { "point": [ 0, 0, 0 ], "overmap": "urban_41_4_south" },
-      { "point": [ 0, -1, 0 ], "overmap": "road_ew" },
-      { "point": [ 1, -1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 1, 1 ], "overmap": "urban_41_5_south" },
       { "point": [ 0, 1, 1 ], "overmap": "urban_41_6_south" },
       { "point": [ 1, 0, 1 ], "overmap": "urban_41_7_south" },
@@ -1297,10 +1261,6 @@
       { "point": [ 0, 0, 2 ], "overmap": "urban_41_12_south" }
     ],
     "locations": [ "land" ],
-    "connections": [
-      { "point": [ -1, -1, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] }
-    ],
     "flags": [ "CLASSIC", "URBAN" ]
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)
Same as https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6539
## Describe the solution (The How)
In the file multitile_city_buildings.json delete the static road and road connection of the following `city_building`:
"urban_31_police_station", "urban_33_hotel", "urban_34_school", "urban_36_projects", "urban_37_office_tower_beehive", "urban_38_bar_hardware_house", "urban_39_market_subway_newspaper" and "urban_41_library"
## Describe alternatives you've considered
none
## Testing
No errors when starting a new game.
I make my character appear in the game at the concerned locations via a scenario.
The buildings after these changes appear against the road in town but sometimes not, in fact most of the buildings that are quite long don't appear completely against the road in town.
## Additional context
none
## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.