### PR TITLE
fix: enemies teleporting to recent sources of sound when they reach th…

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -888,9 +888,7 @@ void monster::move()
         return;
     }
 
-    tripoint destination;
-    bool have_destination = false;
-    bool pathed_to_goal = this->path.empty() ? false : this->path.back() == goal;
+    tripoint destination = this->pos();
 
     if( !this->is_wandering() ) {
         if( this->repath_requested ) {
@@ -920,43 +918,44 @@ void monster::move()
         if( this->path.empty() ) {
             // No prior path, no successful pathing, go in a straight line
             destination = goal;
-            have_destination = true;
         } else {
             destination = this->path.front();
 
             const bool is_viable_dest = here.valid_move( this->pos(), destination, true, true, true );
-            pathed_to_goal = is_viable_dest;
-            have_destination = is_viable_dest;
 
             if( !is_viable_dest ) {
                 // Should not _usually_ occur, but...
+                destination = this->pos();
                 this->path.clear();
                 this->repath_requested = true;
             }
         }
     } else {
+        if( has_flag( MF_SMELLS ) ) {
+            // No sight... or our plans are invalid (e.g. moving through a transparent, but
+            //  solid, square of terrain).  Fall back to smell if we have it.
+            this->unset_dest();
+            tripoint tmp = this->scent_move();
+            if( tmp.x != -1 ) {
+                destination = tmp;
+            }
+        }
+
+        if( this->wandf > 0 && this->friendly == 0 ) {
+            // No LOS, no scent, so as a fall-back follow sound
+            this->unset_dest();
+            if( this->wander_pos != this->pos() ) {
+                destination = this->wander_pos;
+            }
+        }
+
         this->path.clear();
     }
-    this->repath_requested = false;
 
-    if( !have_destination && has_flag( MF_SMELLS ) ) {
-        // No sight... or our plans are invalid (e.g. moving through a transparent, but
-        //  solid, square of terrain).  Fall back to smell if we have it.
-        unset_dest();
-        tripoint tmp = scent_move();
-        if( tmp.x != -1 ) {
-            destination = tmp;
-            have_destination = true;
-        }
-    }
-    if( wandf > 0 && !have_destination &&
-        friendly == 0 ) { // No LOS, no scent, so as a fall-back follow sound
-        unset_dest();
-        if( wander_pos != pos() ) {
-            destination = wander_pos;
-            have_destination = true;
-        }
-    }
+    const bool have_destination = destination != this->pos();
+    const bool pathed_to_goal = this->path.empty() ? false :
+                                this->path.front() == destination && this->path.back() == goal;
+    this->repath_requested = false;
 
     if( !g->m.has_zlevels() ) {
         // Otherwise weird things happen


### PR DESCRIPTION
## Purpose of change (The Why)
Enemies seemingly teleport to player's vicinity under specific circumstances. Fix this.

## Describe the solution (The How)
Fix an edge case where monmove logic thinks that pathfinding has occurred this turn even though it hasn't and blindly uses `destination` variable that's actually set by smell/sound following logic, treating it as the next step proposed by pathfinding, which leads to skipping a few checks down the line and culminates in the enemy instantly being moved to their destination as opposed to moving in a straight line towards it.

## Describe alternatives you've considered
N/A

## Testing
Needs deeper testing

## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
