### PR TITLE
refactor: use c++23 ranges on find_auto_consume

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,7 +44,10 @@ jobs:
       - name: Setup build and dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install gettext libsqlite3-dev zlib1g-dev
+          sudo apt-get install gcc-14 gettext libsqlite3-dev zlib1g-dev
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          g++ --version
 
       - name: Build
         working-directory: ./android

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ if (NOT MSVC)
     if (NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
         set(CATA_WARNINGS "${CATA_WARNINGS} -Wredundant-decls")
     endif ()
-    set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -fsigned-char -g1")
+    set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -fsigned-char -fno-builtin-std-forward_like -g1")
     # Compact the whitespace in the warning string
     string(REGEX REPLACE "[\t ]+" " " CATA_WARNINGS "${CATA_WARNINGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CATA_WARNINGS} ${CATA_OTHER_FLAGS}")

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -16,11 +16,13 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+#include <ranges>
 
 #include "activity_actor_definitions.h"
 #include "avatar.h"
 #include "avatar_action.h"
 #include "calendar.h"
+#include "cata_algo.h"
 #include "character.h"
 #include "character_functions.h"
 #include "clzones.h"
@@ -76,6 +78,9 @@
 #include "vehicle_selector.h"
 #include "vpart_position.h"
 #include "weather.h"
+#include "map_utils.h"
+
+namespace views = std::views;
 
 static const activity_id ACT_BUTCHER_FULL( "ACT_BUTCHER_FULL" );
 static const activity_id ACT_CHOP_LOGS( "ACT_CHOP_LOGS" );
@@ -3140,14 +3145,9 @@ bool find_auto_consume( player &p, const consume_type type )
     if( here.check_vehicle_zones( g->get_levz() ) ) {
         mgr.cache_vzones();
     }
-    const std::unordered_set<tripoint> &dest_set = mgr.get_near( consume_type_zone, here.getabs( pos ),
-            ACTIVITY_SEARCH_DISTANCE );
-    if( dest_set.empty() ) {
-        return false;
-    }
 
-    const auto ok_to_consume = [&p, type]( item & it ) -> bool {
-        item &comest = p.get_consumable_from( it );
+    const auto ok_to_consume = [&p, type]( const item * it ) -> bool {
+        const item &comest = p.get_consumable_from( const_cast<item &>( *it ) );
         /* not food.              */
         if( comest.is_null() || comest.is_craft() || !comest.is_food() )
         {
@@ -3169,7 +3169,7 @@ bool find_auto_consume( player &p, const consume_type type )
             return false;
         }
         /* not ours, freely steal from hostiles however  */
-        if( !it.is_owned_by( p, true ) && it.get_owner()->likes_u >= -10 )
+        if( !it->is_owned_by( p, true ) && it->get_owner()->likes_u >= -10 )
         {
             return false;
         }
@@ -3191,73 +3191,31 @@ bool find_auto_consume( player &p, const consume_type type )
         return true;
     };
 
-    struct {
-        item *min_shelf_life = nullptr;
-        tripoint loc = tripoint_min;
-        item *item_loc = nullptr;
+    using namespace cata::ranges;
 
-        bool longer_life_than( item &it ) {
-            return !min_shelf_life || it.spoilage_sort_order() < min_shelf_life->spoilage_sort_order();
-        };
-    } current;
-
-    const auto should_skip = [&]( item & it ) {
-        return !ok_to_consume( it ) || !current.longer_life_than( it );
+    const auto compare = []( const item * a, const item * b ) {
+        return a->spoilage_sort_order() < b->spoilage_sort_order();
     };
-
-    for( const tripoint loc : dest_set ) {
-        if( loc.z != p.pos().z ) {
-            continue;
-        }
-        const optional_vpart_position vp = here.veh_at( g->m.getlocal( loc ) );
-        if( vp ) {
-            vehicle &veh = vp->vehicle();
-            const int index = veh.part_with_feature( vp->part_index(), "CARGO", false );
-            if( index < 0 ) {
-                continue;
-            }
-            /**
-             * TODO: when we get to use ranges library, current should be replaced with:
-             *
-             * const auto shortest = vehitems | filter_view(ok_to_consume) | max_element(spoilage_sort_order)
-             *
-             * rationale:
-             * 1. much more readable (mandatory FP shilling)
-             * 2. filter_view does not create a new container (it's a view), so it's performant
-             *
-             * @see https://en.cppreference.com/w/cpp/ranges/filter_view
-             * @see https://en.cppreference.com/w/cpp/algorithm/ranges/max_element
-             */
-            vehicle_stack vehitems = veh.get_items( index );
-            for( item *&it : vehitems ) {
-                if( should_skip( *it ) ) {
-                    continue;
-                }
-                current = { it, loc, &p.get_consumable_from( *it ) };
-            }
-        } else {
-            map_stack mapitems = here.i_at( here.getlocal( loc ) );
-            for( item *&it : mapitems ) {
-                if( should_skip( *it ) ) {
-                    continue;
-                }
-                current = { it, loc, &p.get_consumable_from( *it )};
-            }
-        }
-    }
-    if( !current.min_shelf_life ) {
+    std::optional<item *> stalest = mgr.get_near( consume_type_zone, here.getabs( pos ),
+                                    ACTIVITY_SEARCH_DISTANCE )
+                                    | views::filter( [&]( const auto & loc ) -> bool { return loc.z == p.pos().z; } )
+                                    | flat_map( get_items_at )
+                                    | views::filter( ok_to_consume )
+                                    | min_by( compare );
+    if( !stalest ) {
         return false;
     }
 
     // actually eat
-    const auto cost = pickup::cost_to_move_item( p, *current.min_shelf_life );
-    const auto dist = std::max( rl_dist( p.pos(), here.getlocal( current.loc ) ), 1 );
+    const auto cost = pickup::cost_to_move_item( p, **stalest );
+    const auto dist = std::max( rl_dist( p.pos(), here.getlocal( ( *stalest )->position() ) ), 1 );
     p.mod_moves( -cost * dist );
 
-    avatar_action::eat( g->u, current.item_loc );
+    item *item_loc = &p.get_consumable_from( **stalest );
+    avatar_action::eat( get_avatar(), item_loc );
     // eat() may have removed the item, so check its still there.
-    if( current.item_loc && current.item_loc->is_container() ) {
-        current.item_loc->on_contents_changed();
+    if( item_loc && item_loc->is_container() ) {
+        item_loc->on_contents_changed();
     }
     return true;
 }

--- a/src/cata_algo.h
+++ b/src/cata_algo.h
@@ -223,21 +223,21 @@ struct MinAdaptor {
 };
 
 template <typename Comp>
-constexpr auto max_by( Comp &&comp )
+inline auto max_by( Comp &&comp )
 {
     return MaxAdaptor<std::decay_t<Comp>>( std::forward<Comp>( comp ) );
 }
-constexpr auto max()
+inline auto max()
 {
     return MaxAdaptor( std::less{} );
 }
 
 template <typename Comp>
-constexpr auto min_by( Comp &&comp )
+inline auto min_by( Comp &&comp )
 {
     return MinAdaptor<std::decay_t<Comp>>( std::forward<Comp>( comp ) );
 }
-constexpr auto min()
+inline auto min()
 {
     return MinAdaptor( std::less{} );
 }

--- a/src/cata_algo.h
+++ b/src/cata_algo.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include <algorithm>
+#include <functional>
 #include <map>
 #include <cassert>
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <ranges>
 
 namespace cata
 {
@@ -146,5 +148,100 @@ auto group_by( const C &c, F && selector )
     }
     return result;
 }
+
+namespace ranges
+{
+
+/// @remark poor person's flatmap
+inline constexpr auto flat_map = []( auto &&func )
+{
+    return std::views::transform( std::forward<decltype( func )>( func ) ) | std::views::join;
+};
+
+/// allows any invocable that accepts a range to be used in ranges pipeline
+/// doesn't require @tparam Self to be a range adaptor closure
+template <typename Self, std::ranges::input_range R> requires std::invocable<Self, R>
+auto operator|( R &&r, const Self &&adaptor )
+{
+    return adaptor( std::forward<R>( r ) );
+}
+
+template <typename Comp>
+struct MaxAdaptor {
+    Comp comp;
+    explicit MaxAdaptor( Comp c ) : comp( std::move( c ) ) {}
+
+    template <std::ranges::input_range R>
+    requires std::copy_constructible<std::ranges::range_value_t<R>>
+    auto operator()( R &&r ) const -> std::optional<std::ranges::range_value_t<R>> {
+        auto current_it = std::ranges::begin( r );
+        const auto last_it = std::ranges::end( r );
+
+        if( current_it == last_it ) {
+            return std::nullopt;
+        }
+
+        std::ranges::range_value_t<R> max_val = *current_it;
+        ++current_it;
+
+        while( current_it != last_it ) {
+            if( comp( max_val, *current_it ) ) {
+                max_val = *current_it;
+            }
+            ++current_it;
+        }
+        return max_val;
+    }
+};
+
+template <typename Comp>
+struct MinAdaptor {
+    Comp comp;
+    explicit MinAdaptor( Comp c ) : comp( std::move( c ) ) {}
+
+    template <std::ranges::input_range R>
+    requires std::copy_constructible<std::ranges::range_value_t<R>>
+    auto operator()( R &&r ) const -> std::optional<std::ranges::range_value_t<R>> {
+        auto current_it = std::ranges::begin( r );
+        const auto last_it = std::ranges::end( r );
+
+        if( current_it == last_it ) {
+            return std::nullopt;
+        }
+
+        std::ranges::range_value_t<R> min_val = *current_it;
+        ++current_it;
+
+        while( current_it != last_it ) {
+            if( comp( *current_it, min_val ) ) {
+                min_val = *current_it;
+            }
+            ++current_it;
+        }
+        return min_val;
+    }
+};
+
+template <typename Comp>
+constexpr auto max_by( Comp &&comp )
+{
+    return MaxAdaptor<std::decay_t<Comp>>( std::forward<Comp>( comp ) );
+}
+constexpr auto max()
+{
+    return MaxAdaptor( std::less{} );
+}
+
+template <typename Comp>
+constexpr auto min_by( Comp &&comp )
+{
+    return MinAdaptor<std::decay_t<Comp>>( std::forward<Comp>( comp ) );
+}
+constexpr auto min()
+{
+    return MinAdaptor( std::less{} );
+}
+
+} // namespace ranges
 
 } // namespace cata

--- a/src/map_utils.cpp
+++ b/src/map_utils.cpp
@@ -1,0 +1,25 @@
+#include <ranges>
+#include "map.h"
+#include "map_utils.h"
+#include "game.h"
+#include "veh_type.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+
+auto get_items_at( const tripoint &loc ) -> location_subrange
+{
+    map &here = get_map();
+    const optional_vpart_position vp = here.veh_at( g->m.getlocal( loc ) );
+    if( vp ) {
+        vehicle &veh = vp->vehicle();
+        const int index = veh.part_with_feature( vp->part_index(), VPFLAG_CARGO, false );
+        if( index < 0 ) {
+            return {};
+        }
+        auto items = veh.get_items( index );
+        return std::ranges::subrange( items );
+    } else {
+        auto items = here.i_at( here.getlocal( loc ) );
+        return std::ranges::subrange( items );
+    }
+}

--- a/src/map_utils.h
+++ b/src/map_utils.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "location_vector.h"
+#include "point.h"
+
+class item;
+
+using location_subrange =
+    std::ranges::subrange<location_vector<item>::iterator, location_vector<item>::iterator>;
+
+/// @brief Get all items at a given position. If the position is inside a vehicle, it will
+///        return the items in the vehicle's cargo.
+/// @return An item range at the given position.
+auto get_items_at( const tripoint &loc ) -> location_subrange;

--- a/tests/algo_test.cpp
+++ b/tests/algo_test.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <unordered_map>
 #include <vector>
+#include <ranges>
 
 #include "cata_algo.h"
 
@@ -16,10 +17,10 @@ static void check_cycle_finding( std::unordered_map<int, std::vector<int>> &g,
     // Canonicalize the list of loops by rotating each to be lexicographically
     // least and then sorting.
     for( std::vector<int> &loop : loops ) {
-        auto min = std::min_element( loop.begin(), loop.end() );
-        std::rotate( loop.begin(), min, loop.end() );
+        auto min = std::ranges::min_element( loop );
+        std::ranges::rotate( loop, min );
     }
-    std::sort( loops.begin(), loops.end() );
+    std::ranges::sort( loops );
     CHECK( loops == expected );
 }
 
@@ -48,4 +49,123 @@ TEST_CASE( "find_cycles" )
         { 1, 2 },
     };
     check_cycle_finding( g, expected );
+}
+TEST_CASE( "flat_map", "[ranges]" )
+{
+    using namespace cata::ranges;
+    auto fn = []( const int i ) -> std::vector<int> { return { i, i * 2 }; };
+
+    SECTION( "general case" ) {
+        auto input = std::vector{ 1, 2 };
+        auto output = input
+                      | flat_map( fn )
+                      | std::ranges::to<std::vector>();
+
+        CHECK( output == std::vector{ 1, 2, 2, 4 } );
+    }
+
+    SECTION( "empty input" ) {
+        auto input = std::vector<int> {};
+        auto output = input
+                      | flat_map( fn )
+                      | std::ranges::to<std::vector>();
+
+        CHECK( output == std::vector<int> {} );
+    }
+}
+
+struct foo {
+    int i;
+    auto operator<=>( const foo & ) const = default; // *NOPAD*
+};
+
+TEST_CASE( "max", "[ranges]" )
+{
+    using namespace cata::ranges;
+
+    SECTION( "general case" ) {
+        auto input = std::vector{ 1, 2, 3 };
+        auto output = input | max();
+
+        CHECK( output == 3 );
+    }
+
+    SECTION( "empty input" ) {
+        auto input = std::vector<int> {};
+        auto output = input | max();
+
+        CHECK( !output.has_value() );
+    }
+}
+
+TEST_CASE( "max_by", "[ranges]" )
+{
+    using namespace cata::ranges;
+
+    SECTION( "general case" ) {
+        auto input = std::vector{ foo{ 1 }, foo{ 2 }, foo{ 3 } };
+        auto output = input | max_by( std::less{} );
+
+        CHECK( output.value() == foo{3} );
+    }
+
+    SECTION( "empty input" ) {
+        auto input = std::vector<int> {};
+        auto output = input | max_by( std::less{} );
+
+        CHECK( !output.has_value() );
+    }
+}
+
+TEST_CASE( "min", "[ranges]" )
+{
+    using namespace cata::ranges;
+
+    SECTION( "general case" ) {
+        auto input = std::vector{ 1, 2, 3 };
+        auto output = input | min();
+
+        CHECK( output == 1 );
+    }
+
+    SECTION( "empty input" ) {
+        auto input = std::vector<int> {};
+        auto output = input | min();
+
+        CHECK( !output.has_value() );
+    }
+}
+TEST_CASE( "min_by", "[ranges]" )
+{
+    using namespace cata::ranges;
+
+    SECTION( "general case" ) {
+        auto input = std::vector{ foo{ 1 }, foo{ 2 }, foo{ 3 } };
+        auto output = input | min_by( std::less{} );
+
+        CHECK( output.value() == foo{1} );
+    }
+
+    SECTION( "empty input" ) {
+        auto input = std::vector<int> {};
+        auto output = input | min_by( std::less{} );
+
+        CHECK( !output.has_value() );
+    }
+}
+
+TEST_CASE( "complex pipeline", "[ranges]" )
+{
+    using namespace cata::ranges;
+
+    auto dup = []( const int i ) -> int { return i * 2; };
+    auto is_even = []( const int i ) -> bool { return i % 2 == 0; };
+    auto input = std::vector{ 1, 2, 3 };
+    auto output = input
+                  | std::views::filter( is_even )
+                  | flat_map( []( const int i ) -> auto { return std::vector{i, i * 2 }; } )
+                  | std::views::transform( dup )
+                  | max();
+
+    CHECK( output == 8 );
 }

--- a/tests/algo_test.cpp
+++ b/tests/algo_test.cpp
@@ -70,7 +70,7 @@ TEST_CASE( "flat_map", "[ranges]" )
                       | flat_map( fn )
                       | std::ranges::to<std::vector>();
 
-        CHECK( output == std::vector<int> {} );
+        CHECK( output.empty() );
     }
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

finally, after 2 years (#2402), we can use std::ranges to simplify auto consume logic.

## Describe the solution (The How)

adds:

- flat_map (haha monads go brrrrrrr)
- null-safe `max`, `max_by`, `min`, `min_by` that returns `std::optional<T>`
- convenience function to get all items on given position, including vehicles

## Describe alternatives you've considered

- cry on for loops
- min/max functions use loops over ranges variant because while flat_map returns input_iterator, ranges variants requires forward_iterators.

## Testing

1. created auto eat zone.
2. debug edited my character's hunger to 16000kcal (hungry).
3. kept it empty and waited for 5min.
4. no crashes.
5. spawned cheese pizza (1week to rot) and cornbread (1season to rot) on auto eat zone.
6. waited for 5min.
7. player ate pizza first then cornbread

## Additional context

maybe this could be merged as rebase-merge? idk

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


