### PR TITLE
ci: timestamp and links for experimental releases

### DIFF
--- a/.github/workflows/experimental-release.yml
+++ b/.github/workflows/experimental-release.yml
@@ -220,9 +220,10 @@ jobs:
         if: github.repository == 'cataclysmbnteam/Cataclysm-BN'
         run: |
           SHA_SHORT=$(git rev-parse --short HEAD)
+          TIMESTAMP=$(date "+%F %T")
 
           gh release upload experimental --clobber cbn-${{ matrix.artifact }}-experimental.${{ matrix.ext }}
-          gh release edit experimental --title "Experimental $SHA_SHORT" --notes "Experimental build for commit $SHA_SHORT"
+          gh release edit experimental --title "Experimental @ $TIMESTAMP (`$SHA_SHORT`)" --notes "Experimental build for commit $SHA_SHORT on $TIMESTAMP"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash

--- a/README.ko.md
+++ b/README.ko.md
@@ -31,7 +31,7 @@
 
 ### 실행 파일
 
-[![Stable][stable-releases-badge]][stable-releases] [![Recent][all-releases-badge]][all-releases]
+[![Stable][stable-releases-badge]][stable-releases] [![Recent][all-releases-badge]][all-releases] [![Experiemental][experimental-badge]][experimental-releases]
 
 ### 소스 코드
 
@@ -41,6 +41,8 @@
 [stable-releases-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?style=for-the-badge&color=success&label=안정판
 [all-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases?q=prerelease%3Atrue&expanded=true "실험판 실행 파일 내려받기"
 [all-releases-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?style=for-the-badge&color=important&label=최신%20실험판&include_prereleases&sort=date
+[experimental-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/experimental
+[experimental-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?style=for-the-badge&color=salmon&label=Experimental%20Release&include_prereleases&sort=date
 [source]: https://github.com/cataclysmbnteam/Cataclysm-BN/archive/master.zip "소스 코드를 .zip 아카이브로 다운로드할 수 있습니다"
 [source-badge]: https://img.shields.io/badge/ZIP%20아카이브로%20내려받기-black?style=for-the-badge&logo=github
 [clone]: https://github.com/cataclysmbnteam/Cataclysm-BN/ "GitHub 저장소에서 클론할 수 있습니다"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 
 ### Executables
 
-[![Stable][stable-releases-badge]][stable-releases] [![Recent][all-releases-badge]][all-releases]
+[![Stable][stable-releases-badge]][stable-releases] [![Recent][all-releases-badge]][all-releases] [![Experiemental][experimental-badge]][experimental-releases]
 
 ### Source Code
 
@@ -42,6 +42,8 @@ Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 [stable-releases-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?style=for-the-badge&color=success&label=stable
 [all-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases?q=prerelease%3Atrue&expanded=true
 [all-releases-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?style=for-the-badge&color=important&label=Latest%20Release&include_prereleases&sort=date
+[experimental-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/experimental
+[experimental-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?style=for-the-badge&color=salmon&label=Experimental%20Release&include_prereleases&sort=date
 [source]: https://github.com/cataclysmbnteam/Cataclysm-BN/archive/master.zip "The source can be downloaded as a .zip archive"
 [source-badge]: https://img.shields.io/badge/Zip%20Archive-black?style=for-the-badge&logo=github
 [clone]: https://github.com/cataclysmbnteam/Cataclysm-BN/ "clone from our GitHub repo"


### PR DESCRIPTION
## Purpose of change (The Why)

- make it more visible
- hard to see when the last experimental was released

## Describe the solution (The How)

![image](https://github.com/user-attachments/assets/5cf450a7-2515-43ad-aca7-443f004f0001)

show release timestamp more visibly

## Testing

should work

## Additional context


## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

