### PR TITLE
style: keep one line breaks

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -49,3 +49,5 @@
 # insert space padding around parentheses on the inside only
 --pad-paren-in
 
+# Don't break one-line blocks.
+--keep-one-line-blocks


### PR DESCRIPTION

## Purpose of change (The Why)

allows writing one-line blocks, e.g lambdas. currently writing lambdas are needlessly annoying because astyle formats

```c++
const auto fn = []() { return 1; };
```

into 

```c++
const auto fn = []() {
    return 1;
};
```

unless you add meaningless return type like

```c++
const auto fn = []() -> auto { return 1; };
```


## Describe the solution (The How)

add astyle flag [`--keep-one-line-blocks`](https://astyle.sourceforge.net/astyle.html#_keep-one-line-blocks).

## Describe alternatives you've considered

migrate to clang-tidy, i hate astyle so much

## Testing

ran `make astyle` and confirmed it did not cause issues.

## Additional context

new code from now on will default to one-line when possible.

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

