### PR TITLE
feat: more lua bindings for `item`

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -6,7 +6,7 @@
 # Validate the PR title, and ignore all commit messages
 enabled: true
 titleOnly: true
-targetUrl: 'https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/'
+targetUrl: "https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/"
 types:
   - feat
   - fix

--- a/doc/src/content/docs/en/mod/lua/reference/lua.md
+++ b/doc/src/content/docs/en/mod/lua/reference/lua.md
@@ -2610,6 +2610,18 @@ Function `( Item ) -> bool`
 
 Function `( Item, int )`
 
+#### get_kcal
+
+Function `( Item ) -> int`
+
+#### get_quench
+
+Function `( Item ) -> int`
+
+#### get_comestible_fun
+
+Function `( Item ) -> int`
+
 #### get_rot
 
 Gets the TimeDuration until this item rots
@@ -3270,6 +3282,58 @@ Function `( Mass, Mass ) -> bool`
 #### __le
 
 Function `( Mass, Mass ) -> bool`
+
+## MaterialTypeId
+
+### Bases
+
+No base classes.
+
+### Constructors
+
+#### `MaterialTypeId.new()`
+
+#### `MaterialTypeId.new( MaterialTypeId )`
+
+#### `MaterialTypeId.new( string )`
+
+### Members
+
+#### obj
+
+Function `( MaterialTypeId ) -> MaterialTypeRaw`
+
+#### implements_int_id
+
+Function `() -> bool`
+
+#### is_null
+
+Function `( MaterialTypeId ) -> bool`
+
+#### is_valid
+
+Function `( MaterialTypeId ) -> bool`
+
+#### str
+
+Function `( MaterialTypeId ) -> string`
+
+#### NULL_ID
+
+Function `() -> MaterialTypeId`
+
+#### __tostring
+
+Function `( MaterialTypeId ) -> string`
+
+#### serialize
+
+Function `( MaterialTypeId, <cppval: 7JsonOut > )`
+
+#### deserialize
+
+Function `( MaterialTypeId, <cppval: 6JsonIn > )`
 
 ## Monster
 

--- a/doc/src/content/docs/en/mod/lua/reference/lua.md
+++ b/doc/src/content/docs/en/mod/lua/reference/lua.md
@@ -2347,6 +2347,21 @@ Function `( Item, int, bool, int ) -> string`
 Display name with all bells and whistles like ammo and prefixes
 Function `( Item, int ) -> string`
 
+#### weight
+
+Weight of the item. The first `bool` is whether including contents, second `bool` is whether it is `integral_weight`.
+Function `( Item, Opt( bool ), Opt( bool ) ) -> Mass`
+
+#### volume
+
+Volume of the item. `bool` is whether it is `integral_volume`.
+Function `( Item, Opt( bool ) ) -> Volume`
+
+#### price
+
+Cents of the item. `bool` is whether it is a post-cataclysm value.
+Function `( Item, bool ) -> int`
+
 #### has_var
 
 Check for variable of any type
@@ -2594,6 +2609,10 @@ Function `( Item ) -> bool`
 
 Function `( Item ) -> bool`
 
+#### is_stackable
+
+Function `( Item ) -> bool`
+
 #### charges
 
 Variable of type `int`
@@ -2609,6 +2628,14 @@ Function `( Item ) -> bool`
 #### mod_charges
 
 Function `( Item, int )`
+
+#### made_of
+
+Function `( Item ) -> <cppval: St6vectorI9string_idI13material_typeESaIS2_EE >`
+
+#### is_made_of
+
+Function `( Item, MaterialTypeId ) -> bool`
 
 #### get_kcal
 
@@ -3334,6 +3361,26 @@ Function `( MaterialTypeId, <cppval: 7JsonOut > )`
 #### deserialize
 
 Function `( MaterialTypeId, <cppval: 6JsonIn > )`
+
+## MaterialTypeRaw
+
+### Bases
+
+No base classes.
+
+### Constructors
+
+No constructors.
+
+### Members
+
+#### str_id
+
+Function `( MaterialTypeRaw ) -> MaterialTypeId`
+
+#### name
+
+Function `( MaterialTypeRaw ) -> string`
 
 ## Monster
 

--- a/lua_annotations.lua
+++ b/lua_annotations.lua
@@ -14,10 +14,10 @@ game = {}
 --================---- Classes ----================
 
 ---@class ActivityTypeId
+---@field NULL_ID fun(): ActivityTypeId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: ActivityTypeId): boolean
 ---@field is_valid fun(arg1: ActivityTypeId): boolean
----@field NULL_ID fun(): ActivityTypeId
 ---@field obj fun(arg1: ActivityTypeId): ActivityTypeRaw
 ---@field str fun(arg1: ActivityTypeId): string
 ---@field serialize fun(arg1: ActivityTypeId)
@@ -49,10 +49,10 @@ Avatar = {}
 function Avatar.new() end
 
 ---@class BionicDataId
+---@field NULL_ID fun(): BionicDataId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: BionicDataId): boolean
 ---@field is_valid fun(arg1: BionicDataId): boolean
----@field NULL_ID fun(): BionicDataId
 ---@field obj fun(arg1: BionicDataId): BionicDataRaw
 ---@field str fun(arg1: BionicDataId): string
 ---@field serialize fun(arg1: BionicDataId)
@@ -65,11 +65,11 @@ BionicDataId = {}
 function BionicDataId.new() end
 
 ---@class BodyPartTypeId
+---@field NULL_ID fun(): BodyPartTypeId
 ---@field implements_int_id fun(): boolean
 ---@field int_id fun(arg1: BodyPartTypeId): BodyPartTypeIntId
 ---@field is_null fun(arg1: BodyPartTypeId): boolean
 ---@field is_valid fun(arg1: BodyPartTypeId): boolean
----@field NULL_ID fun(): BodyPartTypeId
 ---@field obj fun(arg1: BodyPartTypeId): BodyPartTypeRaw
 ---@field str fun(arg1: BodyPartTypeId): string
 ---@field serialize fun(arg1: BodyPartTypeId)
@@ -103,9 +103,9 @@ function BodyPartTypeIntId.new() end
 ---@field activate_mutation fun(arg1: Character, arg2: MutationBranchId)
 ---@field add_addiction fun(arg1: Character, arg2: AddictionType, arg3: integer)
 ---@field add_bionic fun(arg1: Character, arg2: BionicDataId)
----@field addiction_level fun(arg1: Character, arg2: AddictionType): integer
 ---@field add_item_with_id fun(arg1: Character, arg2: ItypeId, arg3: integer) @Adds an item with the given id and amount
 ---@field add_morale fun(arg1: Character, arg2: MoraleTypeDataId, arg3: integer, arg4: integer, arg5: TimeDuration, arg6: TimeDuration, arg7: boolean, arg8: ItypeRaw)
+---@field addiction_level fun(arg1: Character, arg2: AddictionType): integer
 ---@field age fun(arg1: Character): integer
 ---@field all_items fun(arg1: Character, arg2: boolean): any @Gets all items
 ---@field all_items_with_flag fun(arg1: Character, arg2: JsonFlagId, arg3: boolean): any @Gets all items with the given flag
@@ -118,7 +118,6 @@ function BodyPartTypeIntId.new() end
 ---@field blossoms fun(arg1: Character)
 ---@field bodypart_exposure fun(arg1: Character): any
 ---@field bodyweight fun(arg1: Character): Mass
----@field cancel_activity fun(arg1: Character)
 ---@field can_hear fun(arg1: Character, arg2: Tripoint, arg3: integer): boolean
 ---@field can_mount fun(arg1: Character, arg2: Monster): boolean
 ---@field can_pick_volume fun(arg1: Character, arg2: Volume): boolean
@@ -126,6 +125,7 @@ function BodyPartTypeIntId.new() end
 ---@field can_run fun(arg1: Character): boolean
 ---@field can_unwield fun(arg1: Character, arg2: Item): boolean
 ---@field can_wield fun(arg1: Character, arg2: Item): boolean
+---@field cancel_activity fun(arg1: Character)
 ---@field check_mount_is_spooked fun(arg1: Character): boolean
 ---@field check_mount_will_move fun(arg1: Character, arg2: Tripoint): boolean
 ---@field clear_bionics fun(arg1: Character)
@@ -139,6 +139,7 @@ function BodyPartTypeIntId.new() end
 ---@field expose_to_disease fun(arg1: Character, arg2: DiseaseTypeId)
 ---@field fall_asleep fun(arg1: Character) | fun(arg1: Character, arg2: TimeDuration)
 ---@field forced_dismount fun(arg1: Character)
+---@field getID fun(arg1: Character): CharacterId
 ---@field get_all_skills fun(arg1: Character): SkillLevelMap
 ---@field get_armor_acid fun(arg1: Character, arg2: BodyPartTypeIntId): integer
 ---@field get_base_traits fun(arg1: Character): any
@@ -153,7 +154,6 @@ function BodyPartTypeIntId.new() end
 ---@field get_healthy_mod fun(arg1: Character): integer
 ---@field get_highest_category fun(arg1: Character): MutationCategoryTraitId
 ---@field get_hostile_creatures fun(arg1: Character, arg2: integer): any
----@field getID fun(arg1: Character): CharacterId
 ---@field get_int fun(arg1: Character): integer
 ---@field get_int_base fun(arg1: Character): integer
 ---@field get_int_bonus fun(arg1: Character): integer
@@ -302,10 +302,11 @@ function BodyPartTypeIntId.new() end
 ---@field remove_bionic fun(arg1: Character, arg2: BionicDataId)
 ---@field remove_child_flag fun(arg1: Character, arg2: MutationBranchId)
 ---@field remove_mutation fun(arg1: Character, arg2: MutationBranchId, arg3: boolean)
----@field restore_scent fun(arg1: Character)
 ---@field rest_quality fun(arg1: Character): number
+---@field restore_scent fun(arg1: Character)
 ---@field rooted fun(arg1: Character)
 ---@field rust_rate fun(arg1: Character): integer
+---@field setID fun(arg1: Character, arg2: CharacterId, arg3: boolean)
 ---@field set_base_age fun(arg1: Character, arg2: integer)
 ---@field set_base_height fun(arg1: Character, arg2: integer)
 ---@field set_dex_bonus fun(arg1: Character, arg2: integer)
@@ -313,7 +314,6 @@ function BodyPartTypeIntId.new() end
 ---@field set_fatigue fun(arg1: Character, arg2: integer)
 ---@field set_healthy fun(arg1: Character, arg2: integer)
 ---@field set_healthy_mod fun(arg1: Character, arg2: integer)
----@field setID fun(arg1: Character, arg2: CharacterId, arg3: boolean)
 ---@field set_int_bonus fun(arg1: Character, arg2: integer)
 ---@field set_max_power_level fun(arg1: Character, arg2: Energy)
 ---@field set_movement_mode fun(arg1: Character, arg2: CharacterMoveMode)
@@ -501,10 +501,10 @@ DealtDamageInstance = {}
 function DealtDamageInstance.new() end
 
 ---@class DiseaseTypeId
+---@field NULL_ID fun(): DiseaseTypeId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: DiseaseTypeId): boolean
 ---@field is_valid fun(arg1: DiseaseTypeId): boolean
----@field NULL_ID fun(): DiseaseTypeId
 ---@field obj fun(arg1: DiseaseTypeId): DiseaseTypeRaw
 ---@field str fun(arg1: DiseaseTypeId): string
 ---@field serialize fun(arg1: DiseaseTypeId)
@@ -530,10 +530,10 @@ DistributionGridTracker = {}
 function DistributionGridTracker.new() end
 
 ---@class EffectTypeId
+---@field NULL_ID fun(): EffectTypeId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: EffectTypeId): boolean
 ---@field is_valid fun(arg1: EffectTypeId): boolean
----@field NULL_ID fun(): EffectTypeId
 ---@field obj fun(arg1: EffectTypeId): EffectTypeRaw
 ---@field str fun(arg1: EffectTypeId): string
 ---@field serialize fun(arg1: EffectTypeId)
@@ -558,10 +558,10 @@ Energy = {}
 function Energy.new() end
 
 ---@class FactionId
+---@field NULL_ID fun(): FactionId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: FactionId): boolean
 ---@field is_valid fun(arg1: FactionId): boolean
----@field NULL_ID fun(): FactionId
 ---@field obj fun(arg1: FactionId): FactionRaw
 ---@field str fun(arg1: FactionId): string
 ---@field serialize fun(arg1: FactionId)
@@ -580,11 +580,11 @@ FactionRaw = {}
 function FactionRaw.new() end
 
 ---@class FieldTypeId
+---@field NULL_ID fun(): FieldTypeId
 ---@field implements_int_id fun(): boolean
 ---@field int_id fun(arg1: FieldTypeId): FieldTypeIntId
 ---@field is_null fun(arg1: FieldTypeId): boolean
 ---@field is_valid fun(arg1: FieldTypeId): boolean
----@field NULL_ID fun(): FieldTypeId
 ---@field obj fun(arg1: FieldTypeId): FieldTypeRaw
 ---@field str fun(arg1: FieldTypeId): string
 ---@field serialize fun(arg1: FieldTypeId)
@@ -609,11 +609,11 @@ FieldTypeIntId = {}
 function FieldTypeIntId.new() end
 
 ---@class FurnId
+---@field NULL_ID fun(): FurnId
 ---@field implements_int_id fun(): boolean
 ---@field int_id fun(arg1: FurnId): FurnIntId
 ---@field is_null fun(arg1: FurnId): boolean
 ---@field is_valid fun(arg1: FurnId): boolean
----@field NULL_ID fun(): FurnId
 ---@field obj fun(arg1: FurnId): FurnRaw
 ---@field str fun(arg1: FurnId): string
 ---@field serialize fun(arg1: FurnId)
@@ -669,9 +669,12 @@ function FurnRaw.new() end
 ---@field energy_remaining fun(arg1: Item): Energy
 ---@field erase_var fun(arg1: Item, arg2: string) @Erase variable
 ---@field get_category_id fun(arg1: Item): string @Gets the category id this item is in
+---@field get_comestible_fun fun(arg1: Item): integer
+---@field get_kcal fun(arg1: Item): integer
 ---@field get_mtype fun(arg1: Item): MtypeId @Almost for a corpse.
 ---@field get_owner fun(arg1: Item): FactionId @Gets the faction id that owns this item
 ---@field get_owner_name fun(arg1: Item): string
+---@field get_quench fun(arg1: Item): integer
 ---@field get_reload_time fun(arg1: Item): integer
 ---@field get_rot fun(arg1: Item): TimeDuration @Gets the TimeDuration until this item rots
 ---@field get_techniques fun(arg1: Item): any @Gets all techniques. Including original techniques.
@@ -768,10 +771,10 @@ ItemStack = {}
 function ItemStack.new() end
 
 ---@class ItypeId
+---@field NULL_ID fun(): ItypeId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: ItypeId): boolean
 ---@field is_valid fun(arg1: ItypeId): boolean
----@field NULL_ID fun(): ItypeId
 ---@field obj fun(arg1: ItypeId): ItypeRaw
 ---@field str fun(arg1: ItypeId): string
 ---@field serialize fun(arg1: ItypeId)
@@ -784,10 +787,10 @@ ItypeId = {}
 function ItypeId.new() end
 
 ---@class JsonFlagId
+---@field NULL_ID fun(): JsonFlagId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: JsonFlagId): boolean
 ---@field is_valid fun(arg1: JsonFlagId): boolean
----@field NULL_ID fun(): JsonFlagId
 ---@field obj fun(arg1: JsonFlagId): JsonFlagRaw
 ---@field str fun(arg1: JsonFlagId): string
 ---@field serialize fun(arg1: JsonFlagId)
@@ -800,10 +803,10 @@ JsonFlagId = {}
 function JsonFlagId.new() end
 
 ---@class JsonTraitFlagId
+---@field NULL_ID fun(): JsonTraitFlagId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: JsonTraitFlagId): boolean
 ---@field is_valid fun(arg1: JsonTraitFlagId): boolean
----@field NULL_ID fun(): JsonTraitFlagId
 ---@field obj fun(arg1: JsonTraitFlagId): JsonTraitFlagRaw
 ---@field str fun(arg1: JsonTraitFlagId): string
 ---@field serialize fun(arg1: JsonTraitFlagId)
@@ -854,10 +857,10 @@ MapStack = {}
 function MapStack.new() end
 
 ---@class MartialArtsBuffId
+---@field NULL_ID fun(): MartialArtsBuffId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: MartialArtsBuffId): boolean
 ---@field is_valid fun(arg1: MartialArtsBuffId): boolean
----@field NULL_ID fun(): MartialArtsBuffId
 ---@field obj fun(arg1: MartialArtsBuffId): MartialArtsBuffRaw
 ---@field str fun(arg1: MartialArtsBuffId): string
 ---@field serialize fun(arg1: MartialArtsBuffId)
@@ -870,10 +873,10 @@ MartialArtsBuffId = {}
 function MartialArtsBuffId.new() end
 
 ---@class MartialArtsTechniqueId
+---@field NULL_ID fun(): MartialArtsTechniqueId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: MartialArtsTechniqueId): boolean
 ---@field is_valid fun(arg1: MartialArtsTechniqueId): boolean
----@field NULL_ID fun(): MartialArtsTechniqueId
 ---@field obj fun(arg1: MartialArtsTechniqueId): MartialArtsTechniqueRaw
 ---@field str fun(arg1: MartialArtsTechniqueId): string
 ---@field serialize fun(arg1: MartialArtsTechniqueId)
@@ -900,6 +903,22 @@ function MartialArtsTechniqueId.new() end
 Mass = {}
 ---@return Mass
 function Mass.new() end
+
+---@class MaterialTypeId
+---@field NULL_ID fun(): MaterialTypeId
+---@field implements_int_id fun(): boolean
+---@field is_null fun(arg1: MaterialTypeId): boolean
+---@field is_valid fun(arg1: MaterialTypeId): boolean
+---@field obj fun(arg1: MaterialTypeId): MaterialTypeRaw
+---@field str fun(arg1: MaterialTypeId): string
+---@field serialize fun(arg1: MaterialTypeId)
+---@field deserialize fun(arg1: MaterialTypeId)
+---@field __tostring fun(arg1: MaterialTypeId): string
+MaterialTypeId = {}
+---@return MaterialTypeId
+---@overload fun(arg1: MaterialTypeId): MaterialTypeId
+---@overload fun(arg1: string): MaterialTypeId
+function MaterialTypeId.new() end
 
 ---@class Monster : Creature
 ---@field anger integer
@@ -943,11 +962,11 @@ Monster = {}
 function Monster.new() end
 
 ---@class MonsterFactionId
+---@field NULL_ID fun(): MonsterFactionId
 ---@field implements_int_id fun(): boolean
 ---@field int_id fun(arg1: MonsterFactionId): MonsterFactionIntId
 ---@field is_null fun(arg1: MonsterFactionId): boolean
 ---@field is_valid fun(arg1: MonsterFactionId): boolean
----@field NULL_ID fun(): MonsterFactionId
 ---@field obj fun(arg1: MonsterFactionId): MonsterFactionRaw
 ---@field str fun(arg1: MonsterFactionId): string
 ---@field serialize fun(arg1: MonsterFactionId)
@@ -972,10 +991,10 @@ MonsterFactionIntId = {}
 function MonsterFactionIntId.new() end
 
 ---@class MoraleTypeDataId
+---@field NULL_ID fun(): MoraleTypeDataId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: MoraleTypeDataId): boolean
 ---@field is_valid fun(arg1: MoraleTypeDataId): boolean
----@field NULL_ID fun(): MoraleTypeDataId
 ---@field obj fun(arg1: MoraleTypeDataId): MoraleTypeDataRaw
 ---@field str fun(arg1: MoraleTypeDataId): string
 ---@field serialize fun(arg1: MoraleTypeDataId)
@@ -988,10 +1007,10 @@ MoraleTypeDataId = {}
 function MoraleTypeDataId.new() end
 
 ---@class MtypeId
+---@field NULL_ID fun(): MtypeId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: MtypeId): boolean
 ---@field is_valid fun(arg1: MtypeId): boolean
----@field NULL_ID fun(): MtypeId
 ---@field obj fun(arg1: MtypeId): MtypeRaw
 ---@field str fun(arg1: MtypeId): string
 ---@field serialize fun(arg1: MtypeId)
@@ -1004,10 +1023,10 @@ MtypeId = {}
 function MtypeId.new() end
 
 ---@class MutationBranchId
+---@field NULL_ID fun(): MutationBranchId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: MutationBranchId): boolean
 ---@field is_valid fun(arg1: MutationBranchId): boolean
----@field NULL_ID fun(): MutationBranchId
 ---@field obj fun(arg1: MutationBranchId): MutationBranchRaw
 ---@field str fun(arg1: MutationBranchId): string
 ---@field serialize fun(arg1: MutationBranchId)
@@ -1095,10 +1114,10 @@ MutationBranchRaw = {}
 function MutationBranchRaw.new() end
 
 ---@class MutationCategoryTraitId
+---@field NULL_ID fun(): MutationCategoryTraitId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: MutationCategoryTraitId): boolean
 ---@field is_valid fun(arg1: MutationCategoryTraitId): boolean
----@field NULL_ID fun(): MutationCategoryTraitId
 ---@field obj fun(arg1: MutationCategoryTraitId): MutationCategoryTraitRaw
 ---@field str fun(arg1: MutationCategoryTraitId): string
 ---@field serialize fun(arg1: MutationCategoryTraitId)
@@ -1228,10 +1247,10 @@ QueryPopup = {}
 function QueryPopup.new() end
 
 ---@class RecipeId
+---@field NULL_ID fun(): RecipeId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: RecipeId): boolean
 ---@field is_valid fun(arg1: RecipeId): boolean
----@field NULL_ID fun(): RecipeId
 ---@field obj fun(arg1: RecipeId): RecipeRaw
 ---@field str fun(arg1: RecipeId): string
 ---@field serialize fun(arg1: RecipeId)
@@ -1244,10 +1263,10 @@ RecipeId = {}
 function RecipeId.new() end
 
 ---@class SkillId
+---@field NULL_ID fun(): SkillId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: SkillId): boolean
 ---@field is_valid fun(arg1: SkillId): boolean
----@field NULL_ID fun(): SkillId
 ---@field obj fun(arg1: SkillId): SkillRaw
 ---@field str fun(arg1: SkillId): string
 ---@field serialize fun(arg1: SkillId)
@@ -1278,10 +1297,10 @@ SkillLevelMap = {}
 function SkillLevelMap.new() end
 
 ---@class SpeciesTypeId
+---@field NULL_ID fun(): SpeciesTypeId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: SpeciesTypeId): boolean
 ---@field is_valid fun(arg1: SpeciesTypeId): boolean
----@field NULL_ID fun(): SpeciesTypeId
 ---@field obj fun(arg1: SpeciesTypeId): SpeciesTypeRaw
 ---@field str fun(arg1: SpeciesTypeId): string
 ---@field serialize fun(arg1: SpeciesTypeId)
@@ -1328,10 +1347,10 @@ SpellSimple = {}
 function SpellSimple.new() end
 
 ---@class SpellTypeId
+---@field NULL_ID fun(): SpellTypeId
 ---@field implements_int_id fun(): boolean
 ---@field is_null fun(arg1: SpellTypeId): boolean
 ---@field is_valid fun(arg1: SpellTypeId): boolean
----@field NULL_ID fun(): SpellTypeId
 ---@field obj fun(arg1: SpellTypeId): SpellTypeRaw
 ---@field str fun(arg1: SpellTypeId): string
 ---@field serialize fun(arg1: SpellTypeId)
@@ -1384,11 +1403,11 @@ SpellTypeRaw = {}
 function SpellTypeRaw.new() end
 
 ---@class TerId
+---@field NULL_ID fun(): TerId
 ---@field implements_int_id fun(): boolean
 ---@field int_id fun(arg1: TerId): TerIntId
 ---@field is_null fun(arg1: TerId): boolean
 ---@field is_valid fun(arg1: TerId): boolean
----@field NULL_ID fun(): TerId
 ---@field obj fun(arg1: TerId): TerRaw
 ---@field str fun(arg1: TerId): string
 ---@field serialize fun(arg1: TerId)
@@ -1481,11 +1500,11 @@ Tinymap = {}
 function Tinymap.new() end
 
 ---@class TrapId
+---@field NULL_ID fun(): TrapId
 ---@field implements_int_id fun(): boolean
 ---@field int_id fun(arg1: TrapId): TrapIntId
 ---@field is_null fun(arg1: TrapId): boolean
 ---@field is_valid fun(arg1: TrapId): boolean
----@field NULL_ID fun(): TrapId
 ---@field obj fun(arg1: TrapId): TrapRaw
 ---@field str fun(arg1: TrapId): string
 ---@field serialize fun(arg1: TrapId)
@@ -1580,11 +1599,11 @@ function Volume.new() end
 
 --- Various game constants
 ---@class const
+---@field OMT_MS_SIZE integer # value: 24
+---@field OMT_SM_SIZE integer # value: 2
 ---@field OM_MS_SIZE integer # value: 4320
 ---@field OM_OMT_SIZE integer # value: 180
 ---@field OM_SM_SIZE integer # value: 360
----@field OMT_MS_SIZE integer # value: 24
----@field OMT_SM_SIZE integer # value: 2
 ---@field SM_MS_SIZE integer # value: 12
 const = {}
 

--- a/lua_annotations.lua
+++ b/lua_annotations.lua
@@ -720,6 +720,7 @@ function FurnRaw.new() end
 ---@field is_gunmod fun(arg1: Item): boolean
 ---@field is_holster fun(arg1: Item): boolean
 ---@field is_irremovable fun(arg1: Item): boolean
+---@field is_made_of fun(arg1: Item, arg2: MaterialTypeId): boolean
 ---@field is_magazine fun(arg1: Item): boolean @Is this a magazine? (batteries are magazines)
 ---@field is_map fun(arg1: Item): boolean
 ---@field is_med_container fun(arg1: Item): boolean
@@ -737,6 +738,7 @@ function FurnRaw.new() end
 ---@field is_sided fun(arg1: Item): boolean
 ---@field is_silent fun(arg1: Item): boolean
 ---@field is_soft fun(arg1: Item): boolean
+---@field is_stackable fun(arg1: Item): boolean
 ---@field is_tainted fun(arg1: Item): boolean
 ---@field is_tool fun(arg1: Item): boolean
 ---@field is_toolmod fun(arg1: Item): boolean
@@ -745,13 +747,15 @@ function FurnRaw.new() end
 ---@field is_upgrade fun(arg1: Item): boolean
 ---@field is_watertight_container fun(arg1: Item): boolean
 ---@field is_wheel fun(arg1: Item): boolean
+---@field made_of fun(arg1: Item): any
 ---@field mod_charges fun(arg1: Item, arg2: integer)
+---@field price fun(arg1: Item, arg2: boolean): integer @Cents of the item. `bool` is whether it is a post-cataclysm value.
 ---@field remaining_capacity_for_id fun(arg1: Item, arg2: ItypeId, arg3: boolean): integer @Gets the remaining space available for a type of liquid
 ---@field remove_technique fun(arg1: Item, arg2: MartialArtsTechniqueId) @Removes the additional technique. Doesn't affect originial techniques.
 ---@field set_flag fun(arg1: Item, arg2: JsonFlagId)
 ---@field set_flag_recursive fun(arg1: Item, arg2: JsonFlagId)
----@field set_owner fun(arg1: Item, arg2: FactionId) @Sets the ownership of this item to a faction
 ---@field set_owner fun(arg1: Item, arg2: Character) @Sets the ownership of this item to a character
+---@field set_owner fun(arg1: Item, arg2: FactionId) @Sets the ownership of this item to a faction
 ---@field set_var_num fun(arg1: Item, arg2: string, arg3: number)
 ---@field set_var_str fun(arg1: Item, arg2: string, arg3: string)
 ---@field set_var_tri fun(arg1: Item, arg2: string, arg3: Tripoint)
@@ -759,6 +763,8 @@ function FurnRaw.new() end
 ---@field total_capacity fun(arg1: Item): Volume @Gets maximum volume this item can hold (liquids, ammo, etc)
 ---@field unset_flag fun(arg1: Item, arg2: JsonFlagId)
 ---@field unset_flags fun(arg1: Item)
+---@field volume fun(arg1: Item, arg2: any): Volume @Volume of the item. `bool` is whether it is `integral_volume`.
+---@field weight fun(arg1: Item, arg2: any, arg3: any): Mass @Weight of the item. The first `bool` is whether including contents, second `bool` is whether it is `integral_weight`.
 Item = {}
 ---@return Item
 function Item.new() end
@@ -919,6 +925,13 @@ MaterialTypeId = {}
 ---@overload fun(arg1: MaterialTypeId): MaterialTypeId
 ---@overload fun(arg1: string): MaterialTypeId
 function MaterialTypeId.new() end
+
+---@class MaterialTypeRaw
+---@field name fun(arg1: MaterialTypeRaw): string
+---@field str_id fun(arg1: MaterialTypeRaw): MaterialTypeId
+MaterialTypeRaw = {}
+---@return MaterialTypeRaw
+function MaterialTypeRaw.new() end
 
 ---@class Monster : Creature
 ---@field anger integer

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -31,6 +31,7 @@
 #include "rng.h"
 #include "skill.h"
 #include "sounds.h"
+#include "stomach.h"
 #include "string_input_popup.h"
 #include "translations.h"
 #include "trap.h"
@@ -326,6 +327,21 @@ void cata::detail::reg_item( sol::state &lua )
         DOC( "Display name with all bells and whistles like ammo and prefixes" );
         luna::set_fx( ut, "display_name", &item::display_name );
 
+        DOC("Weight of the item. The first `bool` is whether including contents, second `bool` is whether it is `integral_weight`.");
+        luna::set_fx( ut, "weight", []( item &it, sol::optional<bool> incl_cont, sol::optional<bool> inte ) {
+            bool include_contents = incl_cont.value_or(true);
+            bool integral = inte.value_or(false);
+            return it.weight( include_contents, integral );
+        } );
+        DOC("Volume of the item. `bool` is whether it is `integral_volume`.");
+        luna::set_fx( ut, "volume", []( item &it, sol::optional<bool> inte ) {
+            bool integral = inte.value_or(false);
+            return it.volume( integral );
+        } );
+        
+        DOC("Cents of the item. `bool` is whether it is a post-cataclysm value.");
+        luna::set_fx( ut, "price", &item::price );
+
         DOC( "Check for variable of any type" );
         luna::set_fx( ut, "has_var", &item::has_var );
         DOC( "Erase variable" );
@@ -402,6 +418,8 @@ void cata::detail::reg_item( sol::state &lua )
 
         luna::set_fx( ut, "conductive", &item::conductive );
 
+        luna::set_fx( ut, "is_stackable", sol::resolve<bool() const> (&item::count_by_charges) );
+
         luna::set( ut, "charges", &item::charges );
 
         luna::set_fx( ut, "energy_remaining", &item::energy_remaining );
@@ -410,6 +428,19 @@ void cata::detail::reg_item( sol::state &lua )
 
         luna::set_fx( ut, "mod_charges", &item::mod_charges );
 
+        luna::set_fx( ut, "made_of", sol::resolve<const std::vector<material_id> &() const> ( &item::made_of ) );
+
+        luna::set_fx( ut, "is_made_of", sol::resolve<bool (const material_id & ) const> ( &item::made_of ) );
+
+        luna::set_fx( ut, "get_kcal", []( item & it ) -> int {
+            return it.get_comestible()->default_nutrition.kcal;
+        } );
+        luna::set_fx( ut, "get_quench", []( item & it ) -> int {
+            return it.get_comestible()->quench;
+        } );
+        luna::set_fx( ut, "get_comestible_fun", []( item & it ) -> int {
+            return it.get_comestible_fun();
+        } );
         DOC( "Gets the TimeDuration until this item rots" );
         luna::set_fx( ut, "get_rot", &item::get_rot );
 

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -434,10 +434,10 @@ void cata::detail::reg_item( sol::state &lua )
         luna::set_fx( ut, "is_made_of", sol::resolve<bool (const material_id & ) const> ( &item::made_of ) );
 
         luna::set_fx( ut, "get_kcal", []( item & it ) -> int {
-            return it.get_comestible()->default_nutrition.kcal;
+            return it.is_comestible() ? it.get_comestible()->default_nutrition.kcal : 0 ;
         } );
         luna::set_fx( ut, "get_quench", []( item & it ) -> int {
-            return it.get_comestible()->quench;
+            return it.is_comestible() ? it.get_comestible()->quench : 0 ;
         } );
         luna::set_fx( ut, "get_comestible_fun", []( item & it ) -> int {
             return it.get_comestible_fun();

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -21,6 +21,7 @@
 #include "itype.h"
 #include "map.h"
 #include "martialarts.h"
+#include "material.h"
 #include "messages.h"
 #include "monfaction.h"
 #include "monster.h"

--- a/src/catalua_bindings_ids.cpp
+++ b/src/catalua_bindings_ids.cpp
@@ -16,6 +16,7 @@
 #include "magic.h"
 #include "mapdata.h"
 #include "martialarts.h"
+#include "material.h"
 #include "monfaction.h"
 #include "monstergenerator.h"
 #include "morale_types.h"
@@ -119,6 +120,7 @@ void cata::detail::reg_game_ids( sol::state &lua )
     reg_id<json_trait_flag, false>( lua );
     reg_id<ma_buff, false>( lua );
     reg_id<ma_technique, false>( lua );
+    reg_id<material_type, false>( lua );
     reg_id<monfaction, true>( lua );
     reg_id<morale_type_data, false>( lua );
     reg_id<mtype, false>( lua );
@@ -145,6 +147,13 @@ void cata::detail::reg_types( sol::state &lua )
 
         // Factions are a pain because they _inherit_ from their type, not reference it by id.
         // This causes various weirdness, so let's omit the fields for now.
+    }
+    {
+        sol::usertype<material_type> ut = 
+            luna::new_usertype<material_type>( lua, luna::no_bases, luna::no_constructor );
+        
+        luna::set_fx( ut, "str_id", &material_type::ident );
+        luna::set_fx( ut, "name", &material_type::name );
     }
     {
         sol::usertype<ter_t> ut =

--- a/src/catalua_luna_doc.h
+++ b/src/catalua_luna_doc.h
@@ -35,6 +35,7 @@ class ma_technique;
 class ma_buff;
 class map;
 class map_stack;
+class material_type;
 class monster;
 class npc;
 class player;
@@ -157,6 +158,7 @@ LUNA_ID( json_flag, "JsonFlag" )
 LUNA_ID( json_trait_flag, "JsonTraitFlag" )
 LUNA_ID( ma_buff, "MartialArtsBuff" )
 LUNA_ID( ma_technique, "MartialArtsTechnique" )
+LUNA_ID( material_type, "MaterialType")
 LUNA_ID( monfaction, "MonsterFaction" )
 LUNA_ID( morale_type_data, "MoraleTypeData" )
 LUNA_ID( mtype, "Mtype" )

--- a/src/material.h
+++ b/src/material.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "catalua_type_operators.h"
 #include "fire.h"
 #include "type_id.h"
 
@@ -115,6 +116,8 @@ class material_type
         const mat_burn_products &burn_products() const;
         const material_id_list &compact_accepts() const;
         const mat_compacts_into &compacts_into() const;
+        
+        LUA_TYPE_OPS(material_type, id);
 };
 
 namespace materials


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
More Lua binding is better!
with these bindings, we can do more things about items.

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Add the item bindings below:
- materials
- price
- weight
- volume
- calories
- quench
- fun when you eat it

If you try getting calories or quench from non-edible, you got 0 for those values.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
waiting

## Testing
```lua
local u = gapi.get_avatar()
local its = u:all_items(false)
for _, v in pairs(its) do
  gdebug.log_info(string.format("[%s] CAN_EAT? %b KCAL %d QUENCH %d FUN %d", v:tname(1,false,0), tostring(v:is_comestible()), v:get_kcal()  v:get_quench(), v:get_comestible_fun() ) )
end
```
![image](https://github.com/user-attachments/assets/d3fe938d-9d54-4f62-8158-2ac21fd8c168)

```lua
local u = gapi.get_avatar()
local its = u:all_items(false)
local mats = its[1]:made_of()
gdebug.log_info("This is made of: ")
for _, v in pairs(mats) do
  gdebug.log_info(v:str())
end
```
![image](https://github.com/user-attachments/assets/a5b1d3f6-02a7-414a-92b1-dbefc6b1c933)



<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
