### PR TITLE
feat: Allow mana regen rates to be adjusted in JSON

### DIFF
--- a/data/json/game_balance.json
+++ b/data/json/game_balance.json
@@ -229,5 +229,26 @@
     "info": "Makes mutation more balanced and interesting.",
     "stype": "bool",
     "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "MANA_REGEN_IS_FLAT",
+    "info": "A boolean for whether mana regen is a flat rate or based on regenerating all your mana in a given number of hours",
+    "stype": "bool",
+    "value": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "MANA_REGEN_HOURS_RATE",
+    "info": "The integer number of hours that it should take for the player's mana to fully regenerate by default.",
+    "stype": "int",
+    "value": 8
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "MANA_REGEN_FLAT",
+    "info": "The integer flat rate for mana regen (per hour) that should be used as a baseline if enabled.",
+    "stype": "int",
+    "value": 100
   }
 ]

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1521,23 +1521,22 @@ int known_magic::max_mana( const Character &guy ) const
 
 double known_magic::mana_regen_rate( const Character &guy ) const
 {
-    bool is_flat_rate = get_option<bool>("MANA_REGEN_IS_FLAT");
+    bool is_flat_rate = get_option<bool>( "MANA_REGEN_IS_FLAT" );
     double base_rate;
-    if (!is_flat_rate) {
+    if( !is_flat_rate ) {
         // mana should replenish in hours_to_regen hours by default.
-        int hours_to_regen = get_option<int>("MANA_REGEN_HOURS_RATE");
-        double full_replenish = to_turns<double>( time_duration::from_hours(hours_to_regen) );
+        int hours_to_regen = get_option<int>( "MANA_REGEN_HOURS_RATE" );
+        double full_replenish = to_turns<double>( time_duration::from_hours( hours_to_regen ) );
         double capacity = max_mana( guy );
         base_rate = capacity / full_replenish;
-    }
-    else {
+    } else {
         // mana should regen at a rate of flat_rate by default
-        base_rate = get_option<int>("MANA_REGEN_FLAT") / to_turns<double>( 1_hours );
+        base_rate = get_option<int>( "MANA_REGEN_FLAT" ) / to_turns<double>( 1_hours );
     }
 
     double mut_mul = guy.mutation_value( "mana_regen_multiplier" );
     double natural_regen = std::max( 0.0, base_rate * mut_mul );
-    
+
 
     double ench_bonus = guy.bonus_from_enchantments( natural_regen, enchant_vals::mod::MANA_REGEN );
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -40,6 +40,7 @@
 #include "mtype.h"
 #include "mutation.h"
 #include "output.h"
+#include "options.h"
 #include "pldata.h"
 #include "point.h"
 #include "requirements.h"
@@ -1520,11 +1521,23 @@ int known_magic::max_mana( const Character &guy ) const
 
 double known_magic::mana_regen_rate( const Character &guy ) const
 {
-    // mana should replenish in 8 hours.
-    double full_replenish = to_turns<double>( 8_hours );
-    double capacity = max_mana( guy );
+    bool is_flat_rate = get_option<bool>("MANA_REGEN_IS_FLAT");
+    double base_rate;
+    if (!is_flat_rate) {
+        // mana should replenish in hours_to_regen hours by default.
+        int hours_to_regen = get_option<int>("MANA_REGEN_HOURS_RATE");
+        double full_replenish = to_turns<double>( time_duration::from_hours(hours_to_regen) );
+        double capacity = max_mana( guy );
+        base_rate = capacity / full_replenish;
+    }
+    else {
+        // mana should regen at a rate of flat_rate by default
+        base_rate = get_option<int>("MANA_REGEN_FLAT") / to_turns<double>( 1_hours );
+    }
+
     double mut_mul = guy.mutation_value( "mana_regen_multiplier" );
-    double natural_regen = std::max( 0.0, capacity * mut_mul / full_replenish );
+    double natural_regen = std::max( 0.0, base_rate * mut_mul );
+    
 
     double ench_bonus = guy.bonus_from_enchantments( natural_regen, enchant_vals::mod::MANA_REGEN );
 


### PR DESCRIPTION
## Purpose of change (The Why)

Mana regenerating fully (roughly) in 8 hours by default isn't always desirable, and is very clearly based on D&D. In particular, RoyalFox very much so would like this to be adjustable.

## Describe the solution (The How)

Adds three new external options:
- `MANA_REGEN_IS_FLAT`, which is a boolean for whether the rate should be a flat rate per hour or not by default
- `MANA_REGEN_HOURS_RATE`, the number of hours that your mana should (roughly*) take to regenerate if not a flat rate
- `MANA_REGEN_FLAT`, the integer amount of mana that the flat rate should be if enabled.

They default to False, 8, and 100 respectively.

## Describe alternatives you've considered

- Just make the number of hours adjustable and not worry about the flat rate idea
- Also change the default number of hours

In my opinion, the default number of hours should be its own PR if we want it changed. 

## Testing

Compiled, loaded in, and it seems to work. The flat rate works just fine, the boolean correctly toggles it, and the number of hours indeed impacts the time to regenerate your full mana by default.

## Additional context

In the process of testing it, I discovered that with the number of hours set to 8 it does not *actually* quite correctly restore the amount of mana it should. Instead of restoring 250 per hour, it seems to restore 240. Setting it to 2 hours however correctly restores your full mana amount in 2 hours, so I have no clue what's going wrong here other than some weirdness around floating point values.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.