### PR TITLE
fix (typo): "atomic coffee milk" misnamed as "sweet atomic coffee"

### DIFF
--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -957,7 +957,7 @@
   {
     "type": "COMESTIBLE",
     "id": "milk_atomic_coffee",
-    "name": { "str_sp": "sweet atomic coffee" },
+    "name": { "str_sp": "atomic coffee milk" },
     "copy-from": "milk_coffee",
     "addiction_type": "caffeine",
     "fatigue_mod": 45,


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

The item "atomic coffee milk" is misnamed as "sweet atomic coffee," which already exists. This results in two different items being named "sweet atomic coffee," with the real one being the atomic counterpart to sweet coffee and the other a misnamed atomic counterpart to coffee milk.

## Describe the solution (The How)

Deleting "sweet" and appending a "milk" to the item name.

## Describe alternatives you've considered

ignoring it

## Testing

opening the craft menu, I can see that "atomic coffee milk" is now properly labeled.

## Additional context

The item ID is called "milk_atomic_coffee"
Assuming this coffee is following the naming scheme of all the other coffee's, then it should be called "atomic coffee milk."

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.