### PR TITLE
fix: stop choking on joints and blunts

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -769,11 +769,8 @@
       "smoking_duration": 4,
       "do_weed_msg": true,
       "charges_needed": { "fire": 1 },
-      "effects": [
-        { "id": "weed_high", "duration": "12 m" },
-        { "id": "pkill1", "duration": "12 m" },
-        { "id": "smoke", "duration": "30 s" }
-      ]
+      "effects": [ { "id": "weed_high", "duration": "12 m" }, { "id": "pkill1", "duration": "12 m" } ],
+      "fields_produced": { "fd_weedsmoke": 2 }
     }
   },
   {
@@ -805,9 +802,9 @@
       "effects": [
         { "id": "weed_high", "duration": "90 m" },
         { "id": "cig", "duration": "90 m" },
-        { "id": "pkill1", "duration": "90 m" },
-        { "id": "smoke", "duration": "30 s" }
+        { "id": "pkill1", "duration": "90 m" }
       ],
+      "fields_produced": { "fd_weedsmoke": 2 },
       "addiction_type_too_much": [ [ "cig", "nicotine" ] ]
     }
   },


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Joints and blunts have the "smoke" effect, as in smoke inhalation, upon their use. This results in a coughing fit whenever consuming either of the two.
Neither joint nor blunt produce the "fd_weedsmoke" field upon their use. This is despite all the other smoked drugs producing their respective smoke fields upon use (marijuana included).

## Describe the solution (The How)

Remove "smoke" from effects and add "fd_weedsmoke" to fields

## Describe alternatives you've considered

Continue choking on nonexistent smoke

## Testing

Spawned in and consumed a joint with no coughing, and was weed smoke produced.
The same result occured with a blunt

## Additional context

Originally attempted to add "fd_cigsmoke" alongside "fd_weedsmoke" to the blunt, seeing as It is both tobacco and weed, however "fields_produced" will not accept more than one value.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.