### PR TITLE
feat: Update the overmap special options

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2354,12 +2354,12 @@ void options_manager::add_options_world_default()
 
     add( "SPECIALS_DENSITY", world_default, translate_marker( "Overmap specials density" ),
          translate_marker( "A scaling factor that determines density of overmap specials." ),
-         0.0, 10.0, 1, 0.1
+         0.01, 10.0, 1, 0.1
        );
 
     add( "SPECIALS_SPACING", world_default, translate_marker( "Overmap specials spacing" ),
          translate_marker( "A number determing minimum distance between overmap specials.  -1 allows intersections of specials." ),
-         -1, 18, 6
+         -1, 72, 6
        );
 
     add( "VEHICLE_DAMAGE", world_default, translate_marker( "Vehicle damage modifier" ),


### PR DESCRIPTION
## Purpose of change (The Why)

It's fairly irresponsible and dangerous to let players to completely disable overmap specials from their game entirely. If it actually worked correctly (Kinda feeling like it doesn't since stuff still spawns at 0 as if it was at 0.1 or maybe 0.5) then it would brick possibly half the starting options in the game and maybe lab generation if its not hardcoded.

Additionally, since density doesn't work to a satisfactory level, I thought it would be ok to allow 4x the max spacing, at 72. It should still properly iterate a spawn location since you're not disabling the ability for most places to generate entirely, you're just spacing them.

## Describe the solution (The How)

Sets the game option min and max respectively.

## Describe alternatives you've considered

It needs overhauling but not by me. I could only make it worse.

This is what it looks like at 0.00 and 18 spacing. Somehow it doesn't seem to fully remove specials and their density is still pretty frequent. I'm still convinced it's partially bugged but that's a good thing. We didn't want it to erase all overmap specials.

![image](https://github.com/user-attachments/assets/1f118aa4-4178-4de2-a3d9-0bdd4b2e3f1a)


## Testing

It ran before, tweaking the allowed numbers won't break it.

## Additional context



## Checklist
### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.