### PR TITLE
fix: Don't stack corpses like rotting food

### DIFF
--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -4,15 +4,16 @@
 #include <limits>
 #include <memory>
 
+#include "cached_item_options.h"
 #include "calendar.h"
 #include "enums.h"
 #include "item.h"
 #include "itype.h"
-#include "ret_val.h"
 #include "math_defines.h"
+#include "ret_val.h"
+#include "type_id.h"
 #include "units.h"
 #include "value_ptr.h"
-#include "cached_item_options.h"
 
 TEST_CASE( "item_volume", "[item]" )
 {
@@ -295,5 +296,47 @@ TEST_CASE( "items_have_default_attack_statblocks", "[item]" )
         CHECK( du.damage_multiplier == 1.0f );
         CHECK( du.res_mult == 1.0f );
         CHECK( du.res_pen == 0.0f );
+    }
+}
+
+TEST_CASE( "stacking_corpses", "[item]" )
+{
+    item &human_corpse1 = *item::make_corpse();
+    item &human_corpse2 = *item::make_corpse();
+    item &non_human_corpse1 = *item::make_corpse( mtype_id( "mon_dog" ) );
+    item &non_human_corpse2 = *item::make_corpse( mtype_id( "mon_rabbit" ) );
+    item not_a_corpse( "test_rock" );
+
+    WHEN( "not all corpses" ) {
+        THEN( "corpses only stacks with corpses" ) {
+            CHECK( human_corpse1.stacks_with( human_corpse2 ) );
+            CHECK( !human_corpse1.stacks_with( not_a_corpse ) );
+        }
+    }
+
+    WHEN( "corpse type different" ) {
+        THEN( "they don't stack" ) {
+            CHECK( !human_corpse1.stacks_with( non_human_corpse1 ) );
+        }
+    }
+
+    WHEN( "corpses differently damaged" ) {
+        human_corpse2.inc_damage();
+        THEN( "they don't stack" ) {
+            CHECK( !human_corpse1.stacks_with( human_corpse2 ) );
+        }
+
+        THEN( "they stack if damaged equally" ) {
+            human_corpse1.inc_damage();
+            CHECK( human_corpse1.stacks_with( human_corpse2 ) );
+        }
+    }
+
+    WHEN( "default merge_comestible_mode doesn't stack corpses like rottable food" ) {
+        merge_comestible_mode = merge_comestible_t::merge_all;
+
+        THEN( "different corpses don't stack" ) {
+            CHECK( !non_human_corpse1.stacks_with( non_human_corpse2 ) );
+        }
     }
 }


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Different type corpses would be stacked together if accessed via any inventory UI.

This is caused by `item::stacks_with` doing a check for stacking rotting items before doing a check for stacking corpses - or rather, doing a check for when to _not_ stack corpses.

closes #5869
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Move the stack rotting check - the only case that doesn't short-circuit with `return false` - to the bottom of the function.

Add a comment to function to hopefully guard against future additions. Not very robust: comments will rot. I think ideally we'd want `stacks_with` to have something like `check_for_no_stacking_allowed(); check_for_stacking_allowed()` to separate/ make explicit the short-circuit behavior.

Adds tests for corpse stacking, as well as a test for this specific rotting/corpse bug.

* Fixes the corpse check logic to use `is_corpse`
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

Tests pass.

Manual:
* Spawn zombie_dog and rabbit. (Need to be corpses that can rot)
* Kill them.
* Spawn a hiking backpack for volume.
* Haul all items onto the same tile.
* Advanced Inventory should NOT show them stacked
* Pick up interface should NOT show them stacked
* Pick up both into inventory
* Invetory interface should NOT show them stacked
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
