### PR TITLE
chore: Use better colors for the damage types in spells

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1072,27 +1072,27 @@ nc_color spell::damage_type_color() const
         case DT_ACID:
             return c_light_green;
         case DT_BASH:
-            return c_magenta;
+            return c_brown;
         case DT_BIOLOGICAL:
             return c_green;
         case DT_COLD:
-            return c_white;
+            return c_blue;
         case DT_DARK:
-            return c_green;
-        case DT_LIGHT:
-            return c_yellow;
-        case DT_PSI:
             return c_magenta;
+        case DT_LIGHT:
+            return c_white;
+        case DT_PSI:
+            return c_pink;
         case DT_CUT:
             return c_light_gray;
         case DT_ELECTRIC:
-            return c_light_blue;
+            return c_light_cyan;
         case DT_BULLET:
         /* fallthrough */
         case DT_STAB:
             return c_light_red;
         case DT_TRUE:
-            return c_dark_gray;
+            return c_light_gray;
         default:
             return c_black;
     }


### PR DESCRIPTION
## Purpose of change (The Why)

Some of these color choices, such as bash being magenta, made no real sense. This was noted in #6569 , but was determined to be better to sort out in a separate PR.

## Describe the solution (The How)

- Bash is now brown (if light_brown was an option, I'd have chosen it instead)
- Cold is now blue, as the world has conditioned us to associate it with
- Dark is now magenta, because that's a fairly common choice (especially given how black is absolutely not an option)
- Light is now white (Both because of the association with actual light, as well as the use of it for 'holy')
- Psi is now pink, a classic association for psychicness
- Electric is now light_cyan instead of light_blue because light_cyan really looks like electric blue
- True is now light gray (even though I think that what is currently called light gray really ought to *just* be gray, and light gray should be between it and white)

## Describe alternatives you've considered

- Yellow electric, for the other common electricity color
- Light blue or light cyan cold
- Yellow Light and make True white

## Testing

It compiles and the game displays them properly.

## Additional context

Colors were agreed upon by me and Royal, additional input is always welcome.

Also, when looking in the color manager, it looks like a lot of combo-colors with yellow instead have the yellow appear like a brown? In general, our color management is weird.
![image](https://github.com/user-attachments/assets/30f59fa9-c1ab-4235-9ac0-418c5e7b524a)


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
