### PR TITLE
fix: stop junk metal palisades from being snowy in summer

### DIFF
--- a/data/mods/UDP_BN_FAKE_SNOW/mod_tileset.json
+++ b/data/mods/UDP_BN_FAKE_SNOW/mod_tileset.json
@@ -1191,7 +1191,7 @@
             ]
           },
           {
-            "id": "t_junk_palisade",
+            "id": "t_junk_palisade_season_winter",
             "fg": 882,
             "rotates": false,
             "multitile": true,

--- a/gfx/MSX++UnDeadPeopleEdition/tile_config.json
+++ b/gfx/MSX++UnDeadPeopleEdition/tile_config.json
@@ -29032,7 +29032,7 @@
           ]
         },
         {
-          "id": "t_junk_palisade_season_winter",
+          "id": "t_junk_palisade",
           "fg": 15914,
           "rotates": false,
           "multitile": true,

--- a/gfx/MSX++UnDeadPeopleEdition/tile_config.json
+++ b/gfx/MSX++UnDeadPeopleEdition/tile_config.json
@@ -29032,7 +29032,7 @@
           ]
         },
         {
-          "id": "t_junk_palisade",
+          "id": "t_junk_palisade_season_winter",
           "fg": 15914,
           "rotates": false,
           "multitile": true,


### PR DESCRIPTION
## Purpose of change (The Why)

![image](https://github.com/user-attachments/assets/f082aa3b-94ef-4b49-904d-754409a47b69)


## Describe the solution (The How)

Sets the overwrite in the mod to _season_winter
![image](https://github.com/user-attachments/assets/638456f9-2d29-46ee-9121-8823dbf2f5b6)


## Describe alternatives you've considered
## Testing

I fixed it on my local copy. It was pissing me off.

## Additional context
## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.