### PR TITLE
fix: crafting with unheld components when compiled with >=clang-20.1.3

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1532,13 +1532,13 @@ std::vector<detached_ptr<item>> player::consume_items( const comp_selection<item
                              int batch,
                              const std::function<bool( const item & )> &filter )
 {
-    return consume_items( get_map(), is, batch, filter, pos(), PICKUP_RANGE );
+    return consume_items( get_map(), is, batch, pos(), PICKUP_RANGE, filter );
 }
 
 std::vector<detached_ptr<item>> player::consume_items( map &m, const comp_selection<item_comp> &is,
                              int batch,
-                             const std::function<bool( const item & )> &filter,
-                             const tripoint &origin, int radius )
+                             const tripoint &origin, int radius,
+                             const std::function<bool( const item & )> &filter )
 {
     std::vector<detached_ptr<item>> ret;
 

--- a/src/player.h
+++ b/src/player.h
@@ -215,8 +215,8 @@ class player : public Character
                                      const std::function<bool( const item & )> &filter = return_true<item> );
         std::vector<detached_ptr<item>> consume_items( map &m, const comp_selection<item_comp> &is,
                                      int batch,
-                                     const std::function<bool( const item & )> &filter = return_true<item>,
-                                     const tripoint &origin = tripoint_zero, int radius = PICKUP_RANGE );
+                                     const tripoint &origin, int radius,
+                                     const std::function<bool( const item & )> &filter = return_true<item> );
         std::vector<detached_ptr<item>> consume_items( const std::vector<item_comp> &components,
                                      int batch = 1,
                                      const std::function<bool( const item & )> &filter = return_true<item> );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
Fixes #6599

For whatever reason clang++-20.1.3 (Robbie's) and 20.1.6 (Mine) builds completely fail at passing along the `origin` parameter, passed as `pos()`, properly. Due to not being passed properly the default parameter value of `tripoint_zero` is used.

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Rearranged the parameters for `consume_items( map & m, ...` so that we do not need to use a default parameter for `const tripoint &origin`. That small change was enough to fix the bug experienced by Robbie in #6599.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Remove the `origin` parameter entirely since it's unnecessary for `consume_items( map &, ... )` as it's only ever called from `consume_items( const comp_selection<item_comp> &, ... )`, and change `const tripoint &loc = origin` to use `= pos()`

## Testing
### Bug Confirmation
For Clang-19.1.1 and Clang-20.1.6 I did the following
1. Dumped a lot of rags onto the ground
2. Grabbed 3 rags
3. Moved a few tiles away and crafted 3 makeshift bandages using the ones in inventory.
4. Attempted to craft 3 more makeshift bandages using the remaining rags on the ground.

### Results
Clang 19: Worked fine
Clang 20: Every turn it would `query_yn` to ask if I wanted to use missing components (rags x 3)

### Post Fix
Repeated bug confirmation steps

### Post Fix Results
Clang 19: Continues to work fine
Clang 20: Now works as expected

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
