### PR TITLE
Build x86_64 macos images on osx-13, because osx-14 image is arm.

### DIFF
--- a/.github/workflows/experimental-release.yml
+++ b/.github/workflows/experimental-release.yml
@@ -44,13 +44,13 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: osx-curses-x64
-            os: macos-14
+            os: macos-13
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-14
+            os: macos-13
             tiles: 1
             artifact: osx-tiles-x64
             ext: dmg

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -74,13 +74,13 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: osx-curses-x64
-            os: macos-14
+            os: macos-13
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-14
+            os: macos-13
             tiles: 1
             artifact: osx-tiles-x64
             ext: dmg

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -32,13 +32,13 @@ jobs:
       matrix:
         include:
           - name: osx-curses-x64
-            os: macos-14
+            os: macos-13
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-14
+            os: macos-13
             tiles: 1
             artifact: osx-tiles-x64
             ext: dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,13 +123,13 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: osx-curses-x64
-            os: macos-14
+            os: macos-13
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-14
+            os: macos-13
             tiles: 1
             artifact: osx-tiles-x64
             ext: dmg


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Fix builds for OSX-64.
Fixes #6467 

## Describe the solution (The How)

Use macos-13 image for building. Macos-14 default became arm.

## Describe alternatives you've considered

## Testing

I've built using macos-13 in my fork, run it on my Macbook pro 2019 and it works!
https://github.com/apollovy/Cataclysm-BN/releases/download/2025-05-26/cbn-osx-tiles-x64-2025-05-26.dmg

## Additional context

## Checklist

### Mandatory

- [ x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
