### PR TITLE
feat: don't try to look through night vision goggles and infrared goggles when they're turned off

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1398,7 +1398,7 @@
     "color": "dark_gray",
     "name": { "str": "pair of light amp goggles", "str_pl": "pairs of light amp goggles" },
     "description": "A pair of battery-powered goggles that amplify ambient light, allowing you to see in the dark.  Use it to turn them on.",
-    "flags": [ "FRAGILE" ],
+    "flags": [ "FRAGILE", "HELMET_COMPAT" ],
     "price": "920 USD",
     "price_postapoc": "35 USD",
     "material": [ "plastic", "steel" ],
@@ -1408,18 +1408,18 @@
     "ammo": "battery",
     "use_action": {
       "type": "transform",
-      "msg": "You activate your %s.",
+      "msg": "You activate your %s and pull them down over your eyes.",
       "target": "goggles_nv_on",
       "active": true,
       "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
-    "covers": [ "eyes" ],
+    "covers": [ "head" ],
     "warmth": 10,
     "environmental_protection": 6,
-    "encumbrance": 40,
-    "coverage": 100,
+    "encumbrance": 5,
+    "coverage": 10,
     "material_thickness": 2,
     "magazines": [
       [
@@ -1448,7 +1448,13 @@
     "//": "2019 commercial models can operate at under 0.375W with the IR illuminator on",
     "power_draw": 375,
     "revert_to": "goggles_nv",
-    "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "goggles_nv" },
+    "use_action": {
+      "type": "transform",
+      "menu_text": "Turn off",
+      "msg": "Your %s deactivates and you push them up.",
+      "target": "goggles_nv"
+    },
+    "covers": [ "eyes" ],
     "warmth": 25,
     "encumbrance": 20,
     "magazine_well": "250 ml"
@@ -1461,7 +1467,7 @@
     "color": "dark_gray",
     "name": { "str": "pair of infrared goggles", "str_pl": "pairs of infrared goggles" },
     "description": "A pair of battery-powered goggles that grant infrared vision, allowing you to see warm-blooded creatures in the dark.  Use it to turn them on.",
-    "flags": [ "FRAGILE" ],
+    "flags": [ "FRAGILE", "HELMET_COMPAT" ],
     "price": "920 USD",
     "price_postapoc": "25 USD",
     "material": [ "plastic", "steel" ],
@@ -1471,18 +1477,18 @@
     "ammo": "battery",
     "use_action": {
       "type": "transform",
-      "msg": "You activate your %s.",
+      "msg": "You activate your %s and pull them down over your eyes.",
       "target": "goggles_ir_on",
       "active": true,
       "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
-    "covers": [ "eyes" ],
+    "covers": [ "head" ],
     "warmth": 10,
     "environmental_protection": 6,
-    "encumbrance": 40,
-    "coverage": 100,
+    "encumbrance": 5,
+    "coverage": 10,
     "material_thickness": 2,
     "magazines": [
       [
@@ -1510,7 +1516,12 @@
     "flags": [ "IR_EFFECT", "FRAGILE", "TRADER_AVOID" ],
     "power_draw": 1000,
     "revert_to": "goggles_ir",
-    "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "goggles_ir" },
+    "use_action": {
+      "type": "transform",
+      "menu_text": "Turn off",
+      "msg": "Your %s deactivates and you push them up.",
+      "target": "goggles_ir"
+    },
     "covers": [ "eyes" ],
     "warmth": 25,
     "encumbrance": 20,


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Light amp goggles and infrared goggles currently have 20 eye encumbrance when turned on, and a whopping 40 when turned off. This is quite annoying, since you need extra keypresses to remove the goggles when you want to turn them off. Sometimes, like in partially lit labs, you need to toggle them quite frequently.

It's not immediately obvious WHY this is. While real-world night vision equipment does tend to limit your vision, you generally _cannot see through at all_ when it's turned off, which is why they have some way of lifting the goggles away from your eyes and out of the way when you're not using them.

## Describe the solution (The How)

Made the "off" variant both types of goggles cover the head instead of eyes. Reduced encumbrance to 5 and coverage to 10, since the head is quite a bit larger than the eyeball. Gave the goggles the `HELMET_COMPAT` flag, to let them be worn with hats and helmets.

The "on" variants of the goggles are unchanged, apart from an edit to the activation message, and a missing `"covers"` tag to the NV goggles (previously inherited from the "off" variant).

## Describe alternatives you've considered

Head encumbrance is basically irrelevant, but the coverage matters since it determines how often the goggles get damaged. I'm not sure if we have any other items of similar size that are worn on the forehead, but 10 seemed close enough.

If you wanted to be really pedantic, you could have separate actions for turning the goggles on and putting them on your eyes, and make them block vision like a blindfold when off. With just one 'a'ctivate keybind, though, that'd be a nuisance.

## Testing

Spawned both goggles, wore them, toggled them on and off. Checked that encumbrance on different body parts looked like it should.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
