### PR TITLE
fix(balance): shotgun slugs & flechette rebalance

### DIFF
--- a/data/json/items/ammo/20x66mm.json
+++ b/data/json/items/ammo/20x66mm.json
@@ -144,7 +144,7 @@
     "price": "15 USD",
     "price_postapoc": "40 USD",
     "//": "Balanced as FMJ",
-    "damage": { "damage_type": "bullet", "amount": 84, "armor_penetration": 21, "armor_multiplier": 1.5 },
+    "damage": { "damage_type": "bullet", "amount": 84, "armor_penetration": 21, "armor_multiplier": -1 },
     "relative": { "range": 20 },
     "proportional": { "dispersion": 1.3 },
     "delete": { "effects": [ "SHOT" ] }

--- a/data/json/items/ammo/20x66mm.json
+++ b/data/json/items/ammo/20x66mm.json
@@ -73,7 +73,7 @@
   },
   {
     "id": "20x66_flechette",
-    "copy-from": "20x66_shot",
+    "copy-from": "20x66_shot_abstract",
     "type": "AMMO",
     "name": { "str": "20x66mm flechette" },
     "description": "20x66mm caseless shotgun rounds, flechette type.  Proprietary ammunition for Rivtech shotguns.  Being caseless rounds, these cannot be disassembled or reloaded.",
@@ -81,7 +81,7 @@
     "price_postapoc": "40 USD",
     "count": 10,
     "//": "Balanced as AP.",
-    "relative": { "damage": { "damage_type": "bullet", "amount": -18, "armor_penetration": 36, "armor_multiplier": -1 } }
+    "relative": { "damage": { "damage_type": "bullet", "amount": -18, "armor_penetration": 36, "armor_multiplier": -1.5 } }
   },
   {
     "id": "20x66_frag",
@@ -97,7 +97,7 @@
   },
   {
     "id": "20x66_inc",
-    "copy-from": "20x66_shot",
+    "copy-from": "20x66_shot_abstract",
     "type": "AMMO",
     "name": { "str": "20x66mm incendiary", "str_pl": "20x66mm incendiaries" },
     "description": "20x66mm caseless shotgun rounds, incendiary type.  Proprietary ammunition for Rivtech shotguns.  Being caseless rounds, these cannot be disassembled or reloaded.",
@@ -144,7 +144,7 @@
     "price": "15 USD",
     "price_postapoc": "40 USD",
     "//": "Balanced as FMJ",
-    "damage": { "damage_type": "bullet", "amount": 84, "armor_penetration": 21, "armor_multiplier": -1 },
+    "damage": { "damage_type": "bullet", "amount": 84, "armor_penetration": 21, "armor_multiplier": 1 },
     "relative": { "range": 20 },
     "proportional": { "dispersion": 1.3 },
     "delete": { "effects": [ "SHOT" ] }

--- a/data/json/items/ammo/40x46mm.json
+++ b/data/json/items/ammo/40x46mm.json
@@ -92,7 +92,7 @@
     "weight": "120 g",
     "range": 10,
     "//": "Balanced as FMJ.",
-    "damage": { "damage_type": "bullet", "amount": 96, "armor_penetration": 42, "armor_multiplier": 1.5 },
+    "damage": { "damage_type": "bullet", "amount": 96, "armor_penetration": 42 },
     "proportional": { "recoil": 1.4 },
     "casing": "40x46mm_m118_casing"
   },
@@ -105,7 +105,7 @@
     "weight": "120 g",
     "range": 10,
     "//": "Balanced as FMJ.",
-    "damage": { "damage_type": "bullet", "amount": 96, "armor_penetration": 42, "armor_multiplier": 1.5 },
+    "damage": { "damage_type": "bullet", "amount": 96, "armor_penetration": 42 },
     "proportional": { "recoil": 1.4 },
     "casing": "40x46mm_m199_casing"
   },

--- a/data/json/items/ammo/40x53mm.json
+++ b/data/json/items/ammo/40x53mm.json
@@ -67,7 +67,7 @@
     "weight": "340 g",
     "range": 10,
     "//": "Balanced as FMJ.",
-    "damage": { "damage_type": "bullet", "amount": 104, "armor_penetration": 46, "armor_multiplier": 1.5 },
+    "damage": { "damage_type": "bullet", "amount": 104, "armor_penetration": 46 },
     "proportional": { "recoil": 1.4 },
     "casing": "40x53mm_m169_casing"
   }

--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -163,7 +163,7 @@
     "price_postapoc": "16 USD",
     "//2": "currently can't be crafted",
     "count": 5,
-    "damage": { "damage_type": "bullet", "amount": 30, "armor_penetration": 0 },
+    "damage": { "damage_type": "bullet", "amount": 30, "armor_penetration": 10 },
     "extend": { "effects": [ "EXPLOSIVE" ] }
   },
   {

--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -150,7 +150,7 @@
     "price_postapoc": "8 USD",
     "count": 10,
     "//": "Balanced as standard AP.",
-    "relative": { "damage": { "damage_type": "bullet", "amount": -20, "armor_penetration": 30, "armor_multiplier": -1 } }
+    "relative": { "damage": { "damage_type": "bullet", "amount": -20, "armor_penetration": 15, "armor_multiplier": -1.5 } }
   },
   {
     "id": "shot_he",
@@ -200,7 +200,7 @@
     "price_postapoc": "4 USD",
     "dispersion": 80,
     "//": "Balanced as FMJ",
-    "relative": { "range": 12, "damage": { "damage_type": "bullet", "amount": -15, "armor_penetration": 18, "armor_multiplier": -0.5 } },
+    "relative": { "range": 12, "damage": { "damage_type": "bullet", "amount": -15, "armor_penetration": 18, "armor_multiplier": -1 } },
     "proportional": { "recoil": 1.4 },
     "delete": { "effects": [ "SHOT" ] }
   }

--- a/data/json/items/ammo/shotcanister.json
+++ b/data/json/items/ammo/shotcanister.json
@@ -60,7 +60,7 @@
     "ammo_type": "shotcanister",
     "looks_like": "shot_scrap",
     "range": 3,
-    "damage": { "damage_type": "bullet", "amount": 13, "armor_penetration": 7, "armor_multiplier": 1.5 },
+    "damage": { "damage_type": "bullet", "amount": 13, "armor_penetration": 7, "armor_multiplier": 0.5 },
     "dispersion": 50,
     "loudness": 0,
     "count": 10


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->
Shotgun slugs, despite being functionally an FMJ round fired from a shotgun, have a positive armor multiplier due to my own relative newness at game balancing and how the code worked when I increased shotgun damage. Flechette shells similarly simply have a flat reduction and cancel out the armor multiplier.
## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Further reduced the armor multiplier of 12 gauge, 20x66mm, 40x53mm, and pneumatic shotcanister flechette and slug rounds, causing slugs to have zero armor multiplier and flechette shells to have a negative armor multiplier. Did not touch the black powder shells due to black powder inherently being weaker than smokeless gunpowder.
## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Made sure to test it so it works ingame, fixing any errors on my end.
## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
