### PR TITLE
feat(mods/MagicalNights): Apply new damage types

### DIFF
--- a/data/mods/MagicalNights/Spells/animist.json
+++ b/data/mods/MagicalNights/Spells/animist.json
@@ -238,7 +238,7 @@
     "difficulty": 5,
     "base_casting_time": 100,
     "base_energy_cost": 5,
-    "damage_type": "bio"
+    "damage_type": "dark"
   },
   {
     "id": "create_rune_animist",

--- a/data/mods/MagicalNights/Spells/classless.json
+++ b/data/mods/MagicalNights/Spells/classless.json
@@ -62,7 +62,7 @@
     "description": "You always wanted to fire energy beams like in the animes you watched as a kid.  Now you can!",
     "valid_targets": [ "ally", "hostile", "ground" ],
     "effect": "line_attack",
-    "damage_type": "fire",
+    "damage_type": "light",
     "base_casting_time": 200,
     "base_energy_cost": 8000,
     "energy_source": "STAMINA",
@@ -127,7 +127,7 @@
     "base_energy_cost": 250,
     "energy_source": "MANA",
     "difficulty": 3,
-    "damage_type": "true"
+    "damage_type": "light"
   },
   {
     "id": "ethereal_grasp",

--- a/data/mods/MagicalNights/Spells/monsterspells.json
+++ b/data/mods/MagicalNights/Spells/monsterspells.json
@@ -152,7 +152,7 @@
     "max_level": 37,
     "base_casting_time": 100,
     "base_energy_cost": 2,
-    "damage_type": "bio"
+    "damage_type": "dark"
   },
   {
     "id": "ooze_acidicspray",

--- a/data/mods/MagicalNights/Spells/technomancer.json
+++ b/data/mods/MagicalNights/Spells/technomancer.json
@@ -330,7 +330,7 @@
     "final_energy_cost": 500,
     "spell_class": "TECHNOMANCER",
     "energy_source": "BIONIC",
-    "damage_type": "cut",
+    "damage_type": "light",
     "difficulty": 1,
     "max_level": 45,
     "base_casting_time": 120,

--- a/data/mods/MagicalNights/monsters/golems.json
+++ b/data/mods/MagicalNights/monsters/golems.json
@@ -30,7 +30,7 @@
     "vision_night": 40,
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "NO_BREATHE", "ACIDPROOF", "LOUDMOVES" ]
+    "flags": [ "SEES", "NO_BREATHE", "ACIDPROOF", "PSIPROOF", "BIOPROOF", "LOUDMOVES" ]
   },
   {
     "id": "mon_plasticgolem",
@@ -60,7 +60,7 @@
     "vision_night": 30,
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "NO_BREATHE", "LOUDMOVES" ]
+    "flags": [ "SEES", "HEARS", "PSIPROOF", "BIOPROOF", "NO_BREATHE", "LOUDMOVES" ]
   },
   {
     "id": "mon_stonegolem",
@@ -94,7 +94,7 @@
     "special_attacks": [ { "type": "spell", "spell_data": { "id": "rocket_punch", "min_level": 5 }, "cooldown": 10 } ],
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "NO_BREATHE", "ACIDPROOF", "LOUDMOVES" ]
+    "flags": [ "SEES", "NO_BREATHE", "PSIPROOF", "BIOPROOF", "ACIDPROOF", "LOUDMOVES" ]
   },
   {
     "id": "mon_irongolem",
@@ -128,7 +128,7 @@
     "special_attacks": [ { "type": "spell", "spell_data": { "id": "gas_attack", "min_level": 5 }, "cooldown": 60 } ],
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "NO_BREATHE", "ACIDPROOF", "LOUDMOVES" ]
+    "flags": [ "SEES", "NO_BREATHE", "ACIDPROOF", "PSIPROOF", "BIOPROOF", "LOUDMOVES" ]
   },
   {
     "id": "mon_resingolem_fresh",
@@ -160,7 +160,7 @@
     "death_function": [ "BROKEN" ],
     "regenerates": 25,
     "upgrades": { "into": "mon_resingolem_half", "half_life": 25 },
-    "flags": [ "SEES", "HEARS", "NO_BREATHE", "LOUDMOVES" ]
+    "flags": [ "SEES", "HEARS", "NO_BREATHE", "PSIPROOF", "BIOPROOF", "LOUDMOVES" ]
   },
   {
     "id": "mon_resingolem_half",
@@ -192,7 +192,7 @@
     "death_function": [ "BROKEN" ],
     "regenerates": 10,
     "upgrades": { "into": "mon_resingolem_cured", "half_life": 25 },
-    "flags": [ "SEES", "HEARS", "NO_BREATHE", "LOUDMOVES" ]
+    "flags": [ "SEES", "HEARS", "NO_BREATHE", "PSIPROOF", "BIOPROOF", "LOUDMOVES" ]
   },
   {
     "id": "mon_resingolem_cured",
@@ -222,7 +222,7 @@
     "vision_night": 30,
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "NO_BREATHE", "LOUDMOVES" ]
+    "flags": [ "SEES", "HEARS", "NO_BREATHE", "PSIPROOF", "BIOPROOF", "LOUDMOVES" ]
   },
   {
     "id": "mon_orchigolem",
@@ -255,7 +255,7 @@
     "vision_night": 40,
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "NO_BREATHE", "ACIDPROOF", "LOUDMOVES" ]
+    "flags": [ "SEES", "NO_BREATHE", "ACIDPROOF", "PSIPROOF", "BIOPROOF", "LOUDMOVES" ]
   },
   {
     "id": "mon_mithrgolem",
@@ -289,6 +289,6 @@
     "vision_night": 40,
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "NO_BREATHE", "ACIDPROOF", "LOUDMOVES" ]
+    "flags": [ "SEES", "NO_BREATHE", "ACIDPROOF", "PSIPROOF", "BIOPROOF", "LOUDMOVES" ]
   }
 ]

--- a/data/mods/MagicalNights/monsters/monsters.json
+++ b/data/mods/MagicalNights/monsters/monsters.json
@@ -218,7 +218,9 @@
       "NOGIB",
       "NOHEAD",
       "NO_BREATHE",
-      "SWARMS"
+      "SWARMS",
+      "PSIPROOF",
+      "BIOPROOF"
     ]
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

We have new damage types, so I should probably use them.

## Describe the solution (The How)

Makes a few light-related attack into light damage, usually replacing fire. Also makes a couple spells dark instead of bio

Granted some of the new immunity flags, particularly to the golems (no psi for them, and I missed them on the bioproofing)

## Describe alternatives you've considered

- Also remove a bunch of true damage from the magus spells

Unsure of what I want to do with them at the moment

## Testing

Loadtested, so the JSON is valid

## Additional context

I'll probably make more use of the damage types in the future, especially for any animist expansions.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
