### PR TITLE
docs: document new damage types, missing documentation for `BRAWL` flag on spells

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -139,6 +139,8 @@ experience you need to get to a level is below:
 
 - `PAIN_NORESIST` - pain altering spells can't be resisted (like with the deadened trait)
 
+- `BRAWL` - Allows characters with the Brawler trait to cast the spell (otherwise they cannot)
+
 - `NO_FAIL` - this spell cannot fail when you cast it
 
 #### Currently Implemented Effects and special rules
@@ -238,6 +240,9 @@ experience you need to get to a level is below:
 - `cold`
 - `cut`
 - `electric`
+- `light` - used both for actual light, as well as 'holy'
+- `dark`
+- `psi` - psychic
 - `stab`
 - `true` - this damage type goes through armor altogether, and thus is very powerful. It is the
   default damage type when unspecified.
@@ -615,6 +620,9 @@ damage type has its own enchant value:
 - `ARMOR_BULLET`
 - `ARMOR_COLD`
 - `ARMOR_CUT`
+- `ARMOR_LIGHT`
+- `ARMOR_DARK`
+- `ARMOR_PSI`
 - `ARMOR_ELEC`
 - `ARMOR_HEAT`
 - `ARMOR_STAB`
@@ -649,6 +657,9 @@ value:
 - `ITEM_ARMOR_BULLET`
 - `ITEM_ARMOR_COLD`
 - `ITEM_ARMOR_CUT`
+- `ITEM_ARMOR_LIGHT`
+- `ITEM_ARMOR_DARK`
+- `ITEM_ARMOR_PSI`
 - `ITEM_ARMOR_ELEC`
 - `ITEM_ARMOR_HEAT`
 - `ITEM_ARMOR_STAB`


### PR DESCRIPTION
## Purpose of change (The Why)

Royalfox missed the damage types being put into the magic docs, and I didn't initially put the brawl spell flag in there because iirc we were still considering moving docs methods at the time.

## Describe the solution (The How)

Documents them

## Describe alternatives you've considered

Make Royal fox do hers when her internet is back

## Testing

Eyeballed it

## Additional context

Is the search bar in docs borked for anyone else?
![image](https://github.com/user-attachments/assets/876b5efd-1f2b-47de-a64e-62b5c9f32900)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
