### PR TITLE
fix: NO_SALVAGE applied to copper charges

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -689,6 +689,7 @@
     "volume": "250 ml",
     "weight": "2 g",
     "ammo_type": "components",
+    "flags": [ "NO_SALVAGE" ],
     "count": 200
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

I should not be able to cut up loose copper, it already is the base item.
![image](https://github.com/user-attachments/assets/97f484d9-338d-4962-a6f6-f321e42d7dd1)


## Describe the solution (The How)

Liberal application of NO_SALVAGE

## Describe alternatives you've considered

NO!

## Testing

Tests

## Additional context

Just got my internet back. Florida woes.

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.