### PR TITLE
fix(UI): salvage seemingly double report resulting items

### DIFF
--- a/src/salvage.cpp
+++ b/src/salvage.cpp
@@ -170,9 +170,9 @@ static std::vector<std::pair< material_id, float>> salvage_result_proportions(
 }
 
 //Returns vector of pairs <item id, count>
-std::vector<std::pair< itype_id, float>> salvage_results( const item &target )
+std::unordered_map< itype_id, float> salvage_results( const item &target )
 {
-    std::vector<std::pair< itype_id, float>> salvagable_materials;
+    std::unordered_map<itype_id, float> salvagable_materials;
     //For now we assume that proportions for all materials are equal
     for( auto &material : salvage_result_proportions( target ) ) {
         auto res = material.first->salvaged_into();
@@ -181,14 +181,7 @@ std::vector<std::pair< itype_id, float>> salvage_results( const item &target )
             auto t_mass = target.weight().value();
             auto r_mass = ( **res ).weight.value();
             //cuz we need actual float here
-            auto cnt = t_mass * material.second / r_mass;
-
-            if( auto found = std::ranges::find( salvagable_materials, res, &std::pair<itype_id, float>::first );
-                found != salvagable_materials.end() ) {
-                found->second += cnt;
-            } else {
-                salvagable_materials.emplace_back( *res, cnt );
-            }
+            salvagable_materials[*res] += t_mass * material.second / r_mass;
         }
     }
     return salvagable_materials;

--- a/src/salvage.cpp
+++ b/src/salvage.cpp
@@ -182,7 +182,13 @@ std::vector<std::pair< itype_id, float>> salvage_results( const item &target )
             auto r_mass = ( **res ).weight.value();
             //cuz we need actual float here
             auto cnt = t_mass * material.second / r_mass;
-            salvagable_materials.emplace_back( *res, cnt );
+
+            if( auto found = std::ranges::find( salvagable_materials, res, &std::pair<itype_id, float>::first );
+                found != salvagable_materials.end() ) {
+                found->second += cnt;
+            } else {
+                salvagable_materials.emplace_back( *res, cnt );
+            }
         }
     }
     return salvagable_materials;

--- a/src/salvage.h
+++ b/src/salvage.h
@@ -31,7 +31,7 @@ ret_val<bool> try_salvage( const item &, quality_cache & );
 
 units::mass minimal_weight_to_cut( const item &it );
 
-std::vector<std::pair< itype_id, float>> salvage_results( const item &target );
+std::unordered_map<itype_id, float> salvage_results( const item &target );
 
 void complete_salvage( Character &who, item &cut, tripoint_abs_ms pos );
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

On rare occasions when item consists of different materials that salvage into the same resulting item, this said item reported twice, which may appear as a bug and possibly is annoying.
![image](https://github.com/user-attachments/assets/3dc8c123-7ebc-46c3-8cdf-8e7107e107dd)
![image](https://github.com/user-attachments/assets/4aa61cc8-88d6-45ae-a318-a72f463d8865)

## Describe the solution (The How)

Check if `salvage_results` already contain the item and increment it, instead of adding new entry.

## Testing

- Compile;
- Start;
- Check old things salvaged properly;
- Check reported case works properly. Heavy duty frame is a good example, since it's made of steel and hardsteel, both are salvaged into `steel`.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Appropriate looking result:
![image](https://github.com/user-attachments/assets/51cd3f2a-5e3c-40f6-8757-2d2f90cf2849)
![image](https://github.com/user-attachments/assets/f2703652-f6f7-4247-a0d5-88ca9c98f819)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
