### PR TITLE
feat: add lua bindings for recipe

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -74,7 +74,6 @@ jobs:
             sudo update-alternatives --install /usr/bin/$bin $bin /usr/bin/$bin-$VERSION 200
           done
 
-
       - name: Setup ccache
         uses: Chocobo1/setup-ccache-action@v1
         with:

--- a/doc/src/content/docs/en/mod/lua/reference/lua.md
+++ b/doc/src/content/docs/en/mod/lua/reference/lua.md
@@ -4634,6 +4634,74 @@ Function `( RecipeId, <cppval: 7JsonOut > )`
 
 Function `( RecipeId, <cppval: 6JsonIn > )`
 
+## RecipeRaw
+
+### Bases
+
+No base classes.
+
+### Constructors
+
+No constructors.
+
+### Members
+
+#### category
+
+Variable of type `string`
+
+#### subcategory
+
+Variable of type `string`
+
+#### time
+
+Variable of type `int`
+
+#### skill_used
+
+Variable of type `SkillId`
+
+#### difficulty
+
+Variable of type `int`
+
+#### required_skills
+
+Variable of type `Map( SkillId, int )`
+
+#### learn_by_disassembly
+
+Variable of type `Map( SkillId, int )`
+
+#### booksets
+
+Variable of type `Map( ItypeId, int )`
+
+#### ident
+
+Function `( RecipeRaw ) -> RecipeId`
+
+#### result
+
+Function `( RecipeRaw ) -> ItypeId`
+
+#### result_name
+
+Function `( RecipeRaw ) -> string`
+
+#### has_flag
+
+Function `( RecipeRaw, string ) -> bool`
+
+#### get_from_skill_used
+
+Function `( SkillId ) -> Vector( RecipeRaw )`
+
+#### get_from_flag
+
+Function `( string ) -> Vector( RecipeRaw )`
+
 ## SkillId
 
 ### Bases

--- a/lua_annotations.lua
+++ b/lua_annotations.lua
@@ -103,9 +103,9 @@ function BodyPartTypeIntId.new() end
 ---@field activate_mutation fun(arg1: Character, arg2: MutationBranchId)
 ---@field add_addiction fun(arg1: Character, arg2: AddictionType, arg3: integer)
 ---@field add_bionic fun(arg1: Character, arg2: BionicDataId)
----@field addiction_level fun(arg1: Character, arg2: AddictionType): integer
 ---@field add_item_with_id fun(arg1: Character, arg2: ItypeId, arg3: integer) @Adds an item with the given id and amount
 ---@field add_morale fun(arg1: Character, arg2: MoraleTypeDataId, arg3: integer, arg4: integer, arg5: TimeDuration, arg6: TimeDuration, arg7: boolean, arg8: ItypeRaw)
+---@field addiction_level fun(arg1: Character, arg2: AddictionType): integer
 ---@field age fun(arg1: Character): integer
 ---@field all_items fun(arg1: Character, arg2: boolean): any @Gets all items
 ---@field all_items_with_flag fun(arg1: Character, arg2: JsonFlagId, arg3: boolean): any @Gets all items with the given flag
@@ -118,7 +118,6 @@ function BodyPartTypeIntId.new() end
 ---@field blossoms fun(arg1: Character)
 ---@field bodypart_exposure fun(arg1: Character): any
 ---@field bodyweight fun(arg1: Character): Mass
----@field cancel_activity fun(arg1: Character)
 ---@field can_hear fun(arg1: Character, arg2: Tripoint, arg3: integer): boolean
 ---@field can_mount fun(arg1: Character, arg2: Monster): boolean
 ---@field can_pick_volume fun(arg1: Character, arg2: Volume): boolean
@@ -126,6 +125,7 @@ function BodyPartTypeIntId.new() end
 ---@field can_run fun(arg1: Character): boolean
 ---@field can_unwield fun(arg1: Character, arg2: Item): boolean
 ---@field can_wield fun(arg1: Character, arg2: Item): boolean
+---@field cancel_activity fun(arg1: Character)
 ---@field check_mount_is_spooked fun(arg1: Character): boolean
 ---@field check_mount_will_move fun(arg1: Character, arg2: Tripoint): boolean
 ---@field clear_bionics fun(arg1: Character)
@@ -139,6 +139,7 @@ function BodyPartTypeIntId.new() end
 ---@field expose_to_disease fun(arg1: Character, arg2: DiseaseTypeId)
 ---@field fall_asleep fun(arg1: Character) | fun(arg1: Character, arg2: TimeDuration)
 ---@field forced_dismount fun(arg1: Character)
+---@field getID fun(arg1: Character): CharacterId
 ---@field get_all_skills fun(arg1: Character): SkillLevelMap
 ---@field get_armor_acid fun(arg1: Character, arg2: BodyPartTypeIntId): integer
 ---@field get_base_traits fun(arg1: Character): any
@@ -153,7 +154,6 @@ function BodyPartTypeIntId.new() end
 ---@field get_healthy_mod fun(arg1: Character): integer
 ---@field get_highest_category fun(arg1: Character): MutationCategoryTraitId
 ---@field get_hostile_creatures fun(arg1: Character, arg2: integer): any
----@field getID fun(arg1: Character): CharacterId
 ---@field get_int fun(arg1: Character): integer
 ---@field get_int_base fun(arg1: Character): integer
 ---@field get_int_bonus fun(arg1: Character): integer
@@ -302,10 +302,11 @@ function BodyPartTypeIntId.new() end
 ---@field remove_bionic fun(arg1: Character, arg2: BionicDataId)
 ---@field remove_child_flag fun(arg1: Character, arg2: MutationBranchId)
 ---@field remove_mutation fun(arg1: Character, arg2: MutationBranchId, arg3: boolean)
----@field restore_scent fun(arg1: Character)
 ---@field rest_quality fun(arg1: Character): number
+---@field restore_scent fun(arg1: Character)
 ---@field rooted fun(arg1: Character)
 ---@field rust_rate fun(arg1: Character): integer
+---@field setID fun(arg1: Character, arg2: CharacterId, arg3: boolean)
 ---@field set_base_age fun(arg1: Character, arg2: integer)
 ---@field set_base_height fun(arg1: Character, arg2: integer)
 ---@field set_dex_bonus fun(arg1: Character, arg2: integer)
@@ -313,7 +314,6 @@ function BodyPartTypeIntId.new() end
 ---@field set_fatigue fun(arg1: Character, arg2: integer)
 ---@field set_healthy fun(arg1: Character, arg2: integer)
 ---@field set_healthy_mod fun(arg1: Character, arg2: integer)
----@field setID fun(arg1: Character, arg2: CharacterId, arg3: boolean)
 ---@field set_int_bonus fun(arg1: Character, arg2: integer)
 ---@field set_max_power_level fun(arg1: Character, arg2: Energy)
 ---@field set_movement_mode fun(arg1: Character, arg2: CharacterMoveMode)
@@ -1275,6 +1275,25 @@ RecipeId = {}
 ---@overload fun(arg1: string): RecipeId
 function RecipeId.new() end
 
+---@class RecipeRaw
+---@field booksets any
+---@field category string
+---@field difficulty integer
+---@field learn_by_disassembly any
+---@field required_skills any
+---@field skill_used SkillId
+---@field subcategory string
+---@field time integer
+---@field get_from_flag fun(arg1: string): any
+---@field get_from_skill_used fun(arg1: SkillId): any
+---@field has_flag fun(arg1: RecipeRaw, arg2: string): boolean
+---@field ident fun(arg1: RecipeRaw): RecipeId
+---@field result fun(arg1: RecipeRaw): ItypeId
+---@field result_name fun(arg1: RecipeRaw): string
+RecipeRaw = {}
+---@return RecipeRaw
+function RecipeRaw.new() end
+
 ---@class SkillId
 ---@field NULL_ID fun(): SkillId
 ---@field implements_int_id fun(): boolean
@@ -1612,11 +1631,11 @@ function Volume.new() end
 
 --- Various game constants
 ---@class const
+---@field OMT_MS_SIZE integer # value: 24
+---@field OMT_SM_SIZE integer # value: 2
 ---@field OM_MS_SIZE integer # value: 4320
 ---@field OM_OMT_SIZE integer # value: 180
 ---@field OM_SM_SIZE integer # value: 360
----@field OMT_MS_SIZE integer # value: 24
----@field OMT_SM_SIZE integer # value: 2
 ---@field SM_MS_SIZE integer # value: 12
 const = {}
 

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -1381,6 +1381,7 @@ void cata::reg_all_bindings( sol::state &lua )
     reg_game_ids( lua );
     mod_mutation_branch( lua );
     reg_magic( lua );
+    reg_recipe( lua );
     reg_coords_library( lua );
     reg_constants( lua );
     reg_hooks_examples( lua );

--- a/src/catalua_bindings.h
+++ b/src/catalua_bindings.h
@@ -35,6 +35,7 @@ void reg_magic( sol::state &lua );
 void reg_npc( sol::state &lua );
 void reg_player( sol::state &lua );
 void reg_point_tripoint( sol::state &lua );
+void reg_recipe( sol::state &lua );
 void reg_skill_level_map( sol::state &lua );
 void reg_spell_type( sol::state &lua );
 void reg_spell_fake( sol::state &lua );

--- a/src/catalua_bindings_recipe.cpp
+++ b/src/catalua_bindings_recipe.cpp
@@ -1,0 +1,57 @@
+#include "catalua_bindings.h"
+
+#include "catalua.h"
+#include "catalua_bindings_utils.h"
+#include "catalua_impl.h"
+#include "catalua_log.h"
+#include "catalua_luna.h"
+#include "catalua_luna_doc.h"
+
+#include "recipe.h"
+#include "recipe_dictionary.h"
+
+#include "itype.h"
+#include "skill.h"
+
+void cata::detail::reg_recipe(sol::state &lua)
+{
+#define UT_CLASS recipe
+    {
+        sol::usertype<UT_CLASS> ut =
+        luna::new_usertype<UT_CLASS>(
+            lua,
+            luna::no_bases,
+            luna::no_constructor
+        );
+        SET_MEMB( category );
+        SET_MEMB( subcategory );
+        luna::set( ut, "time", &recipe::time );
+        SET_MEMB( skill_used );
+        SET_MEMB( difficulty );
+        SET_MEMB( required_skills );
+        SET_MEMB( learn_by_disassembly );
+        SET_MEMB( booksets );
+        
+        SET_FX_T( ident, const recipe_id &() const );
+        SET_FX_T( result, const itype_id &() const );
+        SET_FX_T( result_name, std::string () const );
+        SET_FX_T( has_flag, bool ( const std::string &flag_name ) const);
+
+        luna::set_fx( ut, "get_from_skill_used", []( const skill_id &sk ) -> std::vector<recipe> {
+            std::vector<recipe> recipes;
+            for( auto &e: recipe_dict ){
+                const auto &r = e.second;
+                if (r.skill_used == sk){ recipes.push_back(r); }
+            }
+            return recipes;
+        } );
+        luna::set_fx( ut, "get_from_flag", []( const std::string &flag_name ) -> std::vector<recipe> {
+            std::vector<recipe> recipes;
+            for( auto &e: recipe_dict ){
+                const auto &r = e.second;
+                if (r.has_flag( flag_name )){ recipes.push_back(r); }
+            }
+            return recipes;
+        } );
+    }
+}


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
Functions and variables of `RecipeRaw` are needed.
They allow Lua can track recipes' required skills or category, also find the recipes list with mainly used skill or given flag.

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Made `catalua_binding_recipe.cpp` and wrote some code.
I heard `catalua_bindings.cpp` needs to be split(#6602), so new file was added instead of more code on existing file.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
D:(

## Testing

Run this code on lua console:

```lua
local recipes_comp = RecipeRaw.get_from_skill_used(SkillId.new("computer"))
for _, v in ipairs(recipes_comp) do
  if v.category ~= "CC_WEAPON" and v.category ~= "CC_ARMOR" then
    gdebug.log_info(v:result_name())
  end
end
```
![스크린샷 2025-05-31 002535](https://github.com/user-attachments/assets/d9484e77-3f8c-4c1a-8b04-6b755496898d)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Any suggestion for this binding? Such as, adding `get_all_recipes`? (I thought it makes game performance bad, but never verified)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


### Optional

- [x] This PR modifies BN's lua API.
  - [x] I have committed the output of `deno task doc` so the Lua API documentation is updated.
