### PR TITLE
feat(mods/MagicalNights, balance): Lower rock tomb and meteor casting time

### DIFF
--- a/data/mods/MagicalNights/Spells/earthshaper.json
+++ b/data/mods/MagicalNights/Spells/earthshaper.json
@@ -343,7 +343,7 @@
     "id": "rock_tomb",
     "type": "SPELL",
     "name": { "str": "Rock Tomb" },
-    "description": "You tear up the ground beneath you to throw a medium boulder.  It shatters upon impact, scattering rocks and debris everywhere.",
+    "description": "You lift a medium boulder out of the ground, then hurl it at your foes.  It shatters upon impact, scattering rocks and debris everywhere.",
     "effect": "projectile_attack",
     "valid_targets": [ "hostile", "ground", "ally" ],
     "damage_type": "bash",
@@ -358,7 +358,7 @@
     "min_aoe": 1,
     "max_aoe": 4,
     "aoe_increment": 0.5,
-    "base_casting_time": 300,
+    "base_casting_time": 175,
     "base_energy_cost": 600,
     "energy_source": "MANA",
     "flags": [ "SOMATIC", "LOUD", "NO_HANDS" ]
@@ -382,8 +382,8 @@
     "min_aoe": 5,
     "max_aoe": 30,
     "aoe_increment": 0.5,
-    "base_casting_time": 1000,
-    "base_energy_cost": 2000,
+    "base_casting_time": 800,
+    "base_energy_cost": 1500,
     "energy_source": "MANA",
     "flags": [ "CONCENTRATE", "SOMATIC", "LOUD", "NO_HANDS" ]
   }


### PR DESCRIPTION
## Purpose of change (The Why)

As Phoenix noted, the cast time was a little off for rock tomb. Looking over the stats for the meteor spell, I noticed that they also seemed just a touch off.

## Describe the solution (The How)

- Lowers the casting time of rock tomb by a bit under 50%
- Lowers the casting time and energy cost of meteor by a bit
- Adjusts rock tomb's description a little (it sounded like it should be dealing terrain damage before)

## Describe alternatives you've considered

- Do it as part of the batch of re-balancing relating to shrinking the maximum levels later

Better to have this done before hand, keep that future PR simpler

## Testing

Nothing new added, just some numbers tweaked to values that seem better and I know the game wouldn't freak out over.

## Additional context

The two kelvinist spells introduced with rock tomb may need a check-over and potential nerf to their casting time and energy as well, but keeping the scope of this PR small.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
