### PR TITLE
feat(balance, mods/MagicalNights): Nerf mana cap bonuses from magi staves

### DIFF
--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -11,7 +11,7 @@
     "weapon_category": [ "QUARTERSTAVES" ],
     "flags": [ "SHEATH_SPEAR", "ALWAYS_TWOHAND", "FRAGILE_MELEE", "MAGIC_FOCUS" ],
     "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "values": [ { "value": "MANA_CAP", "multiply": 0.5 } ] } ]
+      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "values": [ { "value": "MANA_CAP", "multiply": 0.25 } ] } ]
     },
     "weight": "1400 g",
     "volume": "3 L",
@@ -31,7 +31,7 @@
     "material": "wood",
     "flags": [ "SHEATH_SPEAR", "ALWAYS_TWOHAND", "FRAGILE_MELEE", "MAGIC_FOCUS" ],
     "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "values": [ { "value": "MANA_CAP", "multiply": 1.25 } ] } ]
+      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "values": [ { "value": "MANA_CAP", "multiply": 0.5 } ] } ]
     },
     "weight": "1400 g",
     "volume": "3 L",
@@ -52,7 +52,7 @@
     "weapon_category": [ "QUARTERSTAVES" ],
     "flags": [ "SHEATH_SPEAR", "ALWAYS_TWOHAND", "FRAGILE_MELEE", "MAGIC_FOCUS" ],
     "relic_data": {
-      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "values": [ { "value": "MANA_CAP", "multiply": 2 } ] } ]
+      "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "values": [ { "value": "MANA_CAP", "multiply": 1.25 } ] } ]
     },
     "weight": "1400 g",
     "volume": "3 L",


### PR DESCRIPTION
## Purpose of change (The Why)

125% extra mana capacity on the lesser staff was particularly crazy

## Describe the solution (The How)

changes the progression to be more sane, going from 25% bonus to 50% bonus to 125% bonus at the greater level.

## Describe alternatives you've considered

- Implode the staves
- Give mana regen bonus (Possibly in exchange for some cap bonus)

## Testing

Number tweak

## Additional context

Phoenix with the good balance notes as usual.

My bad for not looking over the questionably high bonuses when I originally accepted the PR that added them (when MN was out-of-repo)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


