### PR TITLE
feat(balance, mods/MagicalNights): Raise bulette spawn cost significantly

### DIFF
--- a/data/mods/MagicalNights/monstergroups.json
+++ b/data/mods/MagicalNights/monstergroups.json
@@ -19,7 +19,7 @@
       { "monster": "mon_claygolem", "freq": 8, "cost_multiplier": 3 },
       { "monster": "mon_stonegolem", "freq": 4, "cost_multiplier": 5 },
       { "monster": "mon_irongolem", "freq": 2, "cost_multiplier": 8 },
-      { "monster": "mon_bulette", "freq": 3, "cost_multiplier": 1 },
+      { "monster": "mon_bulette", "freq": 3, "cost_multiplier": 10 },
       { "monster": "mon_demon_spiderling", "freq": 15, "cost_multiplier": 5, "pack_size": [ 3, 7 ] }
     ]
   },
@@ -35,7 +35,7 @@
       { "monster": "mon_stirge", "freq": 7, "cost_multiplier": 1, "pack_size": [ 2, 8 ] },
       { "monster": "mon_wisp", "freq": 5, "cost_multiplier": 10, "conditions": [ "NIGHT" ] },
       { "monster": "mon_wisp", "freq": 1, "cost_multiplier": 10, "conditions": [ "NIGHT" ], "pack_size": [ 1, 3 ] },
-      { "monster": "mon_bulette", "freq": 3, "cost_multiplier": 1 },
+      { "monster": "mon_bulette", "freq": 3, "cost_multiplier": 10 },
       { "monster": "mon_dragon_black_wyrmling", "freq": 2, "cost_multiplier": 50 },
       { "monster": "mon_dragon_black_young", "freq": 1, "cost_multiplier": 65 },
       { "monster": "mon_lizardfolk_warrior", "freq": 10, "cost_multiplier": 1, "pack_size": [ 1, 3 ] },


### PR DESCRIPTION
## Purpose of change (The Why)

I created a monster (Not really, but I spawned them certainly) that's arguably worse than the owlbears ever were.

## Describe the solution (The How)

Reduce spawn levels to troll-level.

## Describe alternatives you've considered

- Go for an even more aggressive cost increase

Trolls aren't that common, and bulettes spawning later is important for the cool pearls.

## Testing

Number tweaks go brrrr

## Additional context

My apologies to any players that got buletted. 

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

