### PR TITLE
test: Fix issues in bandaged/disinfected healing test

### DIFF
--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -381,21 +381,23 @@ TEST_CASE( "healing_rate_medicine with bandages and/or disinfectant",
     // Combined, healing is 4-12 HP per day while awake, 8-24 HP per day while asleep
     SECTION( "bandages and disinfectant together" ) {
         SECTION( "awake" ) {
-            CHECK( together_rate( "head", awake_rest ) == Approx( 1.72f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "arm_l", awake_rest ) == Approx( 4.32f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "arm_r", awake_rest ) == Approx( 4.32f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "leg_l", awake_rest ) == Approx( 4.32f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "leg_r", awake_rest ) == Approx( 4.32f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "torso", awake_rest ) == Approx( 2.59f * hp_per_day ).epsilon( 0.01f ) );
+            constexpr double base_rate = 1.0 * 4;
+            CHECK( together_rate( "head", awake_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "arm_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "arm_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "leg_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "leg_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "torso", awake_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
 
         SECTION( "asleep" ) {
-            CHECK( together_rate( "head", sleep_rest ) == Approx( 4.32f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "arm_l", sleep_rest ) == Approx( 7.77f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "arm_r", sleep_rest ) == Approx( 7.77f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "leg_l", sleep_rest ) == Approx( 7.77f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "leg_r", sleep_rest ) == Approx( 7.77f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "torso", sleep_rest ) == Approx( 7.77f * hp_per_day ).epsilon( 0.01f ) );
+            constexpr double base_rate = 2.0 * 4;
+            CHECK( together_rate( "head", sleep_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "arm_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "arm_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "leg_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "leg_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "torso", sleep_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
     }
 }

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -272,7 +272,7 @@ static float untreated_rate( const std::string bp_name, const float rest_quality
 }
 
 // Return `healing_rate_medicine` for a `bandaged` body part at a given rest quality
-static float bandaged_rate( const std::string bp_name, const float rest_quality )
+static double bandaged_rate( const std::string bp_name, const float rest_quality )
 {
     avatar dummy;
     const bodypart_str_id &bp = bodypart_str_id( bp_name );
@@ -281,7 +281,7 @@ static float bandaged_rate( const std::string bp_name, const float rest_quality 
 }
 
 // Return `healing_rate_medicine` for a `disinfected` body part at a given rest quality
-static float disinfected_rate( const std::string bp_name, const float rest_quality )
+static double disinfected_rate( const std::string bp_name, const float rest_quality )
 {
     avatar dummy;
     const bodypart_str_id &bp = bodypart_str_id( bp_name );
@@ -290,7 +290,7 @@ static float disinfected_rate( const std::string bp_name, const float rest_quali
 }
 
 // Return `healing_rate_medicine` for a `bandaged` AND `disinfected` body part at a given rest quality
-static float together_rate( const std::string bp_name, const float rest_quality )
+static double together_rate( const std::string bp_name, const float rest_quality )
 {
     avatar dummy;
     const bodypart_str_id &bp = bodypart_str_id( bp_name );

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -336,22 +336,34 @@ TEST_CASE( "healing_rate_medicine with bandages and/or disinfectant",
     SECTION( "bandages only" ) {
         SECTION( "awake" ) {
             constexpr double base_rate = 1.0;
-            CHECK( bandaged_rate( "head", awake_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "arm_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "arm_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "leg_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "leg_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "torso", awake_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "head", awake_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon(
+                       0.01f ) );
+            CHECK( bandaged_rate( "arm_l",
+                                  awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "arm_r",
+                                  awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "leg_l",
+                                  awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "leg_r",
+                                  awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "torso",
+                                  awake_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
 
         SECTION( "asleep" ) {
             constexpr double base_rate = 2.0;
-            CHECK( bandaged_rate( "head", sleep_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "arm_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "arm_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "leg_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "leg_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "torso", sleep_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "head", sleep_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon(
+                       0.01f ) );
+            CHECK( bandaged_rate( "arm_l",
+                                  sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "arm_r",
+                                  sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "leg_l",
+                                  sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "leg_r",
+                                  sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "torso",
+                                  sleep_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
     }
 
@@ -359,22 +371,34 @@ TEST_CASE( "healing_rate_medicine with bandages and/or disinfectant",
     SECTION( "disinfectant only" ) {
         SECTION( "awake" ) {
             constexpr double base_rate = 1.0;
-            CHECK( disinfected_rate( "head", awake_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "arm_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "arm_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "leg_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "leg_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "torso", awake_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "head",
+                                     awake_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "arm_l",
+                                     awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "arm_r",
+                                     awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "leg_l",
+                                     awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "leg_r",
+                                     awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "torso",
+                                     awake_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
 
         SECTION( "asleep" ) {
             constexpr double base_rate = 2.0;
-            CHECK( disinfected_rate( "head", sleep_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "arm_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "arm_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "leg_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "leg_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "torso", sleep_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "head",
+                                     sleep_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "arm_l",
+                                     sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "arm_r",
+                                     sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "leg_l",
+                                     sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "leg_r",
+                                     sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "torso",
+                                     sleep_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
     }
 
@@ -382,22 +406,34 @@ TEST_CASE( "healing_rate_medicine with bandages and/or disinfectant",
     SECTION( "bandages and disinfectant together" ) {
         SECTION( "awake" ) {
             constexpr double base_rate = 1.0 * 4;
-            CHECK( together_rate( "head", awake_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "arm_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "arm_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "leg_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "leg_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "torso", awake_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "head", awake_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon(
+                       0.01f ) );
+            CHECK( together_rate( "arm_l",
+                                  awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "arm_r",
+                                  awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "leg_l",
+                                  awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "leg_r",
+                                  awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "torso",
+                                  awake_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
 
         SECTION( "asleep" ) {
             constexpr double base_rate = 2.0 * 4;
-            CHECK( together_rate( "head", sleep_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "arm_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "arm_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "leg_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "leg_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( together_rate( "torso", sleep_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "head", sleep_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon(
+                       0.01f ) );
+            CHECK( together_rate( "arm_l",
+                                  sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "arm_r",
+                                  sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "leg_l",
+                                  sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "leg_r",
+                                  sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( together_rate( "torso",
+                                  sleep_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
     }
 }

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -308,7 +308,7 @@ static double together_rate( const std::string bp_name, const float rest_quality
 // Healing rates from treatment are doubled while sleeping.
 //
 TEST_CASE( "healing_rate_medicine with bandages and/or disinfectant",
-           "[heal][bandage][disinfect][!mayfail]" )
+           "[heal][bandage][disinfect]" )
 {
     clear_all_state();
     // There are no healing effects from medicine if no medicine has been applied.

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -358,21 +358,23 @@ TEST_CASE( "healing_rate_medicine with bandages and/or disinfectant",
     // Disinfectant heals 1-3 HP per day while awake, 2-6 HP per day while asleep
     SECTION( "disinfectant only" ) {
         SECTION( "awake" ) {
-            CHECK( disinfected_rate( "head", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "arm_l", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "arm_r", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "leg_l", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "leg_r", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "torso", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
+            constexpr double base_rate = 1.0;
+            CHECK( disinfected_rate( "head", awake_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "arm_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "arm_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "leg_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "leg_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "torso", awake_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
 
         SECTION( "asleep" ) {
-            CHECK( disinfected_rate( "head", sleep_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "arm_l", sleep_rest ) == Approx( 1.72f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "arm_r", sleep_rest ) == Approx( 1.72f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "leg_l", sleep_rest ) == Approx( 1.72f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "leg_r", sleep_rest ) == Approx( 1.72f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( disinfected_rate( "torso", sleep_rest ) == Approx( 1.72f * hp_per_day ).epsilon( 0.01f ) );
+            constexpr double base_rate = 2.0;
+            CHECK( disinfected_rate( "head", sleep_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "arm_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "arm_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "leg_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "leg_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( disinfected_rate( "torso", sleep_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
     }
 

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -335,21 +335,23 @@ TEST_CASE( "healing_rate_medicine with bandages and/or disinfectant",
     // Bandages heal 1-3 HP per day while awake, 2-6 HP per day while asleep
     SECTION( "bandages only" ) {
         SECTION( "awake" ) {
-            CHECK( bandaged_rate( "head", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "arm_l", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "arm_r", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "leg_l", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "leg_r", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "torso", awake_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
+            constexpr double base_rate = 1.0;
+            CHECK( bandaged_rate( "head", awake_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "arm_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "arm_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "leg_l", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "leg_r", awake_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "torso", awake_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
 
         SECTION( "asleep" ) {
-            CHECK( bandaged_rate( "head", sleep_rest ) == Approx( 0.86f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "arm_l", sleep_rest ) == Approx( 1.72f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "arm_r", sleep_rest ) == Approx( 1.72f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "leg_l", sleep_rest ) == Approx( 1.72f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "leg_r", sleep_rest ) == Approx( 1.72f * hp_per_day ).epsilon( 0.01f ) );
-            CHECK( bandaged_rate( "torso", sleep_rest ) == Approx( 1.72f * hp_per_day ).epsilon( 0.01f ) );
+            constexpr double base_rate = 2.0;
+            CHECK( bandaged_rate( "head", sleep_rest ) == Approx( base_rate * 0.5 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "arm_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "arm_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "leg_l", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "leg_r", sleep_rest ) == Approx( base_rate * 1.0 * hp_per_day ).epsilon( 0.01f ) );
+            CHECK( bandaged_rate( "torso", sleep_rest ) == Approx( base_rate * 0.75 * hp_per_day ).epsilon( 0.01f ) );
         }
     }
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
Fix issues in test `"healing_rate_medicine with bandages and/or disinfectant"` in `tests/char_healing_test.cpp` introduced in #6663. 

fixes #6668

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
1. Changes return type of `bandaged_rate`, `disinfected_rate`, and `together_rate` to `double` so that if they do fail again we get a more informative failure message. Previous failure message was along the lines of:
`0.00001f == Approx( 0.0000099537 )` which is unhelpful when the actual value was `0.000005787`, a large difference from the displayed `0.00001f`.
2. Largely removed monolithic magic numbers. Base healing rate when bandaged ^ disinfected is 1 while awake and 2 while asleep, and 4 and 8 respectively when bandaged & disinfected.
3. Bodypart healing rates differ slightly, with Head healing at half the rate of limbs and Torso healing at 3/4 the rate of limbs.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Use `Catch::Matchers::WithinRel( expected, epsilon )` instead of `Approx` but that is a change that doesn't fix the problem and can be done in a future PR if desirable.

## Testing
1. Tested if just using `Catch::Matchers::WithinRel()` instead of `Approx` would work. Did not work.
2. Added a lot of different epsilon values to see at what value it would pass. Started passing around epsilon of 0.45. That raised some alarms, leading to...
3. Changed the return types of relevant calculating functions to `double` and reran tests. Now getting a number that's not `0.00001`!
4. Recalculated where the actual value was relative to 1 turn of healing and decided to just forgo the funny calculated magic numbers and just use a few easy constants.
5. Tests now pass

If the constants within the JSON data change the test constants may need to change to reflect the new reality.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
There is another test failure at `tests/char_healing_test.cpp:139` that is slightly outside the scope of this PR and I'm not sure how to properly solve. With the new healing rate values the margin is very slightly expanded from the previously valid `tol = 0.000007` out to within `tol + 0.000002`. It seems weird to add a little extra to the margin in this one location, but I'm not sure if it's worthwhile to increase the tolerance across all uses (25 within the file).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
