### PR TITLE
fix: RM11B scout rifle is no longer silent

### DIFF
--- a/data/json/items/gunmod/muzzle.json
+++ b/data/json/items/gunmod/muzzle.json
@@ -137,7 +137,7 @@
     "material": [ "superalloy", "ceramic" ],
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ] ],
     "handling_modifier": 5,
-    "proportional": { "loudness_modifier": 10 },
+    "loudness_modifier": -100,
     "flags": [ "IRREMOVABLE" ]
   },
   {


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

The Rivtech RM11B scout rifle was completely silent with default ammo. While the integrated suppressor is described as "rather advanced", and there's some precedent for Rivtech breaking the laws of physics, making _no sound whatsoever_ just feels like bad feedback.

## Describe the solution (The How)

The integrated `riv_suppressor` gunmod loudness modifier set to -100. Previously, it was a proportional modifier to the base suppressor item, probably adding up to -750.
With the new value, the scout rifle's noise with default 8x40 ammo is 99, about equivalent to an unsuppressed 9mm Glock 17 (91 noise). With 8x40 sporting ammo, noise is 41; With HVP ammo it is 141.
For comparison, an unsuppressed RM51 assault rifle with default ammo makes 199 noise.

## Describe alternatives you've considered

I want the loudness modifier at a level where it doesn't push the noise of sporting ammo to zero, but there's still some room to make it a bit quieter if someone wants to.

## Testing

Spawned the rifle, fired various ammo through it.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
