### PR TITLE
feat: prevent duplicated noise from spells by default

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -141,6 +141,8 @@ experience you need to get to a level is below:
 
 - `BRAWL` - Allows characters with the Brawler trait to cast the spell (otherwise they cannot)
 
+- `DUPE_SOUND` - Allows a spell to play multiple of the same sound (i.e. a sound for each target affected)
+
 - `NO_FAIL` - this spell cannot fail when you cast it
 
 #### Currently Implemented Effects and special rules

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -104,6 +104,7 @@ std::string enum_to_string<spell_flag>( spell_flag data )
         case spell_flag::NO_FAIL: return "NO_FAIL";
         case spell_flag::WONDER: return "WONDER";
         case spell_flag::BRAWL: return "BRAWL";
+        case spell_flag::DUPE_SOUND: return "DUPE_SOUND";
         case spell_flag::LAST: break;
     }
     debugmsg( "Invalid spell_flag" );

--- a/src/magic.h
+++ b/src/magic.h
@@ -58,6 +58,7 @@ enum spell_flag {
     PAIN_NORESIST, // pain altering spells can't be resisted (like with the deadened trait)
     NO_FAIL, // this spell cannot fail when you cast it
     BRAWL, // this spell can be used by brawlers
+    DUPE_SOUND, // this spell will play 'duplicate' sounds, if relevant to the spell effect
     LAST
 };
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -482,11 +482,15 @@ static void add_effect_to_target( const tripoint &target, const spell &sp )
 static void damage_targets( const spell &sp, Creature &caster,
                             const std::set<tripoint> &targets )
 {
+    bool sound_played = false;
     for( const tripoint &target : targets ) {
         if( !sp.is_valid_target( caster, target ) ) {
             continue;
         }
-        sp.make_sound( target );
+        if (sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
+            sp.make_sound( target );
+            sound_played = true;
+        }
         sp.create_field( target );
         Creature *const cr = g->critter_at<Creature>( target );
         if( !cr ) {
@@ -1018,13 +1022,17 @@ void spell_effect::spawn_summoned_monster( const spell &sp, Creature &caster,
     // this should never be negative, but this'll keep problems from happening
     size_t num_mons = std::abs( sp.damage() );
     const time_duration summon_time = sp.duration_turns();
+    bool sound_played = false;
     while( num_mons > 0 && !area.empty() ) {
         const size_t mon_spot = rng( 0, area.size() - 1 );
         auto iter = area.begin();
         std::advance( iter, mon_spot );
         if( add_summoned_mon( mon_id, *iter, summon_time, sp ) ) {
             num_mons--;
-            sp.make_sound( *iter );
+            if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+                sound_played = true;
+                sp.make_sound( *iter );
+            }
         } else {
             add_msg( m_bad, "failed to place monster" );
         }
@@ -1089,6 +1097,7 @@ void spell_effect::noise( const spell &sp, Creature &, const tripoint &target )
 void spell_effect::vomit( const spell &sp, Creature &caster, const tripoint &target )
 {
     const std::set<tripoint> area = spell_effect_blast( sp, caster.pos(), target, sp.aoe(), true );
+    bool sound_played = false;
     for( const tripoint &potential_target : area ) {
         if( !sp.is_valid_target( caster, potential_target ) ) {
             continue;
@@ -1097,7 +1106,10 @@ void spell_effect::vomit( const spell &sp, Creature &caster, const tripoint &tar
         if( !ch ) {
             continue;
         }
-        sp.make_sound( target );
+        if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+            sound_played = true;
+            sp.make_sound( target );
+        }
         ch->vomit();
     }
 }
@@ -1121,6 +1133,7 @@ void spell_effect::flashbang( const spell &sp, Creature &caster, const tripoint 
 void spell_effect::mod_moves( const spell &sp, Creature &caster, const tripoint &target )
 {
     const std::set<tripoint> area = spell_effect_blast( sp, caster.pos(), target, sp.aoe(), false );
+    bool sound_played = false;
     for( const tripoint &potential_target : area ) {
         if( !sp.is_valid_target( caster, potential_target ) ) {
             continue;
@@ -1129,7 +1142,10 @@ void spell_effect::mod_moves( const spell &sp, Creature &caster, const tripoint 
         if( !critter ) {
             continue;
         }
-        sp.make_sound( potential_target );
+        if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+            sound_played = true;
+            sp.make_sound( potential_target );
+        }
         critter->moves += sp.damage();
     }
 }
@@ -1158,6 +1174,7 @@ void spell_effect::morale( const spell &sp, Creature &caster, const tripoint &ta
                   sp.effect_data() );
         return;
     }
+    bool sound_played = false;
     for( const tripoint &potential_target : area ) {
         player *player_target;
         if( !( sp.is_valid_target( caster, potential_target ) &&
@@ -1166,13 +1183,17 @@ void spell_effect::morale( const spell &sp, Creature &caster, const tripoint &ta
         }
         player_target->add_morale( morale_type( sp.effect_data() ), sp.damage(), 0, sp.duration_turns(),
                                    sp.duration_turns() / 10, false );
-        sp.make_sound( potential_target );
+        if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+            sound_played = true;
+            sp.make_sound( potential_target );
+        }
     }
 }
 
 void spell_effect::charm_monster( const spell &sp, Creature &caster, const tripoint &target )
 {
     const std::set<tripoint> area = spell_effect_blast( sp, caster.pos(), target, sp.aoe(), false );
+    bool sound_played = false;
     for( const tripoint &potential_target : area ) {
         if( !sp.is_valid_target( caster, potential_target ) ) {
             continue;
@@ -1181,7 +1202,10 @@ void spell_effect::charm_monster( const spell &sp, Creature &caster, const tripo
         if( !mon ) {
             continue;
         }
-        sp.make_sound( potential_target );
+        if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+            sound_played = true;
+            sp.make_sound( potential_target );
+        }
         if( mon->friendly == 0 && mon->get_hp() <= sp.damage() ) {
             mon->unset_dest();
             mon->friendly += sp.duration() / 100;
@@ -1192,6 +1216,7 @@ void spell_effect::charm_monster( const spell &sp, Creature &caster, const tripo
 void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &target )
 {
     const std::set<tripoint> area = spell_effect_blast( sp, caster.pos(), target, sp.aoe(), false );
+    bool sound_played = false;
     for( const tripoint &potential_target : area ) {
         if( !sp.is_valid_target( caster, potential_target ) ) {
             continue;
@@ -1214,7 +1239,10 @@ void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &ta
                 guy->mutate_category( mutation_category_id( sp.effect_data() ) );
             }
         }
-        sp.make_sound( potential_target );
+        if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+            sound_played = true;
+            sp.make_sound( potential_target );
+        }
     }
 }
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1029,7 +1029,7 @@ void spell_effect::spawn_summoned_monster( const spell &sp, Creature &caster,
         std::advance( iter, mon_spot );
         if( add_summoned_mon( mon_id, *iter, summon_time, sp ) ) {
             num_mons--;
-            if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+            if ( sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
                 sound_played = true;
                 sp.make_sound( *iter );
             }
@@ -1106,7 +1106,7 @@ void spell_effect::vomit( const spell &sp, Creature &caster, const tripoint &tar
         if( !ch ) {
             continue;
         }
-        if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+        if ( sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
             sound_played = true;
             sp.make_sound( target );
         }
@@ -1142,7 +1142,7 @@ void spell_effect::mod_moves( const spell &sp, Creature &caster, const tripoint 
         if( !critter ) {
             continue;
         }
-        if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+        if ( sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
             sound_played = true;
             sp.make_sound( potential_target );
         }
@@ -1183,7 +1183,7 @@ void spell_effect::morale( const spell &sp, Creature &caster, const tripoint &ta
         }
         player_target->add_morale( morale_type( sp.effect_data() ), sp.damage(), 0, sp.duration_turns(),
                                    sp.duration_turns() / 10, false );
-        if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+        if (sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
             sound_played = true;
             sp.make_sound( potential_target );
         }
@@ -1202,7 +1202,7 @@ void spell_effect::charm_monster( const spell &sp, Creature &caster, const tripo
         if( !mon ) {
             continue;
         }
-        if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+        if ( sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
             sound_played = true;
             sp.make_sound( potential_target );
         }
@@ -1239,7 +1239,7 @@ void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &ta
                 guy->mutate_category( mutation_category_id( sp.effect_data() ) );
             }
         }
-        if (!sp.has_flag(spell_flag::DUPE_SOUND) && !sound_played) {
+        if (sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
             sound_played = true;
             sp.make_sound( potential_target );
         }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -487,7 +487,7 @@ static void damage_targets( const spell &sp, Creature &caster,
         if( !sp.is_valid_target( caster, target ) ) {
             continue;
         }
-        if (sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
+        if( sp.has_flag( spell_flag::DUPE_SOUND ) || !sound_played ) {
             sp.make_sound( target );
             sound_played = true;
         }
@@ -1029,7 +1029,7 @@ void spell_effect::spawn_summoned_monster( const spell &sp, Creature &caster,
         std::advance( iter, mon_spot );
         if( add_summoned_mon( mon_id, *iter, summon_time, sp ) ) {
             num_mons--;
-            if ( sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
+            if( sp.has_flag( spell_flag::DUPE_SOUND ) || !sound_played ) {
                 sound_played = true;
                 sp.make_sound( *iter );
             }
@@ -1106,7 +1106,7 @@ void spell_effect::vomit( const spell &sp, Creature &caster, const tripoint &tar
         if( !ch ) {
             continue;
         }
-        if ( sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
+        if( sp.has_flag( spell_flag::DUPE_SOUND ) || !sound_played ) {
             sound_played = true;
             sp.make_sound( target );
         }
@@ -1142,7 +1142,7 @@ void spell_effect::mod_moves( const spell &sp, Creature &caster, const tripoint 
         if( !critter ) {
             continue;
         }
-        if ( sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
+        if( sp.has_flag( spell_flag::DUPE_SOUND ) || !sound_played ) {
             sound_played = true;
             sp.make_sound( potential_target );
         }
@@ -1183,7 +1183,7 @@ void spell_effect::morale( const spell &sp, Creature &caster, const tripoint &ta
         }
         player_target->add_morale( morale_type( sp.effect_data() ), sp.damage(), 0, sp.duration_turns(),
                                    sp.duration_turns() / 10, false );
-        if (sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
+        if( sp.has_flag( spell_flag::DUPE_SOUND ) || !sound_played ) {
             sound_played = true;
             sp.make_sound( potential_target );
         }
@@ -1202,7 +1202,7 @@ void spell_effect::charm_monster( const spell &sp, Creature &caster, const tripo
         if( !mon ) {
             continue;
         }
-        if ( sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
+        if( sp.has_flag( spell_flag::DUPE_SOUND ) || !sound_played ) {
             sound_played = true;
             sp.make_sound( potential_target );
         }
@@ -1239,7 +1239,7 @@ void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &ta
                 guy->mutate_category( mutation_category_id( sp.effect_data() ) );
             }
         }
-        if (sp.has_flag(spell_flag::DUPE_SOUND) || !sound_played) {
+        if( sp.has_flag( spell_flag::DUPE_SOUND ) || !sound_played ) {
             sound_played = true;
             sp.make_sound( potential_target );
         }


### PR DESCRIPTION
## Purpose of change (The Why)

As Chaos pointed out in my PR to document the noise spell effect, spells were duplicating the noise they made. This seems rather silly to do by default, but some spells may want to do it intentionally.

## Describe the solution (The How)

- Adds a check to the playing of sound to make sure it doesn't play more than once by default
- Add a spell flag to let it play multiple times
  - Short-circuit the OR to make Oren happy
- Update docs

## Describe alternatives you've considered

- Make the spells play the sound once, period
- Not apply the change to summoning monsters since it makes decent sense to play multiple sounds there, and it's already under a few if statements.

## Testing

Compile-tested (of course)

Acid-bombed some flesh walls before and after the change. Before it gave me 45x hearing an explosion, after it gives me 1. 

## Additional context

Now the derg can in-theory remove the workaround on his spells.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
