### PR TITLE
feat(balance): more recipe use of brass

### DIFF
--- a/data/json/items/ammo/4570.json
+++ b/data/json/items/ammo/4570.json
@@ -27,7 +27,7 @@
     "copy-from": "4570_sp",
     "type": "AMMO",
     "name": { "str": ".45-70 +P penetrator" },
-    "description": ".45-70 Government +P ammunition loaded with a 305 grain solid copper penetrator projectile.  Designed for maximum penetration through thick hide and bone while maintaining ideal wounding characteristics.",
+    "description": ".45-70 Government +P ammunition loaded with a 305 grain solid copper or brass penetrator projectile.  Designed for maximum penetration through thick hide and bone while maintaining ideal wounding characteristics.",
     "price": "175 cent",
     "price_postapoc": "6 USD",
     "count": 10,

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -373,7 +373,12 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "bullet_forming", 15 ], [ "ammo_bullet", 8 ] ],
-    "components": [ [ [ "4570_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 17 ] ], [ [ "copper", 7 ] ] ]
+    "components": [
+      [ [ "4570_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 17 ] ],
+      [ [ "copper", 7 ], [ "cartridgebrass", 14 ] ]
+    ]
   },
   {
     "result": "4570_low",

--- a/data/json/recipes/ammo/shot.json
+++ b/data/json/recipes/ammo/shot.json
@@ -42,7 +42,7 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [
       [ [ "gunpowder", 8 ], [ "chem_black_powder", 10 ], [ "chem_match_head_powder", 10 ] ],
-      [ [ "scrap", 1 ], [ "nail", 10 ], [ "copper", 10 ], [ "lead", 10 ] ],
+      [ [ "scrap", 1 ], [ "nail", 10 ], [ "copper", 10 ], [ "lead", 10 ], [ "cartridgebrass", 20 ] ],
       [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ]
     ]
   },
@@ -329,6 +329,8 @@
         [ "lead", 7 ],
         [ "silver_small", 7 ],
         [ "bismuth", 7 ],
+        [ "copper", 7 ],
+        [ "cartridgebrass", 14 ],
         [ "shrapnel", 4 ]
       ]
     ]
@@ -361,6 +363,8 @@
         [ "lead", 7 ],
         [ "silver_small", 7 ],
         [ "lead", 7 ],
+        [ "copper", 7 ],
+        [ "cartridgebrass", 14 ],
         [ "shrapnel", 4 ]
       ]
     ]

--- a/data/json/recipes/other/containers.json
+++ b/data/json/recipes/other/containers.json
@@ -251,7 +251,11 @@
     "autolearn": true,
     "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 6 ] ], [ [ "copper_scrap_equivalent", 2, "LIST" ] ], [ [ "varnish", 3, "LIST" ] ] ]
+    "components": [
+      [ [ "2x4", 6 ] ],
+      [ [ "copper_scrap_equivalent", 2, "LIST" ], [ "cartridgebrass", 100 ] ],
+      [ [ "varnish", 3, "LIST" ] ]
+    ]
   },
   {
     "type": "recipe",
@@ -589,7 +593,7 @@
     "components": [
       [ [ "2x4", 2 ] ],
       [ [ "varnish", 1, "LIST" ] ],
-      [ [ "wire", 1 ], [ "scrap", 2 ], [ "copper_scrap_equivalent", 1, "LIST" ] ],
+      [ [ "wire", 1 ], [ "scrap", 2 ], [ "copper_scrap_equivalent", 1, "LIST" ], [ "cartridgebrass", 50 ] ],
       [ [ "fabric_standard", 2, "LIST" ], [ "felt_patch", 2 ], [ "fabric_hides_any", 2, "LIST" ] ]
     ]
   },

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -160,7 +160,7 @@
         [ "chem_aluminium_powder", 15 ],
         [ "can_drink_unsealed", 2 ]
       ],
-      [ [ "copper_scrap_equivalent", 4, "LIST" ] ]
+      [ [ "copper_scrap_equivalent", 4, "LIST" ], [ "cartridgebrass", 200 ] ]
     ]
   },
   {

--- a/data/json/uncraft/magazine/4570.json
+++ b/data/json/uncraft/magazine/4570.json
@@ -4,6 +4,6 @@
     "type": "uncraft",
     "copy-from": "metal_magazine",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "sheet_metal", 8 ] ], [ [ "steel_lump", 2 ] ] ]
+    "components": [ [ [ "cartridgebrass", 6000 ] ], [ [ "steel_lump", 4 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This makes more use of brass for stuff.

## Describe the solution (The How)

1. Allowed brass as an alternative to copper in the recipe for .45-70 penetrator, since it's flavored as using copper for the core instead of for a jacket, and IRL this is something one often uses brass for. Updated item description accordingly.
2. Allowed use of brass in the recipe for blunderbuss shot as an alternative to copper.
3. Added copper and brass as options for scrap shot.
4. Added brass as an alternative to copper in the recipes for small wooden barrels and wooden canteens.
5. Added brass as an alternative to copper in the hand press recipe.
6. Tweaked the uncraft for gatling drums to return brass and steel lumps equal to the item's weight, instead of getting 48 kilograms of sheet metal out of a 10-kg drum.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
