### PR TITLE
fix: negative crafting progress from eating

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3690,7 +3690,9 @@ void activity_handlers::craft_do_turn( player_activity *act, player *p )
     const double cur_total_moves = std::max( 1, rec.batch_time( craft->charges, crafting_speed,
                                    assistants ) );
     // Delta progress in moves adjusted for current crafting speed
-    const double delta_progress = p->get_moves() * base_total_moves / cur_total_moves;
+    const double delta_progress = p->get_moves() > 0
+                                  ? p->get_moves() * base_total_moves / cur_total_moves
+                                  : 0;
     // Current progress in moves
     const double current_progress = craft->item_counter * base_total_moves / 10'000'000.0 +
                                     delta_progress;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3208,7 +3208,7 @@ bool find_auto_consume( player &p, const consume_type type )
 
     // actually eat
     const auto cost = pickup::cost_to_move_item( p, **stalest );
-    const auto dist = std::max( rl_dist( p.pos(), here.getlocal( ( *stalest )->position() ) ), 1 );
+    const auto dist = std::max( rl_dist( p.pos(), ( *stalest )->position() ), 1 );
     p.mod_moves( -cost * dist );
 
     item *item_loc = &p.get_consumable_from( **stalest );

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -62,6 +62,8 @@
 #include "vehicle_selector.h"
 #include "vpart_position.h"
 
+static const trait_id trait_DEBUG_STORAGE( "DEBUG_STORAGE" );
+
 using item_count = std::pair<item *, int>;
 using pickup_map = std::map<std::string, item_count>;
 
@@ -1270,6 +1272,10 @@ int pickup::cost_to_move_item( const Character &who, const item &it )
         // No free hand? That will cost you extra
         ret += 20;
     }
+    if( who.has_trait( trait_DEBUG_STORAGE ) ) {
+        return ret;
+    }
+
     const int delta_weight = units::to_gram( it.weight() - who.weight_capacity() );
     // Is it too heavy? It'll take 10 moves per kg over limit
     ret += std::max( 0, delta_weight / 100 );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

fixes #6653
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

- Remove `getlocal()` from distance calculations, since `position()` already returns local coords and `getlocal()` creates some insane coordinates;
- Safeguard in crafting code, so delta does not go negative due to negative player `moves`;
- Protection from int_64 overflow due to `trait_DEBUG_STORAGE` in `cost_to_move_item()`.

## Describe alternatives you've considered

## Testing

- Compile;
- Start;
- Perform activities mentioned in issue;

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
