### PR TITLE
fix: use proper NO_RECOVER for all varnish. Revert all "UNRECOVERABLE" additions.

### DIFF
--- a/data/json/items/fuel.json
+++ b/data/json/items/fuel.json
@@ -210,7 +210,6 @@
     "symbol": "=",
     "color": "yellow",
     "material": "hydrocarbons",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "ammo_type": "motor_oil",
     "fuel": {
       "//": "Roughly equivalent to LPG",


### PR DESCRIPTION
## Purpose of change (The Why)

We made [motor oil and a lot of other stuff unrecoverable](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6589) to stop its recovery in varnish. This now makes it incredibly difficult to find oil for engines and motor crafting.

We weren't specifically aware of the use of "NO_RECOVER", but now that we are this is a huge problem.
## Describe the solution (The How)

Proper use of NO_RECOVER instead of indiscriminate application of no salvage and unrecoverable.

## Describe alternatives you've considered

None, but also:

Believable motor oil recipe and not varnishing with it.

## Testing

unnecessary

## Additional context

https://youtu.be/lcBUNSbMW3k?t=4509

## Checklist
### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.