### PR TITLE
fix(balance): varnish changes, undo #6589

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -149,7 +149,6 @@
     "volume": "250 ml",
     "weight": "90 g",
     "ammo_type": "soap",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "count": 10,
     "stack_size": 10
   },

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1020,7 +1020,6 @@
     "material": "powder",
     "volume": "250 ml",
     "weight": "1 g",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "ammo_type": "components",
     "container": "box_small",
     "count": 20
@@ -1035,10 +1034,9 @@
     "looks_like": "detergent",
     "symbol": "=",
     "color": "white",
-    "description": "A bar of soap cut into flakes, it can only be used for varnishing wood now.",
+    "description": "A bar of soap cut into flakes.",
     "volume": "250 ml",
     "weight": "1 g",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "ammo_type": "components",
     "count": 20
   },
@@ -1355,7 +1353,6 @@
     "fun": -15,
     "vitamins": [ [ "mutant_toxin", 240 ] ],
     "qualities": [ [ "SANDING", 1 ] ],
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "container": "box_small",
     "charges": 20
   }

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -929,7 +929,7 @@
     "charges": 2,
     "stack_size": 4,
     "fun": -18,
-    "flags": [ "UNSAFE_CONSUME", "NO_SALVAGE", "UNRECOVERABLE" ],
+    "flags": [ "UNSAFE_CONSUME" ],
     "vitamins": [ [ "meat_allergen", 1 ] ]
   },
   {

--- a/data/json/items/comestibles/drink_other.json
+++ b/data/json/items/comestibles/drink_other.json
@@ -204,7 +204,7 @@
     "charges": 16,
     "phase": "liquid",
     "fun": -25,
-    "flags": [ "NUTRIENT_OVERRIDE", "NO_SALVAGE", "UNRECOVERABLE" ],
+    "flags": [ "NUTRIENT_OVERRIDE" ],
     "vitamins": [ [ "veggy_allergen", 1 ] ]
   },
   {
@@ -229,7 +229,7 @@
     "charges": 16,
     "phase": "liquid",
     "fun": -25,
-    "flags": [ "NUTRIENT_OVERRIDE", "NO_SALVAGE", "UNRECOVERABLE" ],
+    "flags": [ "NUTRIENT_OVERRIDE" ],
     "vitamins": [ [ "meat_allergen", 1 ] ]
   },
   {

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -63,7 +63,6 @@
     "healthy": -1,
     "calories": 35,
     "description": "A large chunk of beeswax.  Not very tasty or nourishing, but okay in an emergency.",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "price": "15 USD",
     "price_postapoc": "10 cent",
     "volume": "250 ml",

--- a/data/json/items/fuel.json
+++ b/data/json/items/fuel.json
@@ -182,7 +182,6 @@
     "symbol": "=",
     "color": "yellow",
     "material": "hydrocarbons",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "ammo_type": "lamp_oil",
     "fuel": {
       "//": "Roughly equivalent to LPG",
@@ -210,7 +209,6 @@
     "symbol": "=",
     "color": "yellow",
     "material": "hydrocarbons",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "ammo_type": "motor_oil",
     "fuel": {
       "//": "Roughly equivalent to LPG",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -278,7 +278,7 @@
     "weight": "4500 mg",
     "volume": "25 ml",
     "to_hit": -2,
-    "flags": [ "UNRECOVERABLE", "NO_SALVAGE" ],
+    "flags": [ "UNRECOVERABLE" ],
     "stackable": true
   },
   {
@@ -288,7 +288,7 @@
     "category": "chems",
     "color": "brown",
     "name": { "str": "bone glue" },
-    "description": "Glue made from boiling animal bones.  The adhesive isn't strong enough for heavy-duty usages, but it can be used as a varnish or holding together small items.",
+    "description": "Glue made from boiling animal bones.  The adhesive isn't strong enough for heavy-duty usages, but it can be used to hold together small items.",
     "price": "18 USD",
     "price_postapoc": "50 cent",
     "material": [ "bone" ],

--- a/data/json/items/resources/home_improvement.json
+++ b/data/json/items/resources/home_improvement.json
@@ -12,7 +12,6 @@
     "material": "steel",
     "volume": "1250 ml",
     "weight": "10 g",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "ammo_type": "NULL",
     "count": 100
   },
@@ -29,7 +28,6 @@
     "material": "steel",
     "volume": "1250 ml",
     "weight": "10 g",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "ammo_type": "NULL",
     "count": 100
   },
@@ -46,7 +44,6 @@
     "material": "steel",
     "volume": "1250 ml",
     "weight": "10 g",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "ammo_type": "NULL",
     "count": 100
   },
@@ -63,7 +60,6 @@
     "material": "steel",
     "volume": "1250 ml",
     "weight": "10 g",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "ammo_type": "NULL",
     "count": 100
   },
@@ -80,7 +76,6 @@
     "material": "steel",
     "volume": "1250 ml",
     "weight": "10 g",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "ammo_type": "NULL",
     "count": 100
   },
@@ -97,7 +92,6 @@
     "material": "steel",
     "volume": "1250 ml",
     "weight": "10 g",
-    "flags": [ "NO_SALVAGE", "UNRECOVERABLE" ],
     "ammo_type": "NULL",
     "count": 100
   },

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -659,9 +659,9 @@
     "time": "1 h 30 m",
     "autolearn": true,
     "using": [ [ "forging_standard", 10 ], [ "steel_standard", 5 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 2 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 2 } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "2x4", 24 ] ], [ [ "varnish", 10, "LIST" ] ], [ [ "nail_glue", 40, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 24 ] ], [ [ "nail_glue", 40, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -253,11 +253,9 @@
     "time": "1 h",
     "book_learn": [ [ "scots_cookbook", 3 ] ],
     "using": [ [ "sewing_standard", 20 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "large_stomach_sealed", 1 ], [ "leather", 10 ], [ "fur", 10 ] ],
       [ [ "stick", 1 ], [ "2x4", 1 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "fabric_standard", 3, "LIST" ] ],
       [ [ "adhesive", 1, "LIST" ] ]
     ]
@@ -332,8 +330,8 @@
     "time": "1 h 30 m",
     "reversible": true,
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 2 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 4 ] ], [ [ "varnish", 2, "LIST" ] ], [ [ "nail_glue", 20, "LIST" ] ], [ [ "hinge", 2 ] ] ]
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 2 } ],
+    "components": [ [ [ "2x4", 4 ] ], [ [ "nail_glue", 20, "LIST" ] ], [ [ "hinge", 2 ] ] ]
   },
   {
     "result": "fish_bait",

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -9,7 +9,7 @@
     "time": "8 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "nail_glue", 8, "LIST" ] ], [ [ "2x4", 3 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "nail_glue", 8, "LIST" ] ], [ [ "2x4", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -494,11 +494,10 @@
     "reversible": true,
     "autolearn": true,
     "book_learn": [ [ "mag_survival", 1 ], [ "atomic_survival", 1 ], [ "textbook_carpentry", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
     "components": [
       [ [ "stick", 1 ], [ "2x4", 1 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "copper_scrap_equivalent", 40, "LIST" ] ],
       [ [ "cordage_short", 2, "LIST" ], [ "filament", 100, "LIST" ], [ "duct_tape", 40 ] ]
     ]
@@ -666,8 +665,8 @@
     "time": "1 h",
     "reversible": true,
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 12 ] ], [ [ "varnish", 6, "LIST" ] ], [ [ "nail_glue", 30, "LIST" ] ] ]
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
+    "components": [ [ [ "2x4", 12 ] ], [ [ "nail_glue", 30, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1080,8 +1079,7 @@
     "time": "2 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1093,8 +1091,7 @@
     "time": "1 h",
     "autolearn": true,
     "using": [ [ "forging_standard", 9 ], [ "bronzesmithing_tools", 1 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "scrap_bronze", 3 ] ] ]
+    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "scrap_bronze", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -1106,9 +1103,9 @@
     "time": "2 h 20 m",
     "autolearn": true,
     "using": [ [ "forging_standard", 12 ], [ "steel_standard", 2 ] ],
-    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
     "tools": [ [ [ "tongs", -1 ] ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ], [ "splinter", 6 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ], [ "splinter", 6 ] ] ]
   },
   {
     "type": "recipe",
@@ -1321,8 +1318,7 @@
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
     "book_learn": [ [ "manual_fabrication", 2 ], [ "textbook_fabrication", 3 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1334,8 +1330,8 @@
     "time": "2 m",
     "byproducts": [ [ "splinter", 4 ] ],
     "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "shovel", 1 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "shovel", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -1350,8 +1346,7 @@
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
     "book_learn": [ [ "manual_fabrication", 2 ], [ "textbook_fabrication", 3 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1378,8 +1373,7 @@
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 3 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ] ]
   },
   {
     "type": "recipe",
@@ -1393,8 +1387,7 @@
     "using": [ [ "blacksmithing_intermediate", 12 ], [ "steel_standard", 3 ] ],
     "book_learn": [ [ "textbook_fabrication", 4 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural_small", 3, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural_small", 3, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1407,8 +1400,7 @@
     "autolearn": true,
     "using": [ [ "forging_standard", 15 ], [ "bronzesmithing_tools", 1 ] ],
     "book_learn": [ [ "textbook_fabrication", 4 ], [ "textbook_weapwest", 4 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural_small", 3, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "scrap_bronze", 5 ] ] ]
+    "components": [ [ [ "wood_structural_small", 3, "LIST" ] ], [ [ "scrap_bronze", 5 ] ] ]
   },
   {
     "type": "recipe",
@@ -1422,8 +1414,7 @@
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1437,8 +1428,7 @@
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 32 ], [ "steel_standard", 8 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1453,8 +1443,7 @@
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 32 ], [ "steel_standard", 8 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1482,8 +1471,7 @@
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 32 ], [ "steel_standard", 20 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1497,8 +1485,7 @@
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 32 ], [ "steel_standard", 4 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -2501,8 +2488,7 @@
     "time": "1 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_advanced", 1 ], [ "steel_tiny", 1 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ] ]
   },
   {
     "result": "hand_pump",
@@ -2529,8 +2515,7 @@
     "time": "2 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_advanced", 6 ], [ "steel_standard", 1 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ] ]
   },
   {
     "result": "knife_paring",
@@ -2698,8 +2683,7 @@
     "time": "1 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_advanced", 1 ], [ "steel_tiny", 1 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 1 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -2743,7 +2727,6 @@
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "2x4", 18 ] ],
-      [ [ "varnish", 9, "LIST" ] ],
       [ [ "nail_glue", 14, "LIST" ] ],
       [ [ "sheet_metal", 1 ] ],
       [ [ "foot_crank", 1 ] ],
@@ -2816,8 +2799,7 @@
     "book_learn": [ [ "textbook_carpentry", 5 ], [ "textbook_fabrication", 6 ] ],
     "using": [ [ "blacksmithing_intermediate", 2 ], [ "steel_standard", 2 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ] ]
   },
   {
     "result": "still",

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -572,14 +572,9 @@
     "difficulty": 3,
     "time": "20 m",
     "book_learn": [ [ "textbook_fabrication", 5 ], [ "textbook_carpentry", 5 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "using": [ [ "sewing_standard", 100 ] ],
-    "components": [
-      [ [ "leather", 6 ], [ "fur", 6 ] ],
-      [ [ "wood_structural", 4, "LIST" ] ],
-      [ [ "varnish", 1, "LIST" ] ],
-      [ [ "rope_natural_short", 4, "LIST" ] ]
-    ]
+    "components": [ [ [ "leather", 6 ], [ "fur", 6 ] ], [ [ "wood_structural", 4, "LIST" ] ], [ [ "rope_natural_short", 4, "LIST" ] ] ]
   },
   {
     "result": "seatbelt",
@@ -950,8 +945,8 @@
     "time": "1 h",
     "reversible": true,
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 5 ] ], [ [ "varnish", 2, "LIST" ] ], [ [ "nail_glue", 15, "LIST" ] ] ]
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
+    "components": [ [ [ "2x4", 5 ] ], [ [ "nail_glue", 15, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -988,12 +983,11 @@
     "difficulty": 2,
     "time": "5 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
     "using": [ [ "sewing_standard", 100 ] ],
     "components": [
       [ [ "sheet", 2 ] ],
       [ [ "wood_structural", 2, "LIST" ] ],
-      [ [ "varnish", 2, "LIST" ] ],
       [ [ "rope_natural_short", 1, "LIST" ] ],
       [ [ "nail_glue", 20, "LIST" ] ]
     ]
@@ -1008,13 +1002,12 @@
     "difficulty": 4,
     "time": "50 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
     "using": [ [ "sewing_standard", 250 ] ],
     "components": [
       [ [ "sheet", 8 ] ],
       [ [ "wood_beam", 1 ] ],
       [ [ "wood_structural", 2, "LIST" ] ],
-      [ [ "varnish", 4, "LIST" ] ],
       [ [ "rope_natural", 1, "LIST" ] ],
       [ [ "nail_glue", 50, "LIST" ] ]
     ]
@@ -1082,14 +1075,8 @@
     "difficulty": 2,
     "time": "40 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [
-      [ [ "nail_glue", 4, "LIST" ] ],
-      [ [ "2x4", 2 ] ],
-      [ [ "stick", 2 ], [ "2x4", 2 ] ],
-      [ [ "varnish", 3, "LIST" ] ],
-      [ [ "towel", 3 ] ]
-    ]
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
+    "components": [ [ [ "nail_glue", 4, "LIST" ] ], [ [ "2x4", 2 ] ], [ [ "stick", 2 ], [ "2x4", 2 ] ], [ [ "towel", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -1332,8 +1319,8 @@
     "time": "6 m",
     "reversible": true,
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 5 ] ], [ [ "nail_glue", 20, "LIST" ] ], [ [ "varnish", 4, "LIST" ] ] ]
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "2x4", 5 ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1346,8 +1333,7 @@
     "reversible": true,
     "autolearn": true,
     "using": [ [ "rope_natural_short", 3 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 3 ], [ "stick", 6 ] ], [ [ "varnish", 3, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 3 ], [ "stick", 6 ] ] ]
   },
   {
     "type": "recipe",
@@ -1359,8 +1345,8 @@
     "time": "90 m",
     "reversible": true,
     "autolearn": true,
-    "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "DRILL", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 2 ] ], [ [ "varnish", 2, "LIST" ] ] ]
+    "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "DRILL", "level": 1 } ],
+    "components": [ [ [ "2x4", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -1372,8 +1358,8 @@
     "time": "6 m",
     "reversible": true,
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 5 ] ], [ [ "varnish", 4, "LIST" ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
+    "components": [ [ [ "2x4", 5 ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1385,8 +1371,8 @@
     "time": "12 m",
     "reversible": true,
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 5 ] ], [ [ "nail_glue", 30, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "scrap", 5 ] ] ]
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
+    "components": [ [ [ "2x4", 5 ] ], [ [ "nail_glue", 30, "LIST" ] ], [ [ "scrap", 5 ] ] ]
   },
   {
     "type": "recipe",
@@ -1398,12 +1384,7 @@
     "time": "6 m",
     "reversible": true,
     "autolearn": true,
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [
-      [ [ "2x4", 6 ] ],
-      [ [ "varnish", 5, "LIST" ] ],
-      [ [ "rope_natural_short", 1, "LIST" ], [ "nail", 5 ], [ "adhesive", 2, "LIST" ] ]
-    ]
+    "components": [ [ [ "2x4", 6 ] ], [ [ "rope_natural_short", 1, "LIST" ], [ "nail", 5 ], [ "adhesive", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1705,7 +1686,7 @@
     "decomp_learn": 1,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 4 ] ], [ [ "wood_panel", 1 ] ], [ [ "varnish", 2, "LIST" ] ], [ [ "nail_glue", 8, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 4 ] ], [ [ "wood_panel", 1 ] ], [ [ "nail_glue", 8, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1967,7 +1948,7 @@
     "time": "20 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "nail_glue", 4, "LIST" ] ], [ [ "stick", 2 ], [ "2x4", 2 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "nail_glue", 4, "LIST" ] ], [ [ "stick", 2 ], [ "2x4", 2 ] ] ]
   },
   {
     "result": "carbonfiber_boat_hull",

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -275,8 +275,7 @@
     "time": "8 h",
     "book_learn": [ [ "textbook_weapwest", 8 ], [ "recipe_melee", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 8 ], [ "steel_standard", 2 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "scrap", 24 ] ], [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "scrap", 24 ] ], [ [ "2x4", 1 ], [ "stick", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -306,9 +305,8 @@
     "difficulty": 4,
     "time": "3 h",
     "book_learn": [ [ "textbook_weapwest", 3 ], [ "recipe_melee", 4 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
     "using": [ [ "blacksmithing_intermediate", 12 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "2x4", 3 ], [ "stick", 6 ] ], [ [ "fabric_hides_any", 3, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 3 ], [ "stick", 6 ] ], [ [ "fabric_hides_any", 3, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -319,9 +317,8 @@
     "difficulty": 6,
     "time": "4 h",
     "book_learn": [ [ "textbook_weapwest", 5 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 16 ], [ "steel_standard", 4 ] ],
-    "components": [ [ [ "2x4", 3 ], [ "stick", 6 ] ], [ [ "fabric_hides_any", 3, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 3 ], [ "stick", 6 ] ], [ [ "fabric_hides_any", 3, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -358,9 +355,8 @@
     "difficulty": 7,
     "time": "6 h",
     "book_learn": [ [ "textbook_weapwest", 6 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 12 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "stick_long", 1 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ], [ [ "varnish", 3, "LIST" ] ] ]
+    "components": [ [ [ "stick_long", 1 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -386,9 +382,8 @@
     "difficulty": 7,
     "time": "7 h",
     "book_learn": [ [ "textbook_weapwest", 6 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 12 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "stick_long", 1 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ], [ [ "varnish", 2, "LIST" ] ] ]
+    "components": [ [ [ "stick_long", 1 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -402,7 +397,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "stick_long", 1 ] ], [ [ "fabric_hides_any", 5, "LIST" ] ], [ [ "varnish", 3, "LIST" ] ] ]
+    "components": [ [ [ "stick_long", 1 ] ], [ [ "fabric_hides_any", 5, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -468,15 +463,9 @@
     "difficulty": 4,
     "time": "30 m",
     "autolearn": true,
-    "qualities": [
-      { "id": "HAMMER", "level": 2 },
-      { "id": "CUT", "level": 1 },
-      { "id": "SAW_M", "level": 1 },
-      { "id": "SANDING", "level": 1 }
-    ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CUT", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [
       [ [ "shillelagh", 1 ], [ "bat", 1 ], [ "cudgel", 1 ], [ "wood_structural_small", 1, "LIST" ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "steel_tiny", 2, "LIST" ], [ "wire", 1 ] ],
       [ [ "wire_barbed", 1 ], [ "spike", 4 ], [ "nail", 20 ] ],
       [ [ "fabric_standard", 1, "LIST" ], [ "felt_patch", 1 ], [ "fabric_hides_any", 1, "LIST" ] ]
@@ -515,15 +504,9 @@
     "skills_required": [ [ "melee", 2 ] ],
     "time": "45 m",
     "autolearn": true,
-    "qualities": [
-      { "id": "HAMMER", "level": 2 },
-      { "id": "CUT", "level": 1 },
-      { "id": "SAW_M", "level": 1 },
-      { "id": "SANDING", "level": 1 }
-    ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CUT", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [
       [ [ "stick_long", 1 ], [ "q_staff", 1 ], [ "i_staff", 1 ], [ "pool_cue", 1 ], [ "broom", 1 ] ],
-      [ [ "varnish", 3, "LIST" ] ],
       [ [ "steel_standard", 1, "LIST" ], [ "canister_empty", 1 ] ],
       [ [ "steel_tiny", 2, "LIST" ], [ "wire", 1 ], [ "wire_barbed", 1 ] ],
       [ [ "wire", 1 ], [ "wire_barbed", 1 ], [ "spike", 4 ], [ "nail", 20 ] ],

--- a/data/json/recipes/weapon/cutting.json
+++ b/data/json/recipes/weapon/cutting.json
@@ -139,9 +139,9 @@
     "difficulty": 6,
     "time": "5 h",
     "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 4 ], [ "steel_standard", 1 ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -169,8 +169,8 @@
     "time": "6 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_advanced", 8 ], [ "steel_standard", 2 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -253,9 +253,9 @@
     "time": "7 h",
     "book_learn": [ [ "textbook_fireman", 8 ], [ "textbook_fabrication", 9 ] ],
     "using": [ [ "blacksmithing_intermediate", 16 ], [ "steel_standard", 4 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ] ]
   },
   {
     "type": "recipe",
@@ -266,9 +266,9 @@
     "difficulty": 6,
     "time": "7 h 40 m",
     "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 24 ], [ "steel_standard", 6 ] ],
-    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "varnish", 2, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ] ]
   },
   {
     "type": "recipe",
@@ -312,9 +312,9 @@
     "difficulty": 7,
     "time": "6 h 40 m",
     "book_learn": [ [ "textbook_weapwest", 6 ], [ "scots_cookbook", 8 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 12 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -325,9 +325,9 @@
     "difficulty": 8,
     "time": "8 h",
     "book_learn": [ [ "textbook_weapwest", 7 ], [ "scots_cookbook", 9 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 12 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -338,9 +338,9 @@
     "difficulty": 8,
     "time": "7 h",
     "book_learn": [ [ "textbook_weapwest", 7 ], [ "scots_cookbook", 9 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 12 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -352,7 +352,7 @@
     "time": "5 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_advanced", 12 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -376,14 +376,9 @@
     "difficulty": 8,
     "time": "8 h",
     "book_learn": [ [ "textbook_armschina", 7 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 12 ], [ "steel_standard", 3 ] ],
-    "components": [
-      [ [ "filament", 100, "LIST" ] ],
-      [ [ "2x4", 1 ], [ "stick", 2 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
-      [ [ "fabric_hides_any", 1, "LIST" ] ]
-    ]
+    "components": [ [ [ "filament", 100, "LIST" ] ], [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -394,9 +389,9 @@
     "difficulty": 8,
     "time": "7 h",
     "book_learn": [ [ "textbook_armschina", 7 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 12 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -407,9 +402,9 @@
     "difficulty": 8,
     "time": "7 h",
     "book_learn": [ [ "textbook_weapwest", 7 ], [ "scots_cookbook", 9 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 16 ], [ "steel_standard", 4 ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -420,9 +415,9 @@
     "difficulty": 9,
     "time": "8 h",
     "book_learn": [ [ "textbook_weapwest", 8 ], [ "scots_cookbook", 10 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 16 ], [ "steel_standard", 4 ] ],
-    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -433,9 +428,9 @@
     "difficulty": 8,
     "time": "7 h",
     "book_learn": [ [ "textbook_weapeast", 7 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 8 ], [ "steel_standard", 2 ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -446,9 +441,9 @@
     "difficulty": 9,
     "time": "8 h",
     "book_learn": [ [ "textbook_weapeast", 8 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 8 ], [ "steel_standard", 2 ] ],
-    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -459,9 +454,9 @@
     "difficulty": 10,
     "time": "9 h 40 m",
     "book_learn": [ [ "textbook_weapeast", 8 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 20 ], [ "steel_standard", 5 ] ],
-    "components": [ [ [ "2x4", 3 ], [ "stick", 6 ] ], [ [ "varnish", 2, "LIST" ] ], [ [ "fabric_hides_any", 3, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 3 ], [ "stick", 6 ] ], [ [ "fabric_hides_any", 3, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -495,12 +490,8 @@
     "time": "8 m",
     "autolearn": true,
     "using": [ [ "adhesive_proper", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [
-      [ [ "rock", 5 ], [ "ceramic_shard", 5 ], [ "sharp_rock", 5 ] ],
-      [ [ "wood_structural_small", 1, "LIST" ] ],
-      [ [ "varnish", 1, "LIST" ] ]
-    ]
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "rock", 5 ], [ "ceramic_shard", 5 ], [ "sharp_rock", 5 ] ], [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -512,8 +503,8 @@
     "time": "16 m",
     "autolearn": true,
     "using": [ [ "adhesive", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "razor_blade", 10 ] ], [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "razor_blade", 10 ] ], [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -525,8 +516,8 @@
     "time": "6 h",
     "book_learn": [ [ "textbook_weapwest", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 12 ], [ "steel_standard", 3 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "stick_long", 1 ] ], [ [ "varnish", 2, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "stick_long", 1 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -538,8 +529,8 @@
     "time": "7 h 40 m",
     "book_learn": [ [ "textbook_weapwest", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 8 ], [ "steel_standard", 2 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "stick_long", 1 ] ], [ [ "varnish", 2, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "stick_long", 1 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -551,8 +542,8 @@
     "time": "7 h 40 m",
     "book_learn": [ [ "textbook_weapeast", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 8 ], [ "steel_standard", 2 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "stick_long", 1 ] ], [ [ "varnish", 2, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "stick_long", 1 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -565,8 +556,8 @@
     "time": "46 m",
     "book_learn": [ [ "textbook_weapeast", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 5 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "katana", 1 ], [ "wakizashi", 1 ] ], [ [ "stick_long", 1 ] ], [ [ "varnish", 2, "LIST" ] ] ]
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "katana", 1 ], [ "wakizashi", 1 ] ], [ [ "stick_long", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -592,9 +583,9 @@
     "time": "13 h 20 m",
     "book_learn": [ [ "textbook_weapeast", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 20 ], [ "steel_standard", 5 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "//": "basically 2.5x the resources of a single machete to cover the fact that it's two weapons, each with a hand guard",
-    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 4, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "fabric_hides_any", 4, "LIST" ] ] ]
   },
   {
     "result": "cavalry_sabre",
@@ -605,9 +596,9 @@
     "difficulty": 8,
     "time": "420 m",
     "book_learn": [ [ "textbook_weapwest", 7 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 2 ], [ "steel_standard", 2 ] ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "result": "dao",
@@ -699,7 +690,7 @@
     "reversible": true,
     "autolearn": true,
     "book_learn": [ [ "mag_survival", 1 ], [ "atomic_survival", 1 ], [ "textbook_carpentry", 2 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "components": [
       [ [ "rock", 1 ], [ "ceramic_shard", 1 ], [ "sharp_rock", 1 ], [ "bone_sturdy", 1, "LIST" ], [ "bone_heavy", 1 ] ],
       [ [ "stick", 1 ], [ "2x4", 1 ] ],
@@ -726,7 +717,7 @@
     "reversible": true,
     "autolearn": true,
     "book_learn": [ [ "mag_survival", 1 ], [ "atomic_survival", 1 ], [ "textbook_carpentry", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "HAMMER", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
     "components": [
       [ [ "stick", 1 ], [ "2x4", 1 ] ],
@@ -879,8 +870,8 @@
     "time": "30 m",
     "autolearn": true,
     "using": [ [ "adhesive_proper", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "teeth_serrated", 5 ] ], [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "teeth_serrated", 5 ] ], [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -893,11 +884,10 @@
     "time": "30 m",
     "autolearn": true,
     "using": [ [ "adhesive_proper", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "components": [
       [ [ "bone_heavy", 2 ] ],
       [ [ "wood_structural_small", 1, "LIST" ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [
         [ "cordage_short", 2, "LIST" ],
         [ "filament", 100, "LIST" ],
@@ -920,11 +910,10 @@
     "time": "15 m",
     "autolearn": true,
     "using": [ [ "adhesive_proper", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "components": [
       [ [ "sword_bone", 1 ] ],
       [ [ "stick_long", 1 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
       [
         [ "cordage_short", 2, "LIST" ],
         [ "filament", 100, "LIST" ],

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -448,12 +448,10 @@
       { "id": "CUT", "level": 1 },
       { "id": "HAMMER", "level": 2 },
       { "id": "SCREW", "level": 1 },
-      { "id": "WRENCH", "level": 1 },
-      { "id": "SANDING", "level": 1 }
+      { "id": "WRENCH", "level": 1 }
     ],
     "components": [
       [ [ "2x4", 1 ], [ "stick", 2 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "cordage_superior_short", 1, "LIST" ] ],
       [ [ "spring", 1 ] ],
       [ [ "scrap", 4 ] ],
@@ -471,8 +469,8 @@
     "difficulty": 3,
     "time": "10 m",
     "autolearn": true,
-    "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 2 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "scrap", 1 ] ] ]
+    "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "SCREW", "level": 1 } ],
+    "components": [ [ [ "2x4", 2 ], [ "stick", 2 ] ], [ [ "scrap", 1 ] ] ]
   },
   {
     "result": "arredondo_chute",

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -117,11 +117,10 @@
     "time": "40 m",
     "reversible": true,
     "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
     "components": [
       [ [ "long_pole", 1 ] ],
-      [ [ "varnish", 4, "LIST" ] ],
       [ [ "fabric_standard", 1, "LIST" ], [ "felt_patch", 1 ], [ "fabric_hides_any", 1, "LIST" ] ],
       [ [ "duct_tape", 20 ], [ "cordage_short", 1, "LIST" ], [ "filament", 50, "LIST" ] ],
       [ [ "copper_scrap_equivalent", 12, "LIST" ] ]
@@ -318,15 +317,9 @@
     "time": "30 m",
     "reversible": true,
     "autolearn": true,
-    "qualities": [
-      { "id": "CUT", "level": 1 },
-      { "id": "HAMMER", "level": 1 },
-      { "id": "DRILL", "level": 1 },
-      { "id": "SANDING", "level": 1 }
-    ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "DRILL", "level": 1 } ],
     "components": [
       [ [ "stick_long", 1 ], [ "long_pole", 1 ], [ "pool_cue", 1 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
       [
         [ "knife_butcher", 1 ],
         [ "knife_chef", 1 ],
@@ -357,13 +350,8 @@
     "time": "30 m",
     "reversible": true,
     "autolearn": true,
-    "qualities": [
-      { "id": "CUT", "level": 1 },
-      { "id": "HAMMER", "level": 1 },
-      { "id": "DRILL", "level": 1 },
-      { "id": "SANDING", "level": 1 }
-    ],
-    "components": [ [ [ "spear_knife", 1 ] ], [ [ "cordage", 1, "LIST" ], [ "duct_tape", 50 ] ], [ [ "varnish", 2, "LIST" ] ] ]
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "DRILL", "level": 1 } ],
+    "components": [ [ [ "spear_knife", 1 ] ], [ [ "cordage", 1, "LIST" ], [ "duct_tape", 50 ] ] ]
   },
   {
     "type": "recipe",
@@ -458,8 +446,7 @@
     "time": "7 h",
     "book_learn": [ [ "textbook_weapwest", 8 ] ],
     "using": [ [ "blacksmithing_advanced", 8 ], [ "steel_standard", 2 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -591,8 +578,7 @@
     "time": "8 h 10 m",
     "book_learn": [ [ "textbook_weapwest", 7 ], [ "scots_cookbook", 9 ] ],
     "using": [ [ "blacksmithing_advanced", 16 ], [ "steel_standard", 4 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fabric_hides_any", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -604,8 +590,7 @@
     "time": "6 h 20 m",
     "book_learn": [ [ "textbook_weapeast", 6 ], [ "manual_knives", 7 ], [ "recipe_melee", 8 ] ],
     "using": [ [ "blacksmithing_advanced", 4 ], [ "steel_standard", 1 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 1 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 1 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -617,8 +602,7 @@
     "time": "6 h",
     "book_learn": [ [ "textbook_weapwest", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 8 ], [ "steel_standard", 2 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "long_pole", 1 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "components": [ [ [ "long_pole", 1 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -652,13 +636,7 @@
     "time": "7 h 40 m",
     "book_learn": [ [ "textbook_armschina", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 4 ], [ "steel_standard", 1 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [
-      [ [ "filament", 100, "LIST" ] ],
-      [ [ "stick_long", 1 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
-      [ [ "fabric_hides_any", 2, "LIST" ] ]
-    ]
+    "components": [ [ [ "filament", 100, "LIST" ] ], [ [ "stick_long", 1 ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -685,8 +663,7 @@
     "time": "6 h",
     "book_learn": [ [ "textbook_weapwest", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 3 ], [ "steel_tiny", 3 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ] ]
   },
   {
     "result": "fencing_foil_sharpened",
@@ -699,8 +676,7 @@
     "time": "6 h",
     "book_learn": [ [ "textbook_weapwest", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 2 ], [ "steel_tiny", 2 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ] ]
   },
   {
     "result": "fencing_sabre_sharpened",
@@ -713,8 +689,7 @@
     "time": "6 h",
     "book_learn": [ [ "textbook_weapwest", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 1 ], [ "steel_tiny", 1 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "sheet_metal_small", 1 ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "sheet_metal_small", 1 ] ] ]
   },
   {
     "result": "kirpan",
@@ -737,8 +712,7 @@
     "time": "10 h",
     "book_learn": [ [ "textbook_weapeast", 9 ] ],
     "using": [ [ "blacksmithing_advanced", 2 ], [ "steel_tiny", 2 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ] ]
   },
   {
     "result": "pitchfork",
@@ -750,8 +724,7 @@
     "time": "3 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_advanced", 2 ], [ "steel_tiny", 2 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "stick_long", 1 ] ], [ [ "varnish", 2, "LIST" ] ] ]
+    "components": [ [ [ "stick_long", 1 ] ] ]
   },
   {
     "result": "sword_cane",
@@ -763,8 +736,7 @@
     "time": "8 h",
     "book_learn": [ [ "textbook_weapwest", 8 ] ],
     "using": [ [ "blacksmithing_advanced", 3 ], [ "steel_tiny", 3 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ] ]
   },
   {
     "result": "spear_steel",
@@ -777,11 +749,9 @@
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 1 ], [ "steel_standard", 1 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "stick_long", 1 ] ],
       [ [ "filament", 100, "LIST" ] ],
-      [ [ "varnish", 2, "LIST" ] ],
       [ [ "fabric_standard", 2, "LIST" ], [ "felt_patch", 2 ], [ "fabric_hides_any", 2, "LIST" ] ]
     ]
   },
@@ -822,11 +792,10 @@
     "time": "3 h",
     "book_learn": [ [ "textbook_armschina", 5 ] ],
     "using": [ [ "forging_standard", 2 ], [ "bronzesmithing_tools", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "scrap_bronze", 4 ] ],
       [ [ "stick_long", 1 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
       [ [ "fabric_standard", 2, "LIST" ], [ "felt_patch", 2 ], [ "fabric_hides_any", 2, "LIST" ] ]
     ]
   },
@@ -840,11 +809,10 @@
     "time": "3 h",
     "book_learn": [ [ "textbook_weapwest", 4 ] ],
     "using": [ [ "forging_standard", 1 ], [ "bronzesmithing_tools", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "scrap_bronze", 2 ] ],
       [ [ "stick_long", 1 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
       [ [ "fabric_standard", 2, "LIST" ], [ "felt_patch", 2 ], [ "fabric_hides_any", 2, "LIST" ] ]
     ]
   },
@@ -873,8 +841,7 @@
     "book_learn": [ [ "textbook_weapwest", 3 ] ],
     "autolearn": true,
     "using": [ [ "blacksmithing_advanced", 4 ], [ "steel_standard", 1 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -887,13 +854,7 @@
     "book_learn": [ [ "textbook_weapwest", 3 ] ],
     "autolearn": true,
     "using": [ [ "forging_standard", 4 ], [ "bronzesmithing_tools", 1 ] ],
-    "qualities": [ { "id": "SANDING", "level": 1 } ],
-    "components": [
-      [ [ "wood_structural_small", 1, "LIST" ] ],
-      [ [ "varnish", 1, "LIST" ] ],
-      [ [ "fabric_hides_any", 2, "LIST" ] ],
-      [ [ "scrap_bronze", 2 ] ]
-    ]
+    "components": [ [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "fabric_hides_any", 2, "LIST" ] ], [ [ "scrap_bronze", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -989,8 +950,8 @@
     "time": "30 m",
     "autolearn": true,
     "using": [ [ "adhesive_proper", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "teeth_serrated", 2 ] ], [ [ "wood_structural_small", 1, "LIST" ] ], [ [ "varnish", 1, "LIST" ] ] ]
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "teeth_serrated", 2 ] ], [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1002,7 +963,7 @@
     "skills_required": [ [ "survival", 2 ] ],
     "time": "30 m",
     "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [
         [ "fabric_standard", 1, "LIST" ],
@@ -1011,7 +972,6 @@
         [ "cordage_short", 2, "LIST" ],
         [ "filament", 100, "LIST" ]
       ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "bee_sting", 1 ], [ "wasp_sting", 1 ] ]
     ]
   },
@@ -1025,7 +985,7 @@
     "skills_required": [ [ "survival", 2 ] ],
     "time": "30 m",
     "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [
         [ "fabric_standard", 1, "LIST" ],
@@ -1034,7 +994,6 @@
         [ "cordage_short", 2, "LIST" ],
         [ "filament", 100, "LIST" ]
       ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "fighter_sting", 1 ] ]
     ]
   },
@@ -1049,11 +1008,10 @@
     "time": "30 m",
     "autolearn": true,
     "using": [ [ "adhesive_proper", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "components": [
       [ [ "teeth_serrated", 2 ] ],
       [ [ "stick_long", 1 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
       [ [ "fabric_standard", 1, "LIST" ], [ "felt_patch", 1 ], [ "fabric_hides_any", 1, "LIST" ] ],
       [ [ "duct_tape", 20 ], [ "filament", 20, "LIST" ] ]
     ]
@@ -1068,11 +1026,10 @@
     "skills_required": [ [ "survival", 2 ] ],
     "time": "30 m",
     "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "bee_sting", 1 ], [ "wasp_sting", 1 ] ],
       [ [ "stick_long", 1 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
       [ [ "fabric_standard", 1, "LIST" ], [ "felt_patch", 1 ], [ "fabric_hides_any", 1, "LIST" ] ],
       [ [ "duct_tape", 20 ], [ "filament", 20, "LIST" ] ]
     ]
@@ -1087,11 +1044,10 @@
     "skills_required": [ [ "survival", 2 ] ],
     "time": "30 m",
     "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "fighter_sting", 1 ] ],
       [ [ "stick_long", 1 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
       [ [ "fabric_standard", 1, "LIST" ], [ "felt_patch", 1 ], [ "fabric_hides_any", 1, "LIST" ] ],
       [ [ "duct_tape", 20 ], [ "filament", 20, "LIST" ] ]
     ]

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -115,7 +115,7 @@
     "autolearn": true,
     "book_learn": [ [ "manual_archery", 2 ], [ "recipe_bows", 1 ], [ "book_archery", 3 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "stick_long", 1 ], [ "2x4", 1 ] ], [ [ "varnish", 2, "LIST" ] ], [ [ "cordage_superior", 2, "LIST" ] ] ]
+    "components": [ [ [ "stick_long", 1 ], [ "2x4", 1 ] ], [ [ "cordage_superior", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -143,7 +143,7 @@
     "autolearn": true,
     "book_learn": [ [ "recipe_bows", 1 ], [ "manual_archery", 2 ], [ "book_archery", 2 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "stick", 1 ], [ "2x4", 1 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "cordage_superior", 2, "LIST" ] ] ]
+    "components": [ [ [ "stick", 1 ], [ "2x4", 1 ] ], [ [ "cordage_superior", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -159,7 +159,6 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "stick", 3 ], [ "2x4", 2 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "bone_sturdy", 3, "LIST" ], [ "bone_heavy", 2 ] ],
       [ [ "adhesive_proper", 5, "LIST" ] ],
       [ [ "cordage_superior", 2, "LIST" ] ]
@@ -179,7 +178,7 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "stick_long", 1 ], [ "2x4", 3 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
+      [ [ "", 2, "LIST" ] ],
       [ [ "bone_sturdy", 4, "LIST" ], [ "bone_heavy", 2 ] ],
       [ [ "adhesive_proper", 5, "LIST" ] ],
       [ [ "cordage_superior", 2, "LIST" ] ]
@@ -296,7 +295,6 @@
     ],
     "components": [
       [ [ "2x4", 2 ], [ "stick", 3 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "cordage_superior_short", 1, "LIST" ] ],
       [ [ "spring", 1 ] ],
       [ [ "scrap", 4 ] ],
@@ -322,12 +320,7 @@
       [ "textbook_armschina", 5 ]
     ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [
-      [ [ "2x4", 2 ], [ "stick", 4 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
-      [ [ "scrap", 1 ] ],
-      [ [ "cordage_superior", 3, "LIST" ] ]
-    ]
+    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "", 2, "LIST" ] ], [ [ "scrap", 1 ] ], [ [ "cordage_superior", 3, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -353,7 +346,7 @@
     ],
     "components": [
       [ [ "stick", 5 ], [ "2x4", 3 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
+      [ [ "", 2, "LIST" ] ],
       [ [ "bone_sturdy", 3, "LIST" ], [ "bone_heavy", 2 ] ],
       [ [ "adhesive_proper", 5, "LIST" ] ],
       [ [ "cordage_superior", 1, "LIST" ] ]
@@ -371,13 +364,7 @@
     "decomp_learn": 2,
     "book_learn": [ [ "recipe_bows", 1 ], [ "manual_archery", 3 ], [ "book_archery", 2 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [
-      [ [ "2x4", 2 ], [ "stick", 4 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
-      [ [ "scrap", 1 ] ],
-      [ [ "cordage_superior", 3, "LIST" ] ],
-      [ [ "leather", 1 ] ]
-    ]
+    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "scrap", 1 ] ], [ [ "cordage_superior", 3, "LIST" ] ], [ [ "leather", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -417,7 +404,7 @@
     "time": "12 m",
     "autolearn": true,
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "pipe", 1 ] ], [ [ "2x4", 1 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "scrap", 2 ] ], [ [ "pilot_light", 1 ] ] ]
+    "components": [ [ [ "pipe", 1 ] ], [ [ "2x4", 1 ] ], [ [ "scrap", 2 ] ], [ [ "pilot_light", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -505,14 +492,7 @@
       { "id": "WRENCH", "level": 1 },
       { "id": "SANDING", "level": 1 }
     ],
-    "components": [
-      [ [ "pipe", 2 ] ],
-      [ [ "spring", 1 ] ],
-      [ [ "steel_chunk", 3 ] ],
-      [ [ "2x4", 1 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
-      [ [ "scrap", 3 ] ]
-    ]
+    "components": [ [ [ "pipe", 2 ] ], [ [ "spring", 1 ] ], [ [ "steel_chunk", 3 ] ], [ [ "2x4", 1 ] ], [ [ "scrap", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -702,7 +682,7 @@
     ],
     "components": [
       [ [ "2x4", 8 ], [ "stick", 16 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
+      [ [ "", 2, "LIST" ] ],
       [ [ "rope_superior_short", 2, "LIST" ] ],
       [ [ "foot_crank", 1 ] ],
       [ [ "spring", 4 ] ],
@@ -729,7 +709,7 @@
     ],
     "components": [
       [ [ "2x4", 4 ], [ "stick", 8 ] ],
-      [ [ "varnish", 2, "LIST" ] ],
+      [ [ "", 2, "LIST" ] ],
       [ [ "spring", 1 ] ],
       [ [ "cordage_superior", 1, "LIST" ] ],
       [ [ "nail_glue", 20, "LIST" ] ]
@@ -933,7 +913,7 @@
     "book_learn": [ [ "manual_rifle", 5 ], [ "mag_rifle", 6 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 4 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "2x4", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "pipe", 1 ] ], [ [ "sharp_rock", 1 ] ] ]
+    "components": [ [ [ "2x4", 2 ] ], [ [ "pipe", 1 ] ], [ [ "sharp_rock", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -948,7 +928,7 @@
     "book_learn": [ [ "manual_rifle", 5 ], [ "mag_rifle", 6 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 6 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "2x4", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "pipe", 1 ] ], [ [ "sharp_rock", 1 ] ] ]
+    "components": [ [ [ "2x4", 2 ] ], [ [ "pipe", 1 ] ], [ [ "sharp_rock", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -963,7 +943,7 @@
     "book_learn": [ [ "manual_rifle", 5 ], [ "mag_rifle", 6 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 3 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "2x4", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "pipe", 1 ] ], [ [ "sharp_rock", 1 ] ] ]
+    "components": [ [ [ "2x4", 2 ] ], [ [ "pipe", 1 ] ], [ [ "sharp_rock", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -978,7 +958,7 @@
     "book_learn": [ [ "manual_pistol", 5 ], [ "mag_pistol", 6 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "using": [ [ "blacksmithing_advanced", 2 ], [ "steel_standard", 3 ] ],
-    "components": [ [ [ "2x4", 1 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "pipe", 1 ] ], [ [ "sharp_rock", 1 ] ] ]
+    "components": [ [ [ "2x4", 1 ] ], [ [ "pipe", 1 ] ], [ [ "sharp_rock", 1 ] ] ]
   },
   {
     "result": "carbine_flintlock_double",
@@ -998,7 +978,7 @@
       { "id": "SANDING", "level": 1 }
     ],
     "using": [ [ "forging_standard", 2 ], [ "steel_standard", 1 ] ],
-    "components": [ [ [ "2x4", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "pipe", 2 ] ], [ [ "sharp_rock", 2 ] ] ]
+    "components": [ [ [ "2x4", 2 ] ], [ [ "pipe", 2 ] ], [ [ "sharp_rock", 2 ] ] ]
   },
   {
     "result": "carbine_flintlock_double",
@@ -1026,7 +1006,7 @@
     "time": "60 m",
     "autolearn": true,
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 2 ], [ "stick", 2 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "hose", 4 ] ], [ [ "scrap", 4 ] ] ]
+    "components": [ [ [ "2x4", 2 ], [ "stick", 2 ] ], [ [ "hose", 4 ] ], [ [ "scrap", 4 ] ] ]
   },
   {
     "type": "recipe",
@@ -1039,7 +1019,7 @@
     "time": "90 m",
     "autolearn": true,
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 3 ], [ "stick", 3 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "hose", 8 ] ], [ [ "scrap", 6 ] ] ]
+    "components": [ [ [ "2x4", 3 ], [ "stick", 3 ] ], [ [ "hose", 8 ] ], [ [ "scrap", 6 ] ] ]
   },
   {
     "type": "recipe",
@@ -1052,7 +1032,7 @@
     "time": "45 m",
     "autolearn": true,
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 1 ] ], [ [ "varnish", 1, "LIST" ] ], [ [ "hose", 2 ] ], [ [ "scrap", 3 ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 1 ] ], [ [ "hose", 2 ] ], [ [ "scrap", 3 ] ] ]
   },
   {
     "result": "helsing",
@@ -1075,7 +1055,6 @@
       [ [ "pipe", 8 ] ],
       [ [ "adhesive", 1, "LIST" ] ],
       [ [ "2x4", 1 ], [ "stick", 1 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "metal_tank_little", 1 ] ],
       [ [ "steel_chunk", 3 ], [ "scrap", 9 ] ]
     ]
@@ -1101,7 +1080,6 @@
       [ [ "pipe", 4 ] ],
       [ [ "adhesive", 1, "LIST" ] ],
       [ [ "2x4", 1 ], [ "stick", 1 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "metal_tank_little", 1 ] ],
       [ [ "steel_chunk", 3 ], [ "scrap", 9 ] ]
     ]
@@ -1127,7 +1105,6 @@
       [ [ "pipe", 3 ] ],
       [ [ "adhesive", 1, "LIST" ] ],
       [ [ "2x4", 1 ], [ "stick", 1 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "metal_tank_little", 1 ] ],
       [ [ "steel_chunk", 4 ], [ "scrap", 12 ] ]
     ]
@@ -1153,7 +1130,6 @@
       [ [ "pipe", 2 ], [ "rebar", 2 ] ],
       [ [ "duct_tape", 200 ] ],
       [ [ "2x4", 2 ], [ "stick", 2 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "spring", 2 ] ],
       [ [ "steel_chunk", 3 ], [ "scrap", 9 ] ]
     ]
@@ -1179,7 +1155,6 @@
     "components": [
       [ [ "cable", 140 ] ],
       [ [ "2x4", 1 ], [ "stick", 1 ] ],
-      [ [ "varnish", 1, "LIST" ] ],
       [ [ "power_supply", 2 ] ],
       [ [ "steel_chunk", 3 ], [ "scrap", 18 ] ],
       [ [ "rebar", 1 ], [ "pipe", 1 ] ],

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -178,7 +178,6 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "stick_long", 1 ], [ "2x4", 3 ] ],
-      [ [ "", 2, "LIST" ] ],
       [ [ "bone_sturdy", 4, "LIST" ], [ "bone_heavy", 2 ] ],
       [ [ "adhesive_proper", 5, "LIST" ] ],
       [ [ "cordage_superior", 2, "LIST" ] ]
@@ -320,7 +319,7 @@
       [ "textbook_armschina", 5 ]
     ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "", 2, "LIST" ] ], [ [ "scrap", 1 ] ], [ [ "cordage_superior", 3, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "scrap", 1 ] ], [ [ "cordage_superior", 3, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -346,7 +345,6 @@
     ],
     "components": [
       [ [ "stick", 5 ], [ "2x4", 3 ] ],
-      [ [ "", 2, "LIST" ] ],
       [ [ "bone_sturdy", 3, "LIST" ], [ "bone_heavy", 2 ] ],
       [ [ "adhesive_proper", 5, "LIST" ] ],
       [ [ "cordage_superior", 1, "LIST" ] ]
@@ -682,7 +680,6 @@
     ],
     "components": [
       [ [ "2x4", 8 ], [ "stick", 16 ] ],
-      [ [ "", 2, "LIST" ] ],
       [ [ "rope_superior_short", 2, "LIST" ] ],
       [ [ "foot_crank", 1 ] ],
       [ [ "spring", 4 ] ],
@@ -709,7 +706,6 @@
     ],
     "components": [
       [ [ "2x4", 4 ], [ "stick", 8 ] ],
-      [ [ "", 2, "LIST" ] ],
       [ [ "spring", 1 ] ],
       [ [ "cordage_superior", 1, "LIST" ] ],
       [ [ "nail_glue", 20, "LIST" ] ]

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -336,7 +336,6 @@
         [ "cooking_oil", 8 ],
         [ "cooking_oil2", 8 ],
         [ "lamp_oil", 100 ],
-        [ "motor_oil", 100 ],
         [ "r_paint", 10 ],
         [ "b_paint", 10 ],
         [ "w_paint", 10 ],
@@ -348,7 +347,6 @@
         [ "wax", 1 ],
         [ "soap", 1 ],
         [ "soap_flakes", 1 ],
-        [ "detergent", 1 ],
         [ "shimmer", 1 ]
       ]
     ]


### PR DESCRIPTION
Varnish and sanding were applied far too liberally when I first designed them, and the later PR to try and prevent them from being salvaged broke engine salvaging; this PR reverts most of the changes caused by the latter, removes sanding and varnish from almost everything but specifically wooden non-reversable items, and changes descriptions to not mention varnish.

<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
Varnish was applied far too much for items that barely had any wood to them, and my attempts to correct the varnish being gotten back from uncrafting wooden items broke engine salvaging.
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Varnish as an ingredient has been removed from all items that are not purely wooden and that can be uncrafted, and sanding as a tool quality has similarly been removed from most recipes. Varnish has been removed from the description of multiple items. And finally, this PR undoes PR #6589 .
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
