### PR TITLE
docs: Add linux dependencies to readme, inform users of where 3rd-party mods go

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ For flatpak users, the user mods folder is ~/.var/app/org.cataclysmbn.CataclysmB
 
 #### How do I update the game manually?
 
-Assuming you've managed your mods appropriately, the correct update process is to delete the old data folder (alongside the gfx folder if you want to be extra safe) and *then* overwrite the contents of the old BN folder with the new BN download. Deleting the old data folder is specifically necessary due to the fact that simply overwriting the old folder will **not** account for deleted files, as may happen with the obsoletion folder for example.
+Assuming you've managed your mods appropriately, the correct update process is to delete the old data folder (alongside the gfx folder if you want to be extra safe) and *then* overwrite the contents of the old BN folder with the new BN download. Deleting the old data folder is specifically necessary due to the fact that simply overwriting the old folder will **not** account for updates which delete files, as may happen with the obsoletion folder for example.
 
 Don't delete your saves folder, memorial, graveyard, etc.!
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ For a manual installation, you should create a mods folder in the root BN folder
 
 For Catapult, you would put them in bn/userdata/mods (creating the folder if it's not already there) inside your catapult installation. For example, it might look like Catapult/bn/userdata/mods.
 
-For Linux users using the XDG directories (but NOT the flatpak): The user mods directory should be in ~~/.local/share/cataclysm-bn/mods (~~/.local/share/cataclysm-bn is the user directory in general)
+For Linux users using the XDG directories (but NOT the flatpak): The user mods directory should be in `~/.local/share/cataclysm-bn/mods` (`~/.local/share/cataclysm-bn` is the user directory in general)
 
-For flatpak users, the user mods folder is ~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/mods (the user directory in general is ~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/)
+For flatpak users, the user mods folder is `~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/mods` (the user directory in general is `~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/`)
 
 #### How do I update the game manually?
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 While many of the dependencies that the game depends on are likely installed by default, some likely aren't installed by default on your distro.
 
 Here are the commands for some of the most popular distro families:
-- Ubuntu / Debian: `sudo apt install libsdl2-image libsdl2-ttf libsdl2-mixer libfreetype6 zip libsqlite3-0`
+- Ubuntu / Debian: `sudo apt install libsdl2-image-2.0.0 libsdl2-ttf-2.0.0 libsdl2-mixer-2.0.0 libfreetype6 zip libsqlite3-0`
 - Fedora: `sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype zip sqlite`
 - Arch: `sudo pacman -S sdl2 sdl2_image sdl2_ttf sdl2_mixer zip sqlite`
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The primary supported launcher is [Catapult](https://github.com/qrrk/Catapult), 
 [experimental-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/experimental
 [experimental-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?style=for-the-badge&color=salmon&label=Experimental%20Release&include_prereleases&sort=date
 [flathub-releases]: https://flathub.org/apps/org.cataclysmbn.CataclysmBN
-[flathub-badge]: https://img.shields.io/flathub/v/org.cataclysmbn.CataclysmBN?color=success
+[flathub-badge]: https://img.shields.io/flathub/v/org.cataclysmbn.CataclysmBN?style=for-the-badge&color=success
 [source]: https://github.com/cataclysmbnteam/Cataclysm-BN/archive/master.zip "The source can be downloaded as a .zip archive"
 [source-badge]: https://img.shields.io/badge/Zip%20Archive-black?style=for-the-badge&logo=github
 [clone]: https://github.com/cataclysmbnteam/Cataclysm-BN/ "clone from our GitHub repo"

--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 While many of the dependencies that the game depends on are likely installed by default, some likely aren't installed by default on your distro.
 
 Here are the commands for some of the most popular distro families:
+
 - Ubuntu / Debian: `sudo apt install libsdl2-image-2.0.0 libsdl2-ttf-2.0.0 libsdl2-mixer-2.0.0 libfreetype6 zip libsqlite3-0`
 - Fedora: `sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype zip sqlite`
 - Arch: `sudo pacman -S sdl2 sdl2_image sdl2_ttf sdl2_mixer zip sqlite`
 
 ### Launchers
-The primary supported launcher is [Catapult](https://github.com/qrrk/Catapult), which can handle both BN and DDA (it defaults to DDA, so be sure to change it in the top menu!)
 
+The primary supported launcher is [Catapult](https://github.com/qrrk/Catapult), which can handle both BN and DDA (it defaults to DDA, so be sure to change it in the top menu!)
 
 ### Source Code
 
@@ -133,13 +134,13 @@ For a manual installation, you should create a mods folder in the root BN folder
 
 For Catapult, you would put them in bn/userdata/mods (creating the folder if it's not already there) inside your catapult installation. For example, it might look like Catapult/bn/userdata/mods.
 
-For Linux users using the XDG directories (but NOT the flatpak): The user mods directory should be in ~/.local/share/cataclysm-bn/mods (~/.local/share/cataclysm-bn is the user directory in general)
+For Linux users using the XDG directories (but NOT the flatpak): The user mods directory should be in ~~/.local/share/cataclysm-bn/mods (~~/.local/share/cataclysm-bn is the user directory in general)
 
 For flatpak users, the user mods folder is ~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/mods (the user directory in general is ~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/)
 
 #### How do I update the game manually?
 
-Assuming you've managed your mods appropriately, the correct update process is to delete the old data folder (alongside the gfx folder if you want to be extra safe) and *then* overwrite the contents of the old BN folder with the new BN download. Deleting the old data folder is specifically necessary due to the fact that simply overwriting the old folder will **not** account for updates which delete files, as may happen with the obsoletion folder for example.
+Assuming you've managed your mods appropriately, the correct update process is to delete the old data folder (alongside the gfx folder if you want to be extra safe) and _then_ overwrite the contents of the old BN folder with the new BN download. Deleting the old data folder is specifically necessary due to the fact that simply overwriting the old folder will **not** account for updates which delete files, as may happen with the obsoletion folder for example.
 
 Don't delete your saves folder, memorial, graveyard, etc.!
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,20 @@ Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 
 ### Executables
 
-[![Stable][stable-releases-badge]][stable-releases] [![Recent][all-releases-badge]][all-releases] [![Experiemental][experimental-badge]][experimental-releases]
+[![Stable][stable-releases-badge]][stable-releases] [![Recent][all-releases-badge]][all-releases] [![Experiemental][experimental-badge]][experimental-releases] [![Flatpak][flathub-badge]][flathub-releases]
+
+#### Linux Instructions
+
+While many of the dependencies that the game depends on are likely installed by default, some likely aren't installed by default on your distro.
+
+Here are the commands for some of the most popular distro families:
+- Ubuntu / Debian: `sudo apt install libsdl2-image libsdl2-ttf libsdl2-mixer libfreetype6 zip libsqlite3-0`
+- Fedora: `sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype zip sqlite`
+- Arch: `sudo pacman -S sdl2 sdl2_image sdl2_ttf sdl2_mixer zip sqlite`
+
+### Launchers
+The primary supported launcher is [Catapult](https://github.com/qrrk/Catapult), which can handle both BN and DDA (it defaults to DDA, so be sure to change it in the top menu!)
+
 
 ### Source Code
 
@@ -44,6 +57,8 @@ Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 [all-releases-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?style=for-the-badge&color=important&label=Latest%20Release&include_prereleases&sort=date
 [experimental-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/experimental
 [experimental-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?style=for-the-badge&color=salmon&label=Experimental%20Release&include_prereleases&sort=date
+[flathub-releases]: https://flathub.org/apps/org.cataclysmbn.CataclysmBN
+[flathub-badge]: https://img.shields.io/flathub/v/org.cataclysmbn.CataclysmBN?color=success
 [source]: https://github.com/cataclysmbnteam/Cataclysm-BN/archive/master.zip "The source can be downloaded as a .zip archive"
 [source-badge]: https://img.shields.io/badge/Zip%20Archive-black?style=for-the-badge&logo=github
 [clone]: https://github.com/cataclysmbnteam/Cataclysm-BN/ "clone from our GitHub repo"
@@ -109,6 +124,26 @@ you wish to assign to that action.
 #### How can I start a new world?
 
 **World** on the main menu will generate a fresh world for you. Select **Create World**.
+
+#### Where should I put 3rd-party mods?
+
+Where you put the third party mods depends on whether you installed manually or with Catapult. No matter which you do, 3rd party mods do **not** go in data/mods. That folder should be reserved for in-repo mods only, especially given Catapult will automatically delete the contents of that folder!
+
+For a manual installation, you should create a mods folder in the root BN folder to store your mods. Thus, instead of putting them in cataclysm-bn/data/mods, you'd put them in cataclysm-bn/mods (Case should not matter)
+
+For Catapult, you would put them in bn/userdata/mods (creating the folder if it's not already there) inside your catapult installation. For example, it might look like Catapult/bn/userdata/mods.
+
+For Linux users using the XDG directories (but NOT the flatpak): The user mods directory should be in ~/.local/share/cataclysm-bn/mods (~/.local/share/cataclysm-bn is the user directory in general)
+
+For flatpak users, the user mods folder is ~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/mods (the user directory in general is ~/.var/app/org.cataclysmbn.CataclysmBN/data/cataclysm-bn/)
+
+#### How do I update the game manually?
+
+Assuming you've managed your mods appropriately, the correct update process is to delete the old data folder (alongside the gfx folder if you want to be extra safe) and *then* overwrite the contents of the old BN folder with the new BN download. Deleting the old data folder is specifically necessary due to the fact that simply overwriting the old folder will **not** account for deleted files, as may happen with the obsoletion folder for example.
+
+Don't delete your saves folder, memorial, graveyard, etc.!
+
+Alternatively, you can always use the Catapult launcher and let it handle updating. It has a good track record of correctly updating the vanilla game.
 
 #### I've found a bug. What should I do?
 


### PR DESCRIPTION
## Purpose of change (The Why)

SDL2 dependencies seem to often be missing for fresh Linux users
People think that they should put their 3rd party mods in the same mods folder as the in-repo mods
People do not know how to correctly update the game manually
We didn't talk about launchers before now
We didn't have a link to the flatpak in the readme

## Describe the solution (The How)

Adds onto the readme.md file

## Describe alternatives you've considered

Make someone else do it

## Testing

I read it over again, and it looks good. I also used my branch to preview it on Github, and looks good there too

## Additional context

Open to changes being suggested

Scarf or someone else will have to update the Korean readme in the future, given I do not know Korean.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
