### PR TITLE
feat: Add a historical recipe for the `crucible` item

### DIFF
--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -3147,5 +3147,20 @@
       [ [ "paper", 1 ], [ "rag", 1 ] ],
       [ [ "adhesive_proper", 1, "LIST" ] ]
     ]
+  },
+  {
+    "type": "recipe",
+    "result": "crucible",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "autolearn": true,
+    "book_learn": [ [ "concrete_book", 5 ], [ "textbook_armwest", 5 ], [ "textbook_weapwest", 5 ] ],
+    "time": "2 h",
+    "using": [ [ "forging_standard", 10 ] ],
+    "//": "Mullite is created by firing kaolinite clay at very high temeperatures.",
+    "components": [ [ [ "clay_lump", 6 ] ], [ [ "material_sand", 60 ] ] ],
+    "//2": "Sand was used in the actual recipes that scientists re-discovered."
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

We had no valid crafting recipe for the normal crucible recipe, and we may want to differentiate between the poor-quality clay crucible and a good quality crucible in the future.

Historically, the Hessians made crucibles with very high temperature maximums that were popular for alchemy and the like through the use of mullite. Mullite is obtained by firing kaolinite clay at very high temperatures.

## Describe the solution (The How)

- Adds a recipe based on the re-discovered hessian method.

## Describe alternatives you've considered

- Graphite crucible
- Advanced ceramics crucible
- Leave it loot-only
- Use aluminum powder as well to cover all the bases

## Testing

Load-tested.

## Additional context

[Wikipedia Article](https://en.wikipedia.org/wiki/Hessian_crucible)
[Actual paper abstract](https://ceramics.onlinelibrary.wiley.com/doi/10.1111/j.1551-2916.2008.02383.x)

I like doing these things the fun, unexpected, but entirely plausible way. Plus, this one has the bonus of being historical AND therefore also being a valid recipe for Innawoods.

Recipe included in the concrete book because it just seemed fun and gave that book more use.

And yes, Massachusetts *does* have natural kaolinite deposits.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
