### PR TITLE
fix: fix healthy tests, additionally slow down health normalization

### DIFF
--- a/src/catalua_bindings_creature.cpp
+++ b/src/catalua_bindings_creature.cpp
@@ -374,14 +374,14 @@ void cata::detail::reg_character( sol::state &lua )
         SET_FX_T( mod_per_bonus, void( int ) );
         SET_FX_T( mod_int_bonus, void( int ) );
 
-        SET_FX_T( get_healthy, int() const );
-        SET_FX_T( get_healthy_mod, int() const );
+        SET_FX_T( get_healthy, float() const );
+        SET_FX_T( get_healthy_mod, float() const );
 
-        SET_FX_T( mod_healthy, void( int ) );
-        SET_FX_T( mod_healthy_mod, void( int, int ) );
+        SET_FX_T( mod_healthy, void( float ) );
+        SET_FX_T( mod_healthy_mod, void( float, float ) );
 
-        SET_FX_T( set_healthy, void( int ) );
-        SET_FX_T( set_healthy_mod, void( int ) );
+        SET_FX_T( set_healthy, void( float ) );
+        SET_FX_T( set_healthy_mod, void( float ) );
 
         SET_FX_T( get_stored_kcal, int() const );
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4639,11 +4639,11 @@ int Character::ranged_per_mod() const
     return std::max( ( 20.0 - get_per() ) * 1.2, 0.0 );
 }
 
-int Character::get_healthy() const
+float Character::get_healthy() const
 {
     return healthy;
 }
-int Character::get_healthy_mod() const
+float Character::get_healthy_mod() const
 {
     return healthy_mod;
 }
@@ -4740,11 +4740,11 @@ std::string enum_to_string<character_stat>( character_stat data )
 }
 } // namespace io
 
-void Character::set_healthy( int nhealthy )
+void Character::set_healthy( float nhealthy )
 {
     healthy = nhealthy;
 }
-void Character::mod_healthy( int nhealthy )
+void Character::mod_healthy( float nhealthy )
 {
     float mut_rate = 1.0f;
     for( const trait_id &mut : get_mutations() ) {
@@ -4752,11 +4752,11 @@ void Character::mod_healthy( int nhealthy )
     }
     healthy += nhealthy * mut_rate;
 }
-void Character::set_healthy_mod( int nhealthy_mod )
+void Character::set_healthy_mod( float nhealthy_mod )
 {
     healthy_mod = nhealthy_mod;
 }
-void Character::mod_healthy_mod( int nhealthy_mod, int cap )
+void Character::mod_healthy_mod( float nhealthy_mod, float cap )
 {
     // TODO: This really should be a full morale-like system, with per-effect caps
     //       and durations.  This version prevents any single effect from exceeding its
@@ -4768,13 +4768,13 @@ void Character::mod_healthy_mod( int nhealthy_mod, int cap )
     if( nhealthy_mod == 0 || cap == 0 ) {
         return;
     }
-    int low_cap;
-    int high_cap;
+    float low_cap;
+    float high_cap;
     if( nhealthy_mod < 0 ) {
         low_cap = cap;
-        high_cap = 200 * 10000;
+        high_cap = 200;
     } else {
-        low_cap = -200 * 10000;
+        low_cap = -200;
         high_cap = cap;
     }
 
@@ -5043,7 +5043,7 @@ std::string Character::get_weight_string() const
 
 int Character::get_max_healthy() const
 {
-    return 200 * 10000;
+    return 200;
 }
 
 void Character::regen( int rate_multiplier )
@@ -5132,35 +5132,36 @@ void Character::update_health( int external_modifiers )
 {
     if( has_artifact_with( AEP_SICK ) ) {
         // Carrying a sickness artifact makes your health 50 points worse on average
-        external_modifiers -= 50 * 10000;
+        external_modifiers -= 50;
     }
     // Limit healthy_mod to [-200, 200].
     // This also sets approximate bounds for the character's health.
     if( get_healthy_mod() > get_max_healthy() ) {
         set_healthy_mod( get_max_healthy() );
-    } else if( get_healthy_mod() < -200 * 10000) {
-        set_healthy_mod( -200 * 10000);
+    } else if( get_healthy_mod() < -200 ) {
+        set_healthy_mod( -200 );
     }
 
     // Active leukocyte breeder will keep your health near 100
-    int effective_healthy_mod = get_healthy_mod();
+    float effective_healthy_mod = get_healthy_mod();
     if( has_active_bionic( bio_leukocyte ) ) {
         // Side effect: dependency
-        mod_healthy_mod( -50 * 10000, -200 * 10000);
-        effective_healthy_mod = 100 * 10000;
+        mod_healthy_mod( -50, -200 );
+        effective_healthy_mod = 100;
     }
 
     // Health tends toward healthy_mod.
     // For small differences, it changes 4 points per day
     // For large ones, up to ~40% of the difference per day
-    int health_change = effective_healthy_mod - get_healthy() + external_modifiers;
-    mod_healthy( sgn( health_change ) * std::max<int>( 1, std::abs( health_change ) * (1 - 0.9971) ) );
+    float health_change = effective_healthy_mod - get_healthy() + external_modifiers;
+    mod_healthy( health_change * ( 1 - 0.9971 ) );
 
     // And healthy_mod decays over time.
     // Slowly near 0, but it's hard to overpower it near +/-100
-    set_healthy_mod( std::round( get_healthy_mod() * 0.9955f ) );
+    set_healthy_mod( get_healthy_mod() * 0.9955f );
 
-    add_msg( m_debug, "Health: %d, Health mod: %d", get_healthy(), get_healthy_mod() );
+    add_msg( m_debug, "Health: %d, Health mod: %d", static_cast<int>( get_healthy() ),
+             static_cast<int>( get_healthy_mod() ) );
 }
 
 // Returns the number of multiples of tick_length we would "pass" on our way `from` to `to`

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4772,9 +4772,9 @@ void Character::mod_healthy_mod( int nhealthy_mod, int cap )
     int high_cap;
     if( nhealthy_mod < 0 ) {
         low_cap = cap;
-        high_cap = 200;
+        high_cap = 200 * 10000;
     } else {
-        low_cap = -200;
+        low_cap = -200 * 10000;
         high_cap = cap;
     }
 
@@ -5043,7 +5043,7 @@ std::string Character::get_weight_string() const
 
 int Character::get_max_healthy() const
 {
-    return 200;
+    return 200 * 10000;
 }
 
 void Character::regen( int rate_multiplier )
@@ -5132,22 +5132,22 @@ void Character::update_health( int external_modifiers )
 {
     if( has_artifact_with( AEP_SICK ) ) {
         // Carrying a sickness artifact makes your health 50 points worse on average
-        external_modifiers -= 50;
+        external_modifiers -= 50 * 10000;
     }
     // Limit healthy_mod to [-200, 200].
     // This also sets approximate bounds for the character's health.
     if( get_healthy_mod() > get_max_healthy() ) {
         set_healthy_mod( get_max_healthy() );
-    } else if( get_healthy_mod() < -200 ) {
-        set_healthy_mod( -200 );
+    } else if( get_healthy_mod() < -200 * 10000) {
+        set_healthy_mod( -200 * 10000);
     }
 
     // Active leukocyte breeder will keep your health near 100
     int effective_healthy_mod = get_healthy_mod();
     if( has_active_bionic( bio_leukocyte ) ) {
         // Side effect: dependency
-        mod_healthy_mod( -50, -200 );
-        effective_healthy_mod = 100;
+        mod_healthy_mod( -50 * 10000, -200 * 10000);
+        effective_healthy_mod = 100 * 10000;
     }
 
     // Health tends toward healthy_mod.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5154,11 +5154,11 @@ void Character::update_health( int external_modifiers )
     // For small differences, it changes 4 points per day
     // For large ones, up to ~40% of the difference per day
     int health_change = effective_healthy_mod - get_healthy() + external_modifiers;
-    mod_healthy( sgn( health_change ) * std::max( 1, std::abs( health_change ) / 10 ) );
+    mod_healthy( sgn( health_change ) * std::max<int>( 1, std::abs( health_change ) * (1 - 0.9971) ) );
 
     // And healthy_mod decays over time.
     // Slowly near 0, but it's hard to overpower it near +/-100
-    set_healthy_mod( std::round( get_healthy_mod() * 0.95f ) );
+    set_healthy_mod( std::round( get_healthy_mod() * 0.9955f ) );
 
     add_msg( m_debug, "Health: %d, Health mod: %d", get_healthy(), get_healthy_mod() );
 }

--- a/src/character.h
+++ b/src/character.h
@@ -366,16 +366,16 @@ class Character : public Creature, public location_visitable<Character>
         void print_health() const;
 
         /** Getters for health values exclusive to characters */
-        virtual int get_healthy() const;
-        virtual int get_healthy_mod() const;
+        virtual float get_healthy() const;
+        virtual float get_healthy_mod() const;
 
         /** Modifiers for health values exclusive to characters */
-        virtual void mod_healthy( int nhealthy );
-        virtual void mod_healthy_mod( int nhealthy_mod, int cap );
+        virtual void mod_healthy( float nhealthy );
+        virtual void mod_healthy_mod( float nhealthy_mod, float cap );
 
         /** Setters for health values exclusive to characters */
-        virtual void set_healthy( int nhealthy );
-        virtual void set_healthy_mod( int nhealthy_mod );
+        virtual void set_healthy( float nhealthy );
+        virtual void set_healthy_mod( float nhealthy_mod );
 
         /** Getter for need values exclusive to characters */
         int get_stored_kcal() const;
@@ -2258,8 +2258,8 @@ class Character : public Creature, public location_visitable<Character>
         int int_bonus = 0;
 
         /** How healthy the character is. */
-        int healthy = 0;
-        int healthy_mod = 0;
+        float healthy = 0;
+        float healthy_mod = 0;
 
         /** age in years at character creation */
         int init_age = 25;

--- a/tests/health_test.cpp
+++ b/tests/health_test.cpp
@@ -15,13 +15,17 @@ static void test_diet( const time_duration &dur, npc &dude,
 {
     std::vector<int> health_samples;
     for( time_duration i = 0_turns; i < dur; i += 1_days ) {
-        const size_t index = to_days<int>( i ) % 4;
-        // They lightly correspond to breakfast, dinner, supper, night snack
-        // No, they don't. The correspond to one meal each day.
-        dude.mod_healthy_mod( hmod_changes_per_day[ index ],
-                              sgn( hmod_changes_per_day[ index ] ) * 200 );
-        dude.update_health();
-        health_samples.emplace_back( dude.get_healthy() );
+        // 'Eat' every 6 hours
+        for( size_t index = 0u; index < 4u; ++index ) {
+            // They lightly correspond to breakfast, dinner, supper, night snack
+            dude.mod_healthy_mod( hmod_changes_per_day[ index ] * 10000,
+                                  sgn( hmod_changes_per_day[ index ] ) * 200 * 10000 );
+            // And update health every 30m over the 6h period
+            for( time_duration n = 0_turns; n < 6_hours; n += 30_minutes ) {
+                dude.update_health();
+            }
+            health_samples.emplace_back( dude.get_healthy() / 10000 );
+        }
     }
 
     std::stringstream ss;
@@ -29,8 +33,8 @@ static void test_diet( const time_duration &dur, npc &dude,
         ss << i << ", ";
     }
     INFO( "Health samples: " << ss.str() );
-    CHECK( dude.get_healthy() >= min );
-    CHECK( dude.get_healthy() <= max );
+    CHECK( dude.get_healthy() / 10000 >= min );
+    CHECK( dude.get_healthy() / 10000 <= max );
 }
 
 // Maximum possible health in feasible environment
@@ -81,7 +85,7 @@ TEST_CASE( "fasting_breakfast", "[health]" )
 TEST_CASE( "recovering_health", "[health]" )
 {
     standard_npc dude( "recovering junk eater" );
-    dude.set_healthy( -100 );
+    dude.set_healthy( -100 * 10000 );
     // Beans and rice * 3 + broccoli = 3 * 1 + 2 healthy
     // 3 meals per day
     // Just a week should be enough to stop dying, but not enough to get healthy

--- a/tests/health_test.cpp
+++ b/tests/health_test.cpp
@@ -18,13 +18,13 @@ static void test_diet( const time_duration &dur, npc &dude,
         // 'Eat' every 6 hours
         for( size_t index = 0u; index < 4u; ++index ) {
             // They lightly correspond to breakfast, dinner, supper, night snack
-            dude.mod_healthy_mod( hmod_changes_per_day[ index ] * 10000,
-                                  sgn( hmod_changes_per_day[ index ] ) * 200 * 10000 );
+            dude.mod_healthy_mod( hmod_changes_per_day[ index ],
+                                  sgn( hmod_changes_per_day[ index ] ) * 200 );
             // And update health every 30m over the 6h period
             for( time_duration n = 0_turns; n < 6_hours; n += 30_minutes ) {
                 dude.update_health();
             }
-            health_samples.emplace_back( dude.get_healthy() / 10000 );
+            health_samples.emplace_back( dude.get_healthy() );
         }
     }
 
@@ -33,8 +33,8 @@ static void test_diet( const time_duration &dur, npc &dude,
         ss << i << ", ";
     }
     INFO( "Health samples: " << ss.str() );
-    CHECK( dude.get_healthy() / 10000 >= min );
-    CHECK( dude.get_healthy() / 10000 <= max );
+    CHECK( dude.get_healthy() >= min );
+    CHECK( dude.get_healthy() <= max );
 }
 
 // Maximum possible health in feasible environment
@@ -85,7 +85,7 @@ TEST_CASE( "fasting_breakfast", "[health]" )
 TEST_CASE( "recovering_health", "[health]" )
 {
     standard_npc dude( "recovering junk eater" );
-    dude.set_healthy( -100 * 10000 );
+    dude.set_healthy( -100 );
     // Beans and rice * 3 + broccoli = 3 * 1 + 2 healthy
     // 3 meals per day
     // Just a week should be enough to stop dying, but not enough to get healthy


### PR DESCRIPTION
## Purpose of change (The Why)
Healthy tests `tests/health_test.cpp` are not reflective of actual health normalization. This is because they simulate a diet eating once a day, and updating health once a day. This is malformed in multiple ways.
1. The test is supposed to simulate up to 4 meals a day, but actually does a single meal per day
2. Simulates a single health update instead of the actual update rate of once per 30 minutes (48 times per day).
Because of both issues the values used as multipliers to dampen `healthy` value toward `healthy_mod` is far too aggressive, moving it by 10% per call, and slightly too aggressive when dampening `healthy_mod` towards zero (0).

## Describe the solution (The How)
@RoyalFox2140 brought this to my attention as a long standing thorn in the side as being far too fast to move around. 
A number floated was that it should take around 5 days to move halfway to the `healthy_mod` value, if that value was constant.

Given that suggested time frame:
- There are 48 calls to `update_health` per day normally.
- Over 5 days this makes 240 calls
- reducing by half over 240 calls gives us a multiplier of `240th root of 0.5` which is around `0.9971` (magic number n.1)
- Since we are using the value as a parameter to `mod_healthy` we need to do a `1 - 0.9971` calculation first before multiplying.

`max( 1, {calculated mod value} )` forces `healthy` to be changed by at least `1` per call, which significantly reduces the amount of time to converge toward `healthy_mod`, and introduces inaccuracies. I think it was used so that there's always some progress toward convergence which is not guaranteed when using `int` values. Our expected range is pretty small `[-200...+200]` so floating point accuracy will be pretty good with a maximum epsilon of `1.52588e-05`.

After changing over to the slower convergence of `1 - 0.9971` from `/ 10` and making the tests actually simulate the full number of `update_health` calls throughout a day the tests were failing due to `healthy_mod` not damping at the correct rate.
I changed the dampening rate multiplier from `0.95` to `0.9955` (magic number n.2)

## Describe alternatives you've considered
Create a new unit for health to support an expanded domain for better precision while continuing to use integer math. The primary reason I did not go with this is the scope of the change expanded far beyond just fixing tests and making `healthy[_mod]` change more slowly.

## Testing
Tests work and do so in an expected way. Changing `INFO` to `WARN` at `tests/health_test.cpp:35` to output the test statistics showed reasonable results.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.