### PR TITLE
fix(mods/MagicalNights): Manually specify enchanted boot materials as leather and steel

### DIFF
--- a/data/mods/MagicalNights/items/enchanted/enchanted_boots.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted_boots.json
@@ -4,6 +4,7 @@
     "type": "ARMOR",
     "copy-from": "boots_hiking",
     "name": { "str": "seven league boots", "str_pl": "pairs of seven league boots" },
+    "material": [ "leather", "steel" ],
     "looks_like": "boots_hiking",
     "description": "Rugged yet extremely comfortable and well fitting boots of worn leather and steel, they look like they've seen a lot of use and will likely see a lot more.  They make your movement a lot less work.",
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "MOVE_COST", "add": -30 } ] } ] },
@@ -18,6 +19,7 @@
     "type": "ARMOR",
     "copy-from": "boots_hiking",
     "name": { "str": "boots of haste", "str_pl": "pairs of boots of haste" },
+    "material": [ "leather", "steel" ],
     "looks_like": "boots_hiking",
     "description": "Rugged yet extremely comfortable and well fitting boots of worn leather and steel, they look like they've seen a lot of use and will likely see a lot more.  They make your movement a lot less work.",
     "relic_data": {
@@ -42,6 +44,7 @@
     "initial_charges": 24,
     "max_charges": 24,
     "charges_per_use": 24,
+    "material": [ "leather", "steel" ],
     "artifact_data": { "charge_type": "ARTC_TIME" },
     "use_action": { "type": "cast_spell", "spell_id": "magus_escape", "no_fail": true, "level": 10, "need_worn": true },
     "encumbrance": 8,


### PR DESCRIPTION
## Purpose of change (The Why)

Description mentions steel, instead contained plastics because hiking boots are plastic (and have been for 9 years)

## Describe the solution (The How)

Instead of changing the hiking boots to be steel, change the enchanted boots to override material because that's less intrusive

## Describe alternatives you've considered

- Make hiking boots steel instead of plastic

I would love to, and if that solution is preferred for vanilla BN too then I'll gladly do that instead.
However, I thought maybe it was that way to increase distinction from steel-toed boots.

## Testing

ctrl-c ctrl-v, looked over my changes

## Additional context

I have no idea why whoever made the boots in Magiclysm thought they were made out of steel.

Not giving steel to the boots of grounding for thematic effect and because steel is a conductor.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.