### PR TITLE
fix(mods/MagicalNights): Fix missing `alloy_padded` option for tailor's kits

### DIFF
--- a/data/mods/MagicalNights/items/enchanted/enchanted_misc.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted_misc.json
@@ -181,12 +181,13 @@
         "clothing_mods": [
           "leather_padded",
           "steel_padded",
+          "alloy_padded",
           "kevlar_padded",
+          "nomex_padded",
           "furred",
+          "wooled",
           "resized_large",
           "pocketed",
-          "nomex_padded",
-          "wooled",
           "owlbear_furred",
           "demonchitin_padded",
           "blackdragon_coated"

--- a/data/mods/MagicalNights/items/tools.json
+++ b/data/mods/MagicalNights/items/tools.json
@@ -155,12 +155,13 @@
         "clothing_mods": [
           "leather_padded",
           "steel_padded",
+          "alloy_padded",
           "kevlar_padded",
+          "nomex_padded",
           "furred",
           "wooled",
           "resized_large",
           "pocketed",
-          "nomex_padded",
           "owlbear_furred",
           "demonchitin_padded",
           "blackdragon_coated"


### PR DESCRIPTION
## Purpose of change (The Why)

It was brought to my attention that the tailors kits weren't letting you pad with superalloy in MN. Oops.

I also moved the nomex padding option just to align the ordering with vanilla and so it's obvious to anyone in the future if MN is missing one properly.

## Describe the solution (The How)

- Add the alloy_padded option back
- move nomex_padded

## Describe alternatives you've considered

- Just add alloy_padded
- Do nothing
- Look into how a previous PR might allow me to extend use_actions

I probably should, but I also get the feeling this wouldn't be what it actually enabled.

## Testing

Lints
ctrl-c ctrl-v hopefully doesn't let me down

## Additional context

It is pretty annoying that registering new repairable materials and the like seems to necessitate overriding the use_action.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
