### PR TITLE
feat: Allow for spell damage to be augmented by melee weapon damage

### DIFF
--- a/data/mods/TEST_DATA/magic.json
+++ b/data/mods/TEST_DATA/magic.json
@@ -22,6 +22,28 @@
     "energy_source": "MANA"
   },
   {
+    "id": "test_spell_pew_melee",
+    "type": "SPELL",
+    "name": "Pew, Pew, MELEE",
+    "description": "You aim your finger at your opponent and make 'Pew, pew' sounds, then punch the opponent.",
+    "effect": "target_attack",
+    "damage_type": "true",
+    "valid_targets": [ "hostile" ],
+    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS", "ADD_MELEE_DAM" ],
+    "max_level": 10,
+    "min_damage": 1,
+    "max_damage": 5,
+    "damage_increment": 1,
+    "min_range": 10,
+    "max_range": 30,
+    "range_increment": 2,
+    "spell_class": "NONE",
+    "difficulty": 1,
+    "base_casting_time": 100,
+    "base_energy_cost": 50,
+    "energy_source": "MANA"
+  },
+  {
     "type": "ter_furn_transform",
     "id": "test_lava_terrain",
     "terrain": [ { "result": "t_lava", "diggable": true } ]

--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -143,6 +143,8 @@ experience you need to get to a level is below:
 
 - `DUPE_SOUND` - Allows a spell to play multiple of the same sound (i.e. a sound for each target affected)
 
+- `ADD_MELEE_DAM` - Adds the highest category of melee damage for your currently wielded item to the spell's damage
+
 - `NO_FAIL` - this spell cannot fail when you cast it
 
 #### Currently Implemented Effects and special rules

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -511,29 +511,30 @@ int spell::damage() const
     }
 }
 
-int spell::damage_as_character(const Character &guy) const {
+int spell::damage_as_character( const Character &guy ) const
+{
     // Open-ended for the purposes of further expansion
     float total_damage = damage();
-    if (has_flag(spell_flag::ADD_MELEE_DAM)) {
-        item& weapon = guy.used_weapon();
+    if( has_flag( spell_flag::ADD_MELEE_DAM ) ) {
+        item &weapon = guy.used_weapon();
         int weapon_damage = 0;
-        if (!weapon.is_null()) {
+        if( !weapon.is_null() ) {
             // Just take the max, rather than worrying about how to integrate the other damage types
             // Also assumes that weapons aren't dealing other damage types
-            weapon_damage = std::max({weapon.damage_melee(DT_STAB), weapon.damage_melee(DT_CUT), weapon.damage_melee(DT_BASH)});
+            weapon_damage = std::max( {weapon.damage_melee( DT_STAB ), weapon.damage_melee( DT_CUT ), weapon.damage_melee( DT_BASH )} );
         }
         total_damage += weapon_damage;
     }
 
-    return std::round(total_damage);
+    return std::round( total_damage );
 }
 
-std::string spell::damage_string(const Character &guy) const
+std::string spell::damage_string( const Character &guy ) const
 {
     if( has_flag( spell_flag::RANDOM_DAMAGE ) ) {
         return string_format( "%d-%d", min_leveled_damage(), type->max_damage );
     } else {
-        const int dmg = damage_as_character(guy);
+        const int dmg = damage_as_character( guy );
         if( dmg >= 0 ) {
             return string_format( "%d", dmg );
         } else {
@@ -1251,17 +1252,17 @@ dealt_damage_instance spell::get_dealt_damage_instance() const
     return dmg;
 }
 
-damage_instance spell::get_damage_instance(const Character &guy) const
+damage_instance spell::get_damage_instance( const Character &guy ) const
 {
     damage_instance dmg;
-    dmg.add_damage( dmg_type(), damage_as_character(guy) );
+    dmg.add_damage( dmg_type(), damage_as_character( guy ) );
     return dmg;
 }
 
-dealt_damage_instance spell::get_dealt_damage_instance(const Character &guy) const
+dealt_damage_instance spell::get_dealt_damage_instance( const Character &guy ) const
 {
     dealt_damage_instance dmg;
-    dmg.set_damage( dmg_type(), damage_as_character(guy) );
+    dmg.set_damage( dmg_type(), damage_as_character( guy ) );
     return dmg;
 }
 
@@ -1764,8 +1765,8 @@ static std::string enumerate_spell_data( const spell &sp )
     if( sp.has_flag( spell_flag::BRAWL ) ) {
         spell_data.emplace_back( _( "can be used by Brawlers" ) );
     }
-    if (sp.has_flag(spell_flag::ADD_MELEE_DAM)) {
-        spell_data.emplace_back(_("can be augmented by melee weapon damage"));
+    if( sp.has_flag( spell_flag::ADD_MELEE_DAM ) ) {
+        spell_data.emplace_back( _( "can be augmented by melee weapon damage" ) );
     }
     return enumerate_as_string( spell_data );
 }
@@ -1878,18 +1879,18 @@ void spellcasting_callback::draw_spell_info( const spell &sp, const uilist *menu
         line++;
     }
 
-    const int damage = sp.damage_as_character(g->u);
+    const int damage = sp.damage_as_character( g->u );
     std::string damage_string;
     std::string aoe_string;
     // if it's any type of attack spell, the stats are normal.
     if( fx == "target_attack" || fx == "projectile_attack" || fx == "cone_attack" ||
         fx == "line_attack" ) {
         if( damage > 0 ) {
-            damage_string = string_format( "%s: %s %s", _( "Damage" ), colorize( sp.damage_string(g->u),
+            damage_string = string_format( "%s: %s %s", _( "Damage" ), colorize( sp.damage_string( g->u ),
                                            sp.damage_type_color() ),
                                            colorize( sp.damage_type_string(), sp.damage_type_color() ) );
         } else if( damage < 0 ) {
-            damage_string = string_format( "%s: %s", _( "Healing" ), colorize( sp.damage_string(g->u),
+            damage_string = string_format( "%s: %s", _( "Healing" ), colorize( sp.damage_string( g->u ),
                                            light_green ) );
         }
         if( sp.aoe() > 0 ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -105,6 +105,7 @@ std::string enum_to_string<spell_flag>( spell_flag data )
         case spell_flag::WONDER: return "WONDER";
         case spell_flag::BRAWL: return "BRAWL";
         case spell_flag::DUPE_SOUND: return "DUPE_SOUND";
+        case spell_flag::ADD_MELEE_DAM: return "ADD_MELEE_DAM";
         case spell_flag::LAST: break;
     }
     debugmsg( "Invalid spell_flag" );
@@ -508,6 +509,20 @@ int spell::damage() const
             return std::max( leveled_damage, type->max_damage );
         }
     }
+}
+
+int spell::damage_as_character(const Character &guy) const {
+    float total_damage = damage();
+    if (has_flag(spell_flag::ADD_MELEE_DAM)) {
+        item& weapon = guy.used_weapon();
+        int weapon_damage = 0;
+        if (!weapon.is_null()) {
+            weapon_damage = std::max({weapon.damage_melee(DT_STAB), weapon.damage_melee(DT_CUT), weapon.damage_melee(DT_BASH)});
+        }
+        total_damage += weapon_damage;
+    }
+
+    return std::round(total_damage);
 }
 
 std::string spell::damage_string() const

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -514,7 +514,7 @@ int spell::damage() const
 int spell::damage_as_character( const Character &guy ) const
 {
     // Open-ended for the purposes of further expansion
-    float total_damage = damage();
+    double total_damage = damage();
     if( has_flag( spell_flag::ADD_MELEE_DAM ) ) {
         item &weapon = guy.used_weapon();
         int weapon_damage = 0;

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1764,6 +1764,9 @@ static std::string enumerate_spell_data( const spell &sp )
     if( sp.has_flag( spell_flag::BRAWL ) ) {
         spell_data.emplace_back( _( "can be used by Brawlers" ) );
     }
+    if (sp.has_flag(spell_flag::ADD_MELEE_DAM)) {
+        spell_data.emplace_back(_("can be augmented by melee weapon damage"));
+    }
     return enumerate_as_string( spell_data );
 }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1251,6 +1251,20 @@ dealt_damage_instance spell::get_dealt_damage_instance() const
     return dmg;
 }
 
+damage_instance spell::get_damage_instance(const Character &guy) const
+{
+    damage_instance dmg;
+    dmg.add_damage( dmg_type(), damage_as_character(guy) );
+    return dmg;
+}
+
+dealt_damage_instance spell::get_dealt_damage_instance(const Character &guy) const
+{
+    dealt_damage_instance dmg;
+    dmg.set_damage( dmg_type(), damage_as_character(guy) );
+    return dmg;
+}
+
 std::string spell::effect_data() const
 {
     return type->effect_str;
@@ -1861,7 +1875,7 @@ void spellcasting_callback::draw_spell_info( const spell &sp, const uilist *menu
         line++;
     }
 
-    const int damage = sp.damage();
+    const int damage = sp.damage_as_character(g->u);
     std::string damage_string;
     std::string aoe_string;
     // if it's any type of attack spell, the stats are normal.

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -512,11 +512,14 @@ int spell::damage() const
 }
 
 int spell::damage_as_character(const Character &guy) const {
+    // Open-ended for the purposes of further expansion
     float total_damage = damage();
     if (has_flag(spell_flag::ADD_MELEE_DAM)) {
         item& weapon = guy.used_weapon();
         int weapon_damage = 0;
         if (!weapon.is_null()) {
+            // Just take the max, rather than worrying about how to integrate the other damage types
+            // Also assumes that weapons aren't dealing other damage types
             weapon_damage = std::max({weapon.damage_melee(DT_STAB), weapon.damage_melee(DT_CUT), weapon.damage_melee(DT_BASH)});
         }
         total_damage += weapon_damage;
@@ -525,12 +528,12 @@ int spell::damage_as_character(const Character &guy) const {
     return std::round(total_damage);
 }
 
-std::string spell::damage_string() const
+std::string spell::damage_string(const Character &guy) const
 {
     if( has_flag( spell_flag::RANDOM_DAMAGE ) ) {
         return string_format( "%d-%d", min_leveled_damage(), type->max_damage );
     } else {
-        const int dmg = damage();
+        const int dmg = damage_as_character(guy);
         if( dmg >= 0 ) {
             return string_format( "%d", dmg );
         } else {
@@ -1865,11 +1868,11 @@ void spellcasting_callback::draw_spell_info( const spell &sp, const uilist *menu
     if( fx == "target_attack" || fx == "projectile_attack" || fx == "cone_attack" ||
         fx == "line_attack" ) {
         if( damage > 0 ) {
-            damage_string = string_format( "%s: %s %s", _( "Damage" ), colorize( sp.damage_string(),
+            damage_string = string_format( "%s: %s %s", _( "Damage" ), colorize( sp.damage_string(g->u),
                                            sp.damage_type_color() ),
                                            colorize( sp.damage_type_string(), sp.damage_type_color() ) );
         } else if( damage < 0 ) {
-            damage_string = string_format( "%s: %s", _( "Healing" ), colorize( sp.damage_string(),
+            damage_string = string_format( "%s: %s", _( "Healing" ), colorize( sp.damage_string(g->u),
                                            light_green ) );
         }
         if( sp.aoe() > 0 ) {

--- a/src/magic.h
+++ b/src/magic.h
@@ -59,6 +59,7 @@ enum spell_flag {
     NO_FAIL, // this spell cannot fail when you cast it
     BRAWL, // this spell can be used by brawlers
     DUPE_SOUND, // this spell will play 'duplicate' sounds, if relevant to the spell effect
+    ADD_MELEE_DAM, // Add melee damage to the spell's damage
     LAST
 };
 
@@ -373,6 +374,8 @@ class spell
         int field_intensity() const;
         // how much damage does the spell do
         int damage() const;
+        // damage with character stats taken into account
+        int damage_as_character(const Character &guy) const;
         dealt_damage_instance get_dealt_damage_instance() const;
         damage_instance get_damage_instance() const;
         // how big is the spell's radius

--- a/src/magic.h
+++ b/src/magic.h
@@ -374,10 +374,12 @@ class spell
         int field_intensity() const;
         // how much damage does the spell do
         int damage() const;
-        // damage with character stats taken into account
-        int damage_as_character(const Character &guy) const;
         dealt_damage_instance get_dealt_damage_instance() const;
         damage_instance get_damage_instance() const;
+        // damage with character stats taken into account
+        int damage_as_character(const Character &guy) const;
+        dealt_damage_instance get_dealt_damage_instance(const Character &guy) const;
+        damage_instance get_damage_instance(const Character &guy) const;
         // how big is the spell's radius
         int aoe() const;
         // "accuracy" of spells (used for determining body part hit)

--- a/src/magic.h
+++ b/src/magic.h
@@ -377,9 +377,9 @@ class spell
         dealt_damage_instance get_dealt_damage_instance() const;
         damage_instance get_damage_instance() const;
         // damage with character stats taken into account
-        int damage_as_character(const Character &guy) const;
-        dealt_damage_instance get_dealt_damage_instance(const Character &guy) const;
-        damage_instance get_damage_instance(const Character &guy) const;
+        int damage_as_character( const Character &guy ) const;
+        dealt_damage_instance get_dealt_damage_instance( const Character &guy ) const;
+        damage_instance get_damage_instance( const Character &guy ) const;
         // how big is the spell's radius
         int aoe() const;
         // "accuracy" of spells (used for determining body part hit)
@@ -445,7 +445,7 @@ class spell
         //if targeted_monster_ids is empty, it returns an empty string
         std::string list_targeted_monster_names() const;
 
-        std::string damage_string(const Character &guy) const;
+        std::string damage_string( const Character &guy ) const;
         std::string aoe_string() const;
         std::string duration_string() const;
 

--- a/src/magic.h
+++ b/src/magic.h
@@ -443,7 +443,7 @@ class spell
         //if targeted_monster_ids is empty, it returns an empty string
         std::string list_targeted_monster_names() const;
 
-        std::string damage_string() const;
+        std::string damage_string(const Character &guy) const;
         std::string aoe_string() const;
         std::string duration_string() const;
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -499,7 +499,7 @@ static void damage_targets( const spell &sp, Creature &caster,
 
         projectile bolt;
         bolt.speed = 10000;
-        bolt.impact = sp.get_damage_instance(*caster.as_character());
+        bolt.impact = sp.get_damage_instance( *caster.as_character() );
         bolt.add_effect( ammo_effect_magic );
 
         dealt_projectile_attack atk;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -499,7 +499,8 @@ static void damage_targets( const spell &sp, Creature &caster,
 
         projectile bolt;
         bolt.speed = 10000;
-        bolt.impact = ( caster.is_monster() ) ? sp.get_damage_instance() : sp.get_damage_instance( *caster.as_character() );
+        bolt.impact = ( caster.is_monster() ) ? sp.get_damage_instance() : sp.get_damage_instance(
+                          *caster.as_character() );
         bolt.add_effect( ammo_effect_magic );
 
         dealt_projectile_attack atk;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -499,7 +499,7 @@ static void damage_targets( const spell &sp, Creature &caster,
 
         projectile bolt;
         bolt.speed = 10000;
-        bolt.impact = sp.get_damage_instance();
+        bolt.impact = sp.get_damage_instance(*caster.as_character());
         bolt.add_effect( ammo_effect_magic );
 
         dealt_projectile_attack atk;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -499,7 +499,7 @@ static void damage_targets( const spell &sp, Creature &caster,
 
         projectile bolt;
         bolt.speed = 10000;
-        bolt.impact = sp.get_damage_instance( *caster.as_character() );
+        bolt.impact = ( caster.is_monster() ) ? sp.get_damage_instance() : sp.get_damage_instance( *caster.as_character() );
         bolt.add_effect( ammo_effect_magic );
 
         dealt_projectile_attack atk;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3709,7 +3709,7 @@ void target_ui::panel_spell_info( int &text_y )
     }
 
     mvwprintz( w_target, point( 1, text_y++ ), c_light_red, _( "Damage: %s" ),
-               casting->damage_string() );
+               casting->damage_string(*you) );
 
     text_y += fold_and_print( w_target, point( 1, text_y ), getmaxx( w_target ) - 2, clr,
                               casting->description() );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3709,7 +3709,7 @@ void target_ui::panel_spell_info( int &text_y )
     }
 
     mvwprintz( w_target, point( 1, text_y++ ), c_light_red, _( "Damage: %s" ),
-               casting->damage_string(*you) );
+               casting->damage_string( *you ) );
 
     text_y += fold_and_print( w_target, point( 1, text_y ), getmaxx( w_target ) - 2, clr,
                               casting->description() );

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -236,21 +236,23 @@ static int spell_damage( const spell_id sp_id, const int spell_level )
     return test_spell.damage();
 }
 
-static int spell_damage_character(const spell_id sp_id, const int spell_level, const Character &guy) {
+static int spell_damage_character( const spell_id sp_id, const int spell_level,
+                                   const Character &guy )
+{
     spell test_spell( sp_id );
     test_spell.set_level( spell_level );
-    return test_spell.damage_as_character(guy);
+    return test_spell.damage_as_character( guy );
 }
 
 TEST_CASE( "spell damage", "[magic][spell][damage]" )
 {
     clear_all_state();
     spell_id pew_id( "test_spell_pew" );
-    spell_id pew_melee_id("test_spell_pew_melee");
+    spell_id pew_melee_id( "test_spell_pew_melee" );
     const spell_type &pew_type = pew_id.obj();
     avatar &dummy = g->u;
     clear_character( dummy );
-    dummy.set_primary_weapon(item::spawn("katana"));
+    dummy.set_primary_weapon( item::spawn( "katana" ) );
 
     // Level 0 damage for this spell is 1
     REQUIRE( pew_type.min_damage == 1 );
@@ -277,11 +279,11 @@ TEST_CASE( "spell damage", "[magic][spell][damage]" )
         CHECK( spell_damage( pew_id, 9 ) == 5 );
         CHECK( spell_damage( pew_id, 10 ) == 5 );
     }
-    
+
     // Expand as new variations are added
-    SECTION( "spells that have character-dependent bonuses correctly vary damage") {
+    SECTION( "spells that have character-dependent bonuses correctly vary damage" ) {
         // ADD_MELEE_DAM
-        CHECK(spell_damage(pew_melee_id, 1) < spell_damage_character(pew_melee_id, 1, dummy));
+        CHECK( spell_damage( pew_melee_id, 1 ) < spell_damage_character( pew_melee_id, 1, dummy ) );
     }
 }
 

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -236,11 +236,21 @@ static int spell_damage( const spell_id sp_id, const int spell_level )
     return test_spell.damage();
 }
 
+static int spell_damage_character(const spell_id sp_id, const int spell_level, const Character &guy) {
+    spell test_spell( sp_id );
+    test_spell.set_level( spell_level );
+    return test_spell.damage_as_character(guy);
+}
+
 TEST_CASE( "spell damage", "[magic][spell][damage]" )
 {
     clear_all_state();
     spell_id pew_id( "test_spell_pew" );
+    spell_id pew_melee_id("test_spell_pew_melee");
     const spell_type &pew_type = pew_id.obj();
+    avatar &dummy = g->u;
+    clear_character( dummy );
+    dummy.set_primary_weapon(item::spawn("katana"));
 
     // Level 0 damage for this spell is 1
     REQUIRE( pew_type.min_damage == 1 );
@@ -266,6 +276,12 @@ TEST_CASE( "spell damage", "[magic][spell][damage]" )
         CHECK( spell_damage( pew_id, 5 ) == 5 );
         CHECK( spell_damage( pew_id, 9 ) == 5 );
         CHECK( spell_damage( pew_id, 10 ) == 5 );
+    }
+    
+    // Expand as new variations are added
+    SECTION( "spells that have character-dependent bonuses correctly vary damage") {
+        // ADD_MELEE_DAM
+        CHECK(spell_damage(pew_melee_id, 1) < spell_damage_character(pew_melee_id, 1, dummy));
     }
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

Step 1 towards Weapon Artes, physical spells, and potentially stuff like martial arts using spells to represent techniques that the user can activate at their leisure.

Additionally, the work required for this will make subsequent future additions of more possible modifiers much easier because the structure will already be in place.

## Describe the solution (The How)

- Adds a new function, `damage_as_character`, which takes a character parameter and returns the base damage + any special modifiers.
- Makes `damage_string` take a character parameter because the only current uses I can find are ones where the player is casting anyway
- Adds and makes use of the damage_instance helping functions for character-based damage
- Adds a spell flag to allow the highest melee weapon damage to be added to the spell's damage (i.e. whichever damage type the weapon does that is the highest, that value gets added. So a zweihander only adds the cut, not the bash)
- Adds a test to make sure it stays correct in the future (and for future tests to accompany)

## Describe alternatives you've considered

- Cry
- See if DDA's done it their own way
- Do more possible modifiers at once

## Testing

It builds, it works for Royal Fox and for me (have not run the test yet, but I presume it shall work)

For testing yourself:
Add `ADD_MELEE_DAM` to a spell like smite's flags, then compare its damage before and after wielding a weapon like a sword.

## Additional context

Test may be implemented a lil oddly, suggestions welcome on it.

Future planned additional modifiers:
- Stats (INT, STR, DEX, PER)
- Skills (melee, computers, etc.)
- Maybe class alignment
- With the advent of fully physical spells, Brawler giving a damage boost to them

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
