### PR TITLE
docs: Update magic documentation

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -13,6 +13,7 @@ In `data/json/debug_spells.json` there is a template spell, copied here for your
   "type": "SPELL",
   "name": "Template Spell", // name of the spell that shows in game
   "description": "This is a template to show off all the available values",
+  "blocker_mutations": ["THRESH_RAT"], // list of mutations that will not allow you to cast the spell
   "valid_targets": ["hostile", "ground", "self", "ally"], // if a valid target is not included, you cannot cast the spell on that target.
   "effect": "shallow_pit", // effects are coded in C++. A list will be provided below of possible effects that have been coded.
   "effect_str": "template", // special. see below
@@ -172,6 +173,12 @@ experience you need to get to a level is below:
 
 - `spawn_item` - spawns an item that will disappear at the end of its duration. Default duration
   is 0. Damage determines quantity.
+
+- `summon_vehicle` - spawns a specified vehicle that should disappear after its duration
+
+- `summon` - spawns a monster that will disappear at the end of its duration. By default friendly to the player. Damage determines quantity.
+
+- `translocate` - teleports the player between registered 'translocators', such as the gates in Magical Nights
 
 - `teleport_random` - teleports the player randomly range spaces with aoe variation
 


### PR DESCRIPTION
## Purpose of change (The Why)

Our docs were outdated

## Describe the solution (The How)

Update docs

## Describe alternatives you've considered

## Testing

Read

## Additional context

Blocker mutations was originally left out because we were considering doing that docs migration and I wanted to save scarf the merge conflicts

The others just must have slipped through the cracks

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

