### PR TITLE
fix: remove retractable claws + arm tentacles exploit

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5472,44 +5472,66 @@
     "category": [ "SPIDER" ]
   },
   {
-    "type": "mutation",
-    "id": "ARM_TENTACLES",
-    "name": { "str": "Tentacle Arms" },
-    "points": -4,
-    "visibility": 7,
-    "ugliness": 4,
-    "mixed_effect": true,
-    "description": "Your arms have transformed into tentacles, resulting in a +1 bonus to Dexterity, permanent hand encumbrance of 30, and an inability to wear gloves.  Somewhat decreases wet penalties.",
-    "encumbrance_always": [ [ "hand_l", 30 ], [ "hand_r", 30 ] ],
-    "restricts_gear": [ "hand_l", "hand_r" ],
-    "types": [ "HANDS" ],
-    "leads_to": [ "CLAWS_TENTACLE" ],
-    "changes_to": [ "ARM_TENTACLES_4" ],
-    "cancels": [ "NAILS", "CLAWS", "TALONS", "WEBBED" ],
-    "wet_protection": [
-      { "part": "arm_l", "neutral": 19 },
-      { "part": "arm_r", "neutral": 19 },
-      { "part": "hand_l", "neutral": 5 },
-      { "part": "hand_r", "neutral": 5 }
-    ],
-    "attacks": [
-      {
-        "attack_text_u": "You slap %s with your tentacle",
-        "attack_text_npc": "%1$s slaps %2$s with their tentacle",
-        "blocker_mutations": [ "CLAWS_TENTACLE" ],
-        "chance": 1,
-        "hardcoded_effect": true
-      },
-      {
-        "attack_text_u": "You rake %s with your tentacle",
-        "attack_text_npc": "%1$s rakes %2$s with their tentacle",
-        "required_mutations": [ "CLAWS_TENTACLE" ],
-        "chance": 1,
-        "hardcoded_effect": true
-      }
-    ],
-    "passive_mods": { "dex_mod": 1 }
+  "type": "mutation",
+  "id": "ARM_TENTACLES",
+  "name": {
+    "str": "Tentacle Arms"
   },
+  "points": -4,
+  "visibility": 7,
+  "ugliness": 4,
+  "mixed_effect": true,
+  "description": "Your arms have transformed into tentacles, resulting in a +1 bonus to Dexterity, permanent hand encumbrance of 30, and an inability to wear gloves.  Somewhat decreases wet penalties.",
+  "encumbrance_always": [
+    [ "hand_l", 30 ],
+    [ "hand_r", 30 ]
+  ],
+  "restricts_gear": [
+    "hand_l",
+    "hand_r"
+  ],
+  "types": [
+    "HANDS"
+  ],
+  "leads_to": [
+    "CLAWS_TENTACLE"
+  ],
+  "changes_to": [
+    "ARM_TENTACLES_4"
+  ],
+  "cancels": [
+    "NAILS",
+    "CLAWS",
+    "CLAWS_RETRACT",
+    "TALONS",
+    "WEBBED"
+  ],
+  "wet_protection": [
+    { "part": "arm_l", "neutral": 19 },
+    { "part": "arm_r", "neutral": 19 },
+    { "part": "hand_l", "neutral": 5 },
+    { "part": "hand_r", "neutral": 5 }
+  ],
+  "attacks": [
+    {
+      "attack_text_u": "You slap %s with your tentacle",
+      "attack_text_npc": "%1$s slaps %2$s with their tentacle",
+      "blocker_mutations": [ "CLAWS_TENTACLE" ],
+      "chance": 1,
+      "hardcoded_effect": true
+    },
+    {
+      "attack_text_u": "You rake %s with your tentacle",
+      "attack_text_npc": "%1$s rakes %2$s with their tentacle",
+      "required_mutations": [ "CLAWS_TENTACLE" ],
+      "chance": 1,
+      "hardcoded_effect": true
+    }
+  ],
+  "passive_mods": {
+    "dex_mod": 1
+    }
+  }
   {
     "type": "mutation",
     "id": "ARM_TENTACLES_4",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5531,7 +5531,7 @@
   "passive_mods": {
     "dex_mod": 1
     }
-  }
+  },
   {
     "type": "mutation",
     "id": "ARM_TENTACLES_4",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5472,65 +5472,43 @@
     "category": [ "SPIDER" ]
   },
   {
-  "type": "mutation",
-  "id": "ARM_TENTACLES",
-  "name": {
-    "str": "Tentacle Arms"
-  },
-  "points": -4,
-  "visibility": 7,
-  "ugliness": 4,
-  "mixed_effect": true,
-  "description": "Your arms have transformed into tentacles, resulting in a +1 bonus to Dexterity, permanent hand encumbrance of 30, and an inability to wear gloves.  Somewhat decreases wet penalties.",
-  "encumbrance_always": [
-    [ "hand_l", 30 ],
-    [ "hand_r", 30 ]
-  ],
-  "restricts_gear": [
-    "hand_l",
-    "hand_r"
-  ],
-  "types": [
-    "HANDS"
-  ],
-  "leads_to": [
-    "CLAWS_TENTACLE"
-  ],
-  "changes_to": [
-    "ARM_TENTACLES_4"
-  ],
-  "cancels": [
-    "NAILS",
-    "CLAWS",
-    "CLAWS_RETRACT",
-    "TALONS",
-    "WEBBED"
-  ],
-  "wet_protection": [
-    { "part": "arm_l", "neutral": 19 },
-    { "part": "arm_r", "neutral": 19 },
-    { "part": "hand_l", "neutral": 5 },
-    { "part": "hand_r", "neutral": 5 }
-  ],
-  "attacks": [
-    {
-      "attack_text_u": "You slap %s with your tentacle",
-      "attack_text_npc": "%1$s slaps %2$s with their tentacle",
-      "blocker_mutations": [ "CLAWS_TENTACLE" ],
-      "chance": 1,
-      "hardcoded_effect": true
-    },
-    {
-      "attack_text_u": "You rake %s with your tentacle",
-      "attack_text_npc": "%1$s rakes %2$s with their tentacle",
-      "required_mutations": [ "CLAWS_TENTACLE" ],
-      "chance": 1,
-      "hardcoded_effect": true
-    }
-  ],
-  "passive_mods": {
-    "dex_mod": 1
-    }
+    "type": "mutation",
+    "id": "ARM_TENTACLES",
+    "name": { "str": "Tentacle Arms" },
+    "points": -4,
+    "visibility": 7,
+    "ugliness": 4,
+    "mixed_effect": true,
+    "description": "Your arms have transformed into tentacles, resulting in a +1 bonus to Dexterity, permanent hand encumbrance of 30, and an inability to wear gloves.  Somewhat decreases wet penalties.",
+    "encumbrance_always": [ [ "hand_l", 30 ], [ "hand_r", 30 ] ],
+    "restricts_gear": [ "hand_l", "hand_r" ],
+    "types": [ "HANDS" ],
+    "leads_to": [ "CLAWS_TENTACLE" ],
+    "changes_to": [ "ARM_TENTACLES_4" ],
+    "cancels": [ "NAILS", "CLAWS", "CLAWS_RETRACT", "TALONS", "WEBBED" ],
+    "wet_protection": [
+      { "part": "arm_l", "neutral": 19 },
+      { "part": "arm_r", "neutral": 19 },
+      { "part": "hand_l", "neutral": 5 },
+      { "part": "hand_r", "neutral": 5 }
+    ],
+    "attacks": [
+      {
+        "attack_text_u": "You slap %s with your tentacle",
+        "attack_text_npc": "%1$s slaps %2$s with their tentacle",
+        "blocker_mutations": [ "CLAWS_TENTACLE" ],
+        "chance": 1,
+        "hardcoded_effect": true
+      },
+      {
+        "attack_text_u": "You rake %s with your tentacle",
+        "attack_text_npc": "%1$s rakes %2$s with their tentacle",
+        "required_mutations": [ "CLAWS_TENTACLE" ],
+        "chance": 1,
+        "hardcoded_effect": true
+      }
+    ],
+    "passive_mods": { "dex_mod": 1 }
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

The only way for a player to have tentacles and claw-like equivelents was supposed to be by going post-threshold cephalopod and mutating tentacle rakes (CLAWS_TENTACLE). However, it is currently possible for a player to have retractable claws before mutating tentacle arms, thus smuggling in the claws.

## Describe the solution (The How)

Add retractable claws to the "cancels" list of tentacle arms

## Describe alternatives you've considered

Continue allowing players with tentacle arms to also have retractable claws protruding from fingers they don't have.

## Testing

Spawned in, 
injected feline serum until retractable claws,
injected cephalopod serum until tentacle arms,
was no longer able to keep retractable claws after mutating tentacle arms.

## Additional context

The entire ARM_TENTACLES entry was replaced because the linting machine told me to.
But then the other machine told me to put it back.

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.