### PR TITLE
feat: allows the mechanical winch to work with more different walls

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -5388,7 +5388,7 @@
       [ [ "chain", 1 ] ],
       [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ]
     ],
-    "pre_note": "Must be adjacent to a brick or (reinforced)concrete wall that is itself adjacent to a garage gate in order to open said gate.",
+    "pre_note": "Must be adjacent to a brick, concrete, stone or plastered wooden wall that is itself adjacent to a garage gate in order to open said gate.",
     "pre_special": "check_empty",
     "post_terrain": "t_gates_mech_control"
   },

--- a/data/json/gates.json
+++ b/data/json/gates.json
@@ -13,9 +13,13 @@
       "t_wall_g",
       "t_wall_y",
       "t_wall_p",
-      "t_concrete_wall",
+      "t_wall_P",
       "t_brick_wall",
-      "t_strconc_wall"
+      "t_adobe_brick_wall",
+      "t_sconc_wall",
+      "t_concrete_wall",
+      "t_strconc_wall",
+      "t_rock_wall"
     ],
     "messages": {
       "pull": "You turn the handle…",


### PR DESCRIPTION
## Purpose of change (The Why)
Allows the mechanical winch "t_gates_mech_control" to work with more different walls.
## Describe the solution (The How)
Make the mechanical winch work with these walls:
[pink wall](https://cbn-guide.mythoscraft.org/terrain/t_wall_P)
[adobe wall](https://cbn-guide.mythoscraft.org/terrain/t_adobe_brick_wall)
[simple concrete wall](https://cbn-guide.mythoscraft.org/terrain/t_sconc_wall)
[stone wall](https://cbn-guide.mythoscraft.org/terrain/t_rock_wall)

Updated the description of the mechanical winch construction to specify which wall is compatible.
## Describe alternatives you've considered
none
## Testing
No errors when I started a new game.
## Additional context

<details>
<summary>Screenshot (Before):</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/046b1db3-eed8-48d4-b574-5e0ff819abc1"></a>
</details>

<details>
<summary>Screenshot (After):</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/83987bae-b9bd-470a-a1c3-dfd2ed0b71d9"></a>
</details>

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.