### PR TITLE
fix: screen porch walls are not fences

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1101,6 +1101,32 @@
   },
   {
     "type": "construction",
+    "id": "constr_screen_door",
+    "group": "build_screen_door",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 2 ] ],
+    "time": "60 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "components": [ [ [ "screen_mesh", 1 ] ], [ [ "2x4", 4 ] ], [ [ "nail", 20 ] ], [ [ "hinge", 2 ] ] ],
+    "pre_note": "Needs to be supported on both sides by fencing, walls, etc.",
+    "pre_terrain": "t_floor",
+    "post_terrain": "t_screen_door_c"
+  },
+  {
+    "type": "construction",
+    "id": "constr_screened_porch_wall",
+    "group": "build_screen_mesh_wall",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 2 ] ],
+    "time": "60 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "components": [ [ [ "screen_mesh", 1 ] ], [ [ "2x4", 4 ] ], [ [ "nail", 10 ] ] ],
+    "pre_note": "Needs to be supported on both sides by fencing, walls, etc.",
+    "pre_terrain": "t_floor",
+    "post_terrain": "t_screened_porch_wall"
+  },
+  {
+    "type": "construction",
     "id": "constr_sandbag_half",
     "group": "build_sandbag_wall",
     "//": "Step 1: Build sandbag barricade",
@@ -1773,32 +1799,6 @@
     "pre_note": "Needs to be supported on both sides by fencing, walls, etc.",
     "pre_special": "check_empty",
     "post_terrain": "t_chaingate_c"
-  },
-  {
-    "type": "construction",
-    "id": "constr_screen_door",
-    "group": "build_screen_door",
-    "category": "CONSTRUCT",
-    "required_skills": [ [ "fabrication", 2 ] ],
-    "time": "60 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-    "components": [ [ [ "screen_mesh", 1 ] ], [ [ "2x4", 4 ] ], [ [ "nail", 20 ] ], [ [ "hinge", 2 ] ] ],
-    "pre_note": "Needs to be supported on both sides by fencing, walls, etc.",
-    "pre_special": "check_empty",
-    "post_terrain": "t_screen_door_c"
-  },
-  {
-    "type": "construction",
-    "id": "constr_screened_porch_wall",
-    "group": "build_screen_mesh_wall",
-    "category": "CONSTRUCT",
-    "required_skills": [ [ "fabrication", 2 ] ],
-    "time": "60 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-    "components": [ [ [ "screen_mesh", 1 ] ], [ [ "2x4", 4 ] ], [ [ "nail", 10 ] ] ],
-    "pre_note": "Needs to be supported on both sides by fencing, walls, etc.",
-    "pre_special": "check_empty",
-    "post_terrain": "t_screened_porch_wall"
   },
   {
     "type": "construction",

--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -2867,5 +2867,75 @@
         { "item": "hinge", "count": [ 1, 2 ] }
       ]
     }
+  },
+  {
+    "type": "terrain",
+    "id": "t_screen_door_c",
+    "name": "closed screen door",
+    "description": "A simple wooden doorway with screen mesh.",
+    "symbol": "+",
+    "color": "brown",
+    "looks_like": "t_chickenwire_gate_c",
+    "move_cost": 0,
+    "flags": [ "TRANSPARENT", "DOOR", "PERMEABLE", "CONNECT_TO_WALL" ],
+    "open": "t_screen_door_o",
+    "deconstruct": {
+      "ter_set": "t_floor",
+      "items": [
+        { "item": "2x4", "count": 4 },
+        { "item": "screen_mesh", "count": 1 },
+        { "item": "nail", "charges": 20 },
+        { "item": "hinge", "count": 2 }
+      ]
+    },
+    "bash": {
+      "str_min": 5,
+      "str_max": 12,
+      "str_min_blocked": 5,
+      "str_max_blocked": 15,
+      "sound": "rattle!",
+      "sound_fail": "thump!",
+      "ter_set": "t_floor",
+      "items": [
+        { "item": "screen_mesh", "count": [ 0, 1 ] },
+        { "item": "2x4", "count": [ 2, 4 ] },
+        { "item": "hinge", "count": [ 1, 2 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_screen_door_o",
+    "name": "open screen door",
+    "description": "A simple wooden doorway with screen mesh.",
+    "symbol": "'",
+    "color": "brown",
+    "looks_like": "t_chickenwire_gate_o",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "DOOR", "PERMEABLE", "CONNECT_TO_WALL" ],
+    "close": "t_screen_door_c",
+    "deconstruct": {
+      "ter_set": "t_floor",
+      "items": [
+        { "item": "2x4", "count": 4 },
+        { "item": "screen_mesh", "count": 1 },
+        { "item": "nail", "charges": 20 },
+        { "item": "hinge", "count": 2 }
+      ]
+    },
+    "bash": {
+      "str_min": 5,
+      "str_max": 12,
+      "str_min_blocked": 5,
+      "str_max_blocked": 15,
+      "sound": "rattle!",
+      "sound_fail": "thump!",
+      "ter_set": "t_floor",
+      "items": [
+        { "item": "screen_mesh", "count": [ 0, 1 ] },
+        { "item": "2x4", "count": [ 2, 4 ] },
+        { "item": "hinge", "count": [ 1, 2 ] }
+      ]
+    }
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -233,76 +233,6 @@
   },
   {
     "type": "terrain",
-    "id": "t_screen_door_c",
-    "name": "closed screen door",
-    "description": "A simple wooden doorway with screen mesh.",
-    "symbol": "+",
-    "color": "brown",
-    "looks_like": "t_chickenwire_gate_c",
-    "move_cost": 0,
-    "flags": [ "TRANSPARENT", "DOOR", "PERMEABLE", "BURROWABLE", "CONNECT_TO_WALL" ],
-    "open": "t_screen_door_o",
-    "deconstruct": {
-      "ter_set": "t_floor",
-      "items": [
-        { "item": "2x4", "count": 4 },
-        { "item": "screen_mesh", "count": 1 },
-        { "item": "nail", "charges": 20 },
-        { "item": "hinge", "count": 2 }
-      ]
-    },
-    "bash": {
-      "str_min": 5,
-      "str_max": 12,
-      "str_min_blocked": 5,
-      "str_max_blocked": 15,
-      "sound": "rattle!",
-      "sound_fail": "thump!",
-      "ter_set": "t_floor",
-      "items": [
-        { "item": "screen_mesh", "count": [ 0, 1 ] },
-        { "item": "2x4", "count": [ 2, 4 ] },
-        { "item": "hinge", "count": [ 1, 2 ] }
-      ]
-    }
-  },
-  {
-    "type": "terrain",
-    "id": "t_screen_door_o",
-    "name": "open screen door",
-    "description": "A simple wooden doorway with screen mesh.",
-    "symbol": "'",
-    "color": "brown",
-    "looks_like": "t_chickenwire_gate_o",
-    "move_cost": 2,
-    "flags": [ "TRANSPARENT", "DOOR", "PERMEABLE", "BURROWABLE", "CONNECT_TO_WALL" ],
-    "close": "t_screen_door_c",
-    "deconstruct": {
-      "ter_set": "t_floor",
-      "items": [
-        { "item": "2x4", "count": 4 },
-        { "item": "screen_mesh", "count": 1 },
-        { "item": "nail", "charges": 20 },
-        { "item": "hinge", "count": 2 }
-      ]
-    },
-    "bash": {
-      "str_min": 5,
-      "str_max": 12,
-      "str_min_blocked": 5,
-      "str_max_blocked": 15,
-      "sound": "rattle!",
-      "sound_fail": "thump!",
-      "ter_set": "t_floor",
-      "items": [
-        { "item": "screen_mesh", "count": [ 0, 1 ] },
-        { "item": "2x4", "count": [ 2, 4 ] },
-        { "item": "hinge", "count": [ 1, 2 ] }
-      ]
-    }
-  },
-  {
-    "type": "terrain",
     "id": "t_chickenwire_gate_c",
     "name": "closed chickenwire gate",
     "description": "A gate for a chickenwire fence with a simple latch system to stay closed.",
@@ -486,34 +416,6 @@
       "sound_fail": "whack!",
       "ter_set": "t_fence_post",
       "items": [ { "item": "wire", "count": [ 5, 10 ] } ]
-    }
-  },
-  {
-    "type": "terrain",
-    "id": "t_screened_porch_wall",
-    "name": "screen mesh wall",
-    "description": "A rather flimsy tall wall made of 2x4s and screen mesh, suitable for keeping the bugs out.",
-    "symbol": "LINE_OXOX",
-    "color": "brown",
-    "looks_like": "t_chickenwire_fence",
-    "move_cost": 0,
-    "flags": [ "TRANSPARENT", "NOITEM", "PERMEABLE", "AUTO_WALL_SYMBOL", "BURROWABLE", "AUTO_WALL_SYMBOL" ],
-    "examine_action": "chainfence",
-    "deconstruct": {
-      "ter_set": "t_floor",
-      "items": [ { "item": "screen_mesh", "count": 1 }, { "item": "nail", "charges": 10 }, { "item": "2x4", "charges": 4 } ]
-    },
-    "bash": {
-      "str_min": 5,
-      "str_max": 12,
-      "sound": "metal rattling!",
-      "sound_fail": "whack!",
-      "ter_set": "t_floor",
-      "items": [
-        { "item": "screen_mesh", "count": [ 0, 1 ] },
-        { "item": "nail", "charges": [ 5, 10 ] },
-        { "item": "2x4", "count": [ 1, 3 ] }
-      ]
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -773,6 +773,33 @@
   },
   {
     "type": "terrain",
+    "id": "t_screened_porch_wall",
+    "name": "screen mesh wall",
+    "description": "A rather flimsy tall wall made of 2x4s and screen mesh, suitable for keeping the bugs out.",
+    "symbol": "LINE_OXOX",
+    "color": "brown",
+    "looks_like": "t_chickenwire_fence",
+    "move_cost": 0,
+    "flags": [ "TRANSPARENT", "NOITEM", "PERMEABLE", "AUTO_WALL_SYMBOL", "WALL" ],
+    "deconstruct": {
+      "ter_set": "t_floor",
+      "items": [ { "item": "screen_mesh", "count": 1 }, { "item": "nail", "charges": 10 }, { "item": "2x4", "charges": 4 } ]
+    },
+    "bash": {
+      "str_min": 5,
+      "str_max": 12,
+      "sound": "metal rattling!",
+      "sound_fail": "whack!",
+      "ter_set": "t_floor",
+      "items": [
+        { "item": "screen_mesh", "count": [ 0, 1 ] },
+        { "item": "nail", "charges": [ 5, 10 ] },
+        { "item": "2x4", "count": [ 1, 3 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_wall_wood",
     "name": "wooden wall",
     "description": "A finished wall of planks and support beams, capable of supporting an upper level or roof.  Still highly flammable.",


### PR DESCRIPTION
## Purpose of change (The Why)

Screen porch walls and doors are treated as fences and gates respectively. You can burrow under them as if they were fences and hop over them as if there wasn't a roof over them. Speaking of which, the crafting of screen wall/door doesn't require any specific terrain to be built upon despite leaving t_floor after being destroyed/dismantled (new wooden floor + roof out of nowhere). To top it off, screen porch walls do not have the "WALL" flag and thus cannot take any orientation other than the defualt horizontal position. They also have "AUTO_WALL_SYMBOL" twice for some reason.
## Describe the solution (The How)
- Move screen door open/close to terrain-doors.json
- Move screen porch wall to terrain-walls.json
- Remove `BURROWABLE` from both's flags and remove `"examine_action": "chainfence",`
- Change `"pre_special": "check_empty",` to `"pre_terrain": "t_floor",` 
(this makes it so now you have to build a wooden floor + roof before building screen door/wall).
- Add `WALL` flag, remove second `AUTO_WALL_SYMBOL` flag

## Describe alternatives you've considered

Continue building screened in porches without a ceiling or wooden floor.
Subsequently, destroying the walls to spontaniously manifest wooden floors with ceilings.
Afterwards, going to house with an already built screened in porch and either climbing over, despite the very real roof of the house, or burrowing under, despite the very real concrete patio on both sides, the screen porch walls.

## Testing

Spawned in various houses that have screened in porches. The walls are now able to make corners, go vertical, etc. Can no longer climb/burrow. Contruction requires wooden floor + ceiling. Test succesful.

## Additional context

I put the screen porch wall next to the log wall in terrain-walls.json because adding it to the bottom, right next to the nuclear reactor, felt a bit out of place.

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
