### PR TITLE
chore: Add default folders to the repo for player mods and soundpacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,11 +26,13 @@ test_user_dir*
 /font/
 /graveyard/
 /memorial/
+/mods/
 /obj/
 /objwin/
 /save/
 /src/version.h
 /src/prefix.h
+/sound/
 /templates/
 /tools/format/json_formatter.cgi
 CataclysmWin.cscope_file_list

--- a/.gitignore
+++ b/.gitignore
@@ -26,13 +26,11 @@ test_user_dir*
 /font/
 /graveyard/
 /memorial/
-/mods/
 /obj/
 /objwin/
 /save/
 /src/version.h
 /src/prefix.h
-/sound/
 /templates/
 /tools/format/json_formatter.cgi
 CataclysmWin.cscope_file_list

--- a/Makefile
+++ b/Makefile
@@ -854,6 +854,12 @@ ifeq ($(USE_XDG_DIR),1)
   DEFINES += -DUSE_XDG_DIR
 endif
 
+ifeq ($(USE_XDG_DIR),0)
+  ifeq ($(USE_HOME_DIR),0)
+    BINDIST_EXTRAS += player-mods player-soundpacks
+  endif
+endif
+
 ifeq ($(LTO), 1)
   # Depending on the compiler version, LTO usually requires all the
   # optimization flags to be specified on the link line, and requires them to

--- a/Makefile
+++ b/Makefile
@@ -856,7 +856,7 @@ endif
 
 ifeq ($(USE_XDG_DIR),0)
   ifeq ($(USE_HOME_DIR),0)
-    BINDIST_EXTRAS += player-mods player-soundpacks
+    BINDIST_EXTRAS += mods sound
   endif
 endif
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ you wish to assign to that action.
 
 Where you put the third party mods depends on whether you installed manually or with Catapult. No matter which you do, 3rd party mods do **not** go in data/mods. That folder should be reserved for in-repo mods only, especially given Catapult will automatically delete the contents of that folder!
 
-For a manual installation, you should create a mods folder in the root BN folder to store your mods. Thus, instead of putting them in cataclysm-bn/data/mods, you'd put them in cataclysm-bn/mods (Case should not matter)
+For a manual installation, you should use the player-mods folder (if it is not present, you are either using an older version and should manually create a folder in the base cataclysm folder yourself or you are using XDG or Home directories on a supported platform)
 
 For Catapult, you would put them in bn/userdata/mods (creating the folder if it's not already there) inside your catapult installation. For example, it might look like Catapult/bn/userdata/mods.
 


### PR DESCRIPTION
## Purpose of change (The Why)

Players keep making the (understandable) mistake of placing their 3rd-party mods into `data/mods`. It is fairly desirable to attempt to help them out with this, especially given that it's such a simple change.

Similarly, it is not clear to a new user where to put their soundpacks.

## Describe the solution (The How)

- Adds `mods` and `sound` to the root of the repo with an empty text file in each to explain their purpose with its name.
- Adds them into the `bindist` in the makefile if neither XDG nor Home directories are being used.
- Updates the readme

## Describe alternatives you've considered

- create the folders in the makefile instead of having them sit around in the repo

Also valid, but I think this is clearer.

## Testing

I looked over the makefile to try and make sure my syntax is correct and that I'm adding it to the tars/zips the correct way.

In theory I could test build locally, but I think it's better to do it on github anyway.

## Additional context

I have no clue whether this should count as refactor, build, or chore. (or I guess CI?)

Scarf or someone else will have to also make any relevant changes to cmake if necessary before doing the great migration to cmake in our CI. Given I'm not sure if we even have bindist in our CMake anyway atm, I don't think this is too big compared to the existing work that would be needed.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
