### PR TITLE
feat(balance): reduce weight of dab pens from monsterdrops to same range as most other items on the list, remove redundant spawn

### DIFF
--- a/data/json/monsterdrops/zombie_default.json
+++ b/data/json/monsterdrops/zombie_default.json
@@ -183,7 +183,6 @@
           { "item": "nic_gum", "prob": 20 },
           { "item": "ecig", "prob": 15 },
           { "item": "butane_can", "prob": 10 },
-          { "item": "light_battery_cell", "charges": 100, "container-item": "dab_pen", "prob": 10 },
           { "collection": [ { "item": "weed" }, { "item": "pipe_glass", "prob": 50 } ], "prob": 10 },
           { "collection": [ { "item": "nectar_collector" }, { "item": "thc_wax", "prob": 50 } ], "prob": 10 },
           { "distribution": [ { "item": "joint", "prob": 80 }, { "item": "joint_roach", "prob": 20 } ], "prob": 10 },
@@ -197,7 +196,7 @@
           { "collection": [ { "item": "advanced_ecig" }, { "item": "nicotine_liquid" } ], "prob": 10 },
           {
             "collection": [ { "item": "light_battery_cell", "charges": 100, "container-item": "dab_pen" }, { "item": "thc_liquid" } ],
-            "prob": 50
+            "prob": 10
           },
           { "collection": [ { "item": "crackpipe" }, { "item": "crack" } ], "prob": 5 }
         ],


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6422 made dab pens ABSURDLY common on monster drops. Most of the weights for smoker items on the associated distribution have a weight of 10, and dab pens were given a nonsensical weight of **50**, when most of the items on the list except the expected basic cigs have a weight of 10. Dab pens were added twice in fact, one with no other items at a weight of 10, and one at the giant 50 weight as a collection with THC liquid.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Toned down the collection of dab pen+THC liquid's weight from 50 to 10.
2. Removed the redundant extra spawn of just an unusable dab pen by itself.

## Describe alternatives you've considered

The amount of THC liquid could be made variable, but on the other hand the regular vapes already come with a 100% spawn of nicotine liquid at a fixed amount so eh.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Used my eyes.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Also, I'm irritated that butane cans literally only exist for making THC liquid. We should at some point convert then from holding generic charges to an actual fuel item and make lighters contain butane as ammo, then start adding more uses for them. Making them the main fuel for refillable lighters would be a no-brainer, plus butane cans would make sense as a tool for refilling disposable lighters.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
