### PR TITLE
fix: swap volume of minireactor and generator

### DIFF
--- a/data/json/items/furniture.json
+++ b/data/json/items/furniture.json
@@ -96,7 +96,7 @@
     "name": "plutonium generator",
     "description": "A generator used on large ships or submarines.  Using a compact nuclear reactor, refined nuclear fuel is sealed within and configured to provide a constant low yield of power when properly installed.  It could be taken apart to reuse the minireactor for more energy-intensive applications, or installed in a local grid to continue providing a small but limitless source of electricity.",
     "weight": "150 kg",
-    "volume": "75 L",
+    "volume": "100 L",
     "price": "50000 USD",
     "price_postapoc": "100 USD",
     "material": "steel",

--- a/data/json/items/vehicle/utilities.json
+++ b/data/json/items/vehicle/utilities.json
@@ -25,7 +25,7 @@
     "color": "light_cyan",
     "symbol": ":",
     "material": [ "superalloy", "ceramic" ],
-    "volume": "100 L",
+    "volume": "75 L",
     "bashing": 7,
     "category": "veh_parts",
     "price": "900 USD",


### PR DESCRIPTION
## Purpose of change (The Why)

Disassembling a 75L plutonium generator will produce a 100L minireactor.
This is physically impossible unless it was **really** packed in there good and only decompressed after it was removed from the generator, like a new mattress.

## Describe the solution (The How)

swap the volume of the two

## Describe alternatives you've considered

Brainstorm on new volumes, so long as the minireactor is smaller than the generator.

Custom-built reactors that are even bigger.

## Testing

Spawned in
The "small portable plutonium reactor" is now more portable.
The "compact nuclear reactor" is now less portable

## Additional context

I wanted to make a joke about Chernobyl and nesting dolls, but I couldn't get it to fit.

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.