### PR TITLE
fix: make blunts produce blunt smoke

### DIFF
--- a/data/json/emit.json
+++ b/data/json/emit.json
@@ -16,6 +16,14 @@
     "chance": 2
   },
   {
+    "id": "emit_blunt_trail",
+    "type": "emit",
+    "//": "Intermittent blunt smoke",
+    "field": "fd_bluntsmoke",
+    "intensity": 3,
+    "chance": 2
+  },
+  {
     "id": "emit_AEP_SMOKE",
     "type": "emit",
     "//": "Intermittent smoke from an artifact",

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -858,6 +858,26 @@
     "looks_like": "fd_cigsmoke"
   },
   {
+    "id": "fd_bluntsmoke",
+    "type": "field_type",
+    "intensity_levels": [
+      { "name": "swirl of blunt smoke", "translucency": 5 },
+      { "name": "blunt smoke", "color": "light_gray" },
+      { "name": "thick blunt smoke", "color": "dark_gray" }
+    ],
+    "npc_complain": { "chance": 20, "issue": "weed_smoke", "duration": "10 minutes", "speech": "<weed_smoke>" },
+    "decay_amount_factor": 5,
+    "percent_spread": 225,
+    "outdoor_age_speedup": "6 minutes",
+    "dirty_transparency_cache": true,
+    "priority": 8,
+    "half_life": "35 minutes",
+    "phase": "gas",
+    "accelerated_decay": true,
+    "display_field": true,
+    "looks_like": "fd_cigsmoke"
+  },
+  {
     "id": "fd_cracksmoke",
     "type": "field_type",
     "legacy_enum_id": 35,

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2518,7 +2518,7 @@
     "symbol": "!",
     "description": "The smoke billowing from this blunt has a sweet, fruity odor.",
     "category": "drugs",
-    "emits": [ "emit_tobacco_trail" ],
+    "emits": [ "emit_blunt_trail" ],
     "use_action": [
       { "type": "firestarter", "moves": 200, "moves_slow": 2000 },
       {


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

This fix resolves https://github.com/cataclysmbnteam/Cataclysm-BN/issues/6725. EDIT: In my testing, blunts do give the weed effect. HOWEVER after publishing the PR I noticed the issue (hardcoded in item::process_litcig and item::process_extinguish), which is a C++ change. I plan on tackling that as soon as possible, and either adding the changes to this PR, or just splitting it into a separate C++ PR as I need to fix blunt_roaches as well.

(don't know if the above satisfies auto-close, so resolves #6725 )

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Add fd_bluntsmoke and emit_blunt_trail. Change the blunt item to produce this new smoke variant instead of the normal tobacco smoke. (Which was chosen because we can only have one emit_field effect, but this should solve the confusion.)

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

Smoked a blunt. Got high. It made smoke.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
![image](https://github.com/user-attachments/assets/619462f5-afb5-49b3-8622-312e1f2eee2e)
![image](https://github.com/user-attachments/assets/16f69fd2-8a83-4f63-9ff6-c9c3de46dea4)
(the time is so high because i smoked a few back to back)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
