### PR TITLE
fix: keybind debug menu to F12 by default

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -2156,7 +2156,7 @@
     "name": "Debug Menu",
     "category": "DEFAULTMODE",
     "id": "debug",
-    "bindings": [ { "input_method": "keyboard", "key": "F11" } ]
+    "bindings": [ { "input_method": "keyboard", "key": "F12" } ]
   },
   {
     "type": "keybinding",


### PR DESCRIPTION
## Purpose of change (The Why)

F11 is almost universally recognized as the "fullscreen button" across most applications.
Currently the debug menu is bound to F11, making it useless for just about anyone who hasn't bound it to a different key.
Why have a default keybind that >90% of players must change anyway?

## Describe the solution (The How)

Changing the default keybind from F11 to F12

## Describe alternatives you've considered

Binding it to any other key that doesn't already do something for almost everyone.

## Testing

Spawned in
I can now open the debug menu without putting my game in windowed mode.

## Additional context

Many versions back, debug menu was bound to F12 by default, but at some point it was left unbound by default.
Later in #4503, Debug menu was bound to F11.
This is a very small thing, but it seems silly to have a keybind that nobody can use by default (unless they shift +F11 every single time without fail).

## Checklist



### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
