### PR TITLE
fix: nicotine withdrawal removes 1 intelligence, blunt fix pt2

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2020,6 +2020,11 @@
     "context": [  ]
   },
   {
+    "id": "MARIJUANA",
+    "type": "json_flag",
+    "context": [  ]
+  },
+  {
     "id": "TOURNIQUET",
     "type": "json_flag",
     "context": [  ]

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2529,7 +2529,7 @@
         "type": "transform"
       }
     ],
-    "flags": [ "LITCIG", "TOBACCO", "LIGHT_4", "TRADER_AVOID", "FIRESTARTER" ]
+    "flags": [ "LITCIG", "MARIJUANA", "TOBACCO", "LIGHT_4", "TRADER_AVOID", "FIRESTARTER" ]
   },
   {
     "type": "GENERIC",
@@ -2605,7 +2605,7 @@
         "type": "transform"
       }
     ],
-    "flags": [ "LITCIG", "LIGHT_4", "TRADER_AVOID", "FIRESTARTER" ]
+    "flags": [ "LITCIG", "MARIJUANA", "LIGHT_4", "TRADER_AVOID", "FIRESTARTER" ]
   },
   {
     "type": "GENERIC",

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -61,6 +61,7 @@ void addict_effect( Character &u, addiction &add )
 
     switch( add.type ) {
         case add_type::CIG:
+            u.mod_int_bonus( -1 );
             if( !one_in( 2000 - 20 * in ) ) {
                 break;
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -134,6 +134,8 @@ static const efftype_id effect_weed_high( "weed_high" );
 static const fault_id fault_gun_blackpowder( "fault_gun_blackpowder" );
 static const fault_id fault_bionic_nonsterile( "fault_bionic_nonsterile" );
 
+static const flag_id flag_MARIJUANA( "MARIJUANA" );
+
 static const gun_mode_id gun_mode_REACH( "REACH" );
 
 static const itype_id itype_barrel_small( "barrel_small" );
@@ -9770,11 +9772,16 @@ detached_ptr<item> item::process_litcig( detached_ptr<item> &&self, player *carr
             duration = 30_seconds;
         }
         carrier->add_msg_if_player( m_neutral, _( "You take a puff of your %s." ), it.tname() );
+
+        // we need to figure out a way to get the item before this got converted,
+        // but i don't think that's going to be very easy...
         if( it.has_flag( flag_TOBACCO ) ) {
             carrier->add_effect( effect_cig, duration );
-        } else {
+        }
+        if( it.has_flag( flag_MARIJUANA ) ) {
             carrier->add_effect( effect_weed_high, duration / 2 );
         }
+
         carrier->moves -= 15;
 
         if( ( carrier->has_effect( effect_shakes ) && one_in( 10 ) ) ) {
@@ -9807,12 +9814,9 @@ detached_ptr<item> item::process_litcig( detached_ptr<item> &&self, player *carr
         if( carrier != nullptr ) {
             carrier->add_msg_if_player( m_neutral, _( "You finish your %s." ), it.tname() );
         }
-        if( it.typeId() == itype_cig_lit ) {
-            it.convert( itype_cig_butt );
-        } else if( it.typeId() == itype_cigar_lit ) {
-            it.convert( itype_cigar_butt );
-        } else { // joint
-            it.convert( itype_joint_roach );
+        it.convert( dynamic_cast<const iuse_transform *>
+                    ( it.type->get_use( "transform" )->get_actor_ptr() )->target );
+        if( it.has_flag( flag_MARIJUANA ) ) {
             if( carrier != nullptr ) {
                 carrier->add_effect( effect_weed_high, 1_minutes ); // one last puff
                 here.add_field( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), fd_weedsmoke, 2 );
@@ -9887,13 +9891,8 @@ detached_ptr<item> item::process_extinguish( detached_ptr<item> &&self, player *
 
     // cig dies out
     if( self->has_flag( flag_LITCIG ) ) {
-        if( self->typeId() == itype_cig_lit ) {
-            self->convert( itype_cig_butt );
-        } else if( self->typeId() == itype_cigar_lit ) {
-            self->convert( itype_cigar_butt );
-        } else { // joint
-            self->convert( itype_joint_roach );
-        }
+        self->convert( dynamic_cast<const iuse_transform *>
+                       ( self->type->get_use( "transform" )->get_actor_ptr() )->target );
     } else { // transform (lit) items
         if( !self->revert( carrier ) ) {
             self->type->invoke( carrier != nullptr ? *carrier : get_avatar(), *self, pos, "transform" );


### PR DESCRIPTION
## Purpose of change (The Why)
resolves https://github.com/cataclysmbnteam/Cataclysm-BN/issues/6723
and part 2 of the fix for 6725.
## Describe the solution (The How)
Adds a single line to the cig addiction that was presumably removed at some point accidentally, or never existed in the first place. (despite the description)
Add new flag "MARIJUANA" that is used to determine the puffs from a cigarette.
## Describe alternatives you've considered
## Testing
## Additional context
 I went the "MARIJUANA" flag route because the cig_lit variant of whatever smoking item does not have the relevant information to determine the effect type. This could be fixed in a separate PR, but custom smoking items will still work, just in a one shot sort of way. (like the blunt did before this fix) If anyone has suggestions on how to get the relevant information from the item before it was transformed, I'd be happy to implement the fix.
## Checklist
### Mandatory
- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
