### PR TITLE
feat(balance): Lower `makeshift_crowbar` recipe hammering requirement

### DIFF
--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -3013,7 +3013,7 @@
     "skill_used": "fabrication",
     "time": "1 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "components": [ [ [ "pipe", 1 ] ] ]
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

#1274 Upped the hammering requirement even though it no-longer gave the makeshift crowbar prying 2, which seems to have been the original concern / reasoning for the hammering being bumped.

Hammering 2 v.s. 1 is, truthfully, a minor distinction at the moment given the fact that a stone hammer is just 1-2 rocks, a plank/heavy stick, and some string away.

## Describe the solution (The How)

Lower the hammering requirement back down to 1

## Describe alternatives you've considered

- Wait for someone else to do it
- Do nothing

## Testing

Small number tweak, the linter doesn't shit itself so I assume it's fine.

## Additional context

Prompted by a reddit post.

I firmly believe that this is such a minor change it doesn't even really affect balance, especially given the chances to fail when prying as it is.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
