### PR TITLE
fix: Remove NO_QUICKDRAW from several holsters

### DIFF
--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -27,7 +27,7 @@
       "flags": [ "BELT_CLIP" ]
     },
     "valid_mods": [ "resized_large" ],
-    "flags": [ "FANCY", "WAIST", "COMPACT", "NO_QUICKDRAW", "WATER_FRIENDLY" ]
+    "flags": [ "FANCY", "WAIST", "COMPACT", "WATER_FRIENDLY" ]
   },
   {
     "abstract": "judo_belt_abstract",

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -238,7 +238,7 @@
       "flags": [ "BELT_CLIP", "SHEATH_KNIFE" ]
     },
     "valid_mods": [ "resized_large" ],
-    "flags": [ "WAIST", "COMPACT", "NO_QUICKDRAW", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY" ]
   },
   {
     "id": "webbing_belt",

--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -23,7 +23,7 @@
       "draw_cost": 150,
       "skills": [ "smg", "shotgun", "rifle", "launcher" ]
     },
-    "flags": [ "BELTED", "COMPACT", "OVERSIZE", "NO_QUICKDRAW" ]
+    "flags": [ "BELTED", "COMPACT", "OVERSIZE" ]
   },
   {
     "id": "bootstrap",

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -442,7 +442,7 @@
       "flags": [ "SHEATH_SWORD", "SHEATH_AXE", "SHEATH_SPEAR" ],
       "skills": [ "smg", "shotgun", "rifle", "launcher" ]
     },
-    "flags": [ "POWERARMOR_MOD", "COMPACT", "BELTED", "NO_QUICKDRAW", "ONLY_ONE" ]
+    "flags": [ "POWERARMOR_MOD", "COMPACT", "BELTED", "ONLY_ONE" ]
   },
   {
     "id": "power_armor_leg_hardpoint",


### PR DESCRIPTION
## Purpose of change (The Why)

Normally, having a gun in a holster will enable one to 'f'ire dirrectly from the gun holstered within, which is much more convenient than manually going into inventory to wield it. Holsters with the `NO_QUICKDRAW` flag however, have this feature disabled. It doesn't even effect draw/holster speed, it merely exists to make you 'a'ctivate your holster rather than firing dirrectly from it, annoying you in the process.

## Describe the solution (The How)

Remove the `NO_QUICKDRAW` flag from several holsters

## Describe alternatives you've considered

Obsolete the `NO_QUICKDRAW` flag all together.
DDA already canned it in their #65423

## Testing

Spawned in and used all of the affected holsters.
I was able to press "f" and the holstered weapon would appear as an option.
This desirable outcome was observed with all but the fireman belt and the tool belt, neither of which are capable of carrying a gun in the first place. Why they have the flag, I have no idea.

## Additional context

Didn't touch the C.R.I.T. backpack because it was mod content and I assumed the flag was intentional judging by its description of drawing and holstering being "awkward".

The only reason I've been able to find for `NO_QUICKDRAW`'s continued existance is that #4722 said "quick-drawing from a holster that has multiple guns stashed in it doesn't work well." It's not entirely useless; it's just not being used for anything right now, like that one t-shirt that you never wear but still keep for some reason.

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
