### PR TITLE
fix: double spawns, friendlier civilians

### DIFF
--- a/data/mods/Civilians/civilians.json
+++ b/data/mods/Civilians/civilians.json
@@ -17,6 +17,7 @@
     "color": "white",
     "diff": 2,
     "aggression": -50,
+    "aggro_character": false,
     "morale": -50,
     "vision_day": 10,
     "melee_dice": 1,

--- a/data/mods/Civilians/monstergroup.json
+++ b/data/mods/Civilians/monstergroup.json
@@ -4,19 +4,19 @@
     "name": "GROUP_ZOMBIE",
     "default": "mon_zombie",
     "monsters": [
-      { "monster": "mon_civilian_panic", "freq": 6, "cost_multiplier": 0, "pack_size": [ 1, 5 ], "ends": 72 },
-      { "monster": "mon_civilian_stationary", "freq": 6, "cost_multiplier": 0, "ends": 48 },
+      { "monster": "mon_civilian_panic", "freq": 12, "cost_multiplier": 1, "pack_size": [ 1, 5 ], "ends": 72 },
+      { "monster": "mon_civilian_stationary", "freq": 12, "cost_multiplier": 0, "ends": 48 },
       {
         "monster": "mon_civilian_parent",
-        "freq": 6,
-        "cost_multiplier": 0,
+        "freq": 12,
+        "cost_multiplier": 1,
         "pack_size": [ 1, 2 ],
         "starts": 24,
         "ends": 72
       },
-      { "monster": "mon_civilian_child", "freq": 6, "cost_multiplier": 0, "starts": 24, "ends": 72 },
-      { "monster": "mon_civilian_zombiefighter", "freq": 6, "cost_multiplier": 0, "ends": 72 },
-      { "monster": "mon_civilian_police", "freq": 4, "cost_multiplier": 0, "ends": 72 }
+      { "monster": "mon_civilian_child", "freq": 12, "cost_multiplier": 0, "starts": 24, "ends": 72 },
+      { "monster": "mon_civilian_zombiefighter", "freq": 12, "cost_multiplier": 0, "ends": 72 },
+      { "monster": "mon_civilian_police", "freq": 8, "cost_multiplier": 0, "ends": 72 }
     ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)
Increase civilian spawns & add make civilians less trigger happy.
## Describe the solution (The How)
Doubles the monstergroup's spawns, and add `"aggro_character": false` to the base civilian.
## Describe alternatives you've considered
## Testing
Before this change, overconfident officers would shoot on sight in a field. After, they no longer attack the player without first being provoked and agitated by another enemy.
## Additional context
I doubled the spawn rate because they were almost nonexistent before. Considering these enemies stop spawning on day 3 anyways, I figured the new amount is reasonable.
## Checklist
### Mandatory
- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.