### PR TITLE
feat: auto-find stairs & port find_stairs extraction from find_or_make_stairs

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -548,6 +548,42 @@ void game::load_map( const tripoint_abs_sm &pos_sm,
     grid_tracker_ptr->load( m );
 }
 
+tripoint game::find_closest_stair( const tripoint &near_this, const ter_bitflags stair_type )
+{
+    // we probably need to add furniture/traps for drainspouts at some point
+    map &here = get_map();
+    for( const tripoint &candidate : closest_points_first( get_avatar().pos(), 40 ) ) {
+        if( here.has_flag( stair_type, candidate ) ) {
+            return candidate;
+
+        }
+    }
+    // we didn't find it
+    return near_this;
+}
+
+void game::suggest_auto_walk_to_stairs( Character &u, map &m, const std::string &direction )
+{
+    const ter_bitflags stair_flag = direction == "up" ? TFLAG_GOES_UP : TFLAG_GOES_DOWN;
+    tripoint stair_pos = find_closest_stair( u.pos(), stair_flag );
+    if( !u.sees( stair_pos ) ) {
+        return;
+    }
+
+    auto route = m.route( u.pos(), stair_pos, u.get_legacy_pathfinding_settings(),
+                          u.get_legacy_path_avoid() );
+    if( route.size() <= 1 ) {
+        // Don't repeat the main fail msg — just silently fail.
+        return;
+    }
+
+    if( query_yn( "Walk to %s?", m.ter( stair_pos ).obj().name() ) ) {
+        route.pop_back();
+        u.set_destination( route, u.remove_activity() );
+        u.activity = std::make_unique<player_activity>();
+    }
+}
+
 // Set up all default values for a new game
 bool game::start_game()
 {
@@ -10057,6 +10093,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
         // Climbing
         if( m.has_floor_or_support( stairs ) ) {
             add_msg( m_info, _( "You can't climb here - there's a ceiling above your head." ) );
+            suggest_auto_walk_to_stairs( u, m, "up" );
             return;
         }
 
@@ -10094,6 +10131,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
             } else {
                 add_msg( m_info, _( "You can't climb here - you need walls and/or furniture to brace against." ) );
 
+                suggest_auto_walk_to_stairs( u, m, "up" );
             }
             return;
 
@@ -10102,6 +10140,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
         if( pts.empty() ) {
             add_msg( m_info,
                      _( "You can't climb here - there is no terrain above you that would support your weight." ) );
+            suggest_auto_walk_to_stairs( u, m, "up" );
             return;
         } else {
             // TODO: Make it an extended action
@@ -10119,6 +10158,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
     if( !force && movez == -1 && !m.has_flag( "GOES_DOWN", u.pos() ) &&
         !u.is_underwater() ) {
         add_msg( m_info, _( "You can't go down here!" ) );
+        suggest_auto_walk_to_stairs( u, m, "down" );
         return;
     } else if( !climbing && !force && movez == 1 && !m.has_flag( "GOES_UP", u.pos() ) &&
                !u.is_underwater() ) {

--- a/src/game.h
+++ b/src/game.h
@@ -471,6 +471,7 @@ class game
         void unload_npcs();
     public:
         static tripoint find_closest_stair( const tripoint &near_this, const ter_bitflags stair_type );
+        std::optional<tripoint> find_local_stairs_leading_to( map &mp, const int z_after );
         void suggest_auto_walk_to_stairs( Character &u, map &m, const std::string &direction );
         /** Unloads, then loads the NPCs */
         void reload_npcs();

--- a/src/game.h
+++ b/src/game.h
@@ -24,6 +24,7 @@
 #include "enums.h"
 #include "game_constants.h"
 #include "memory_fast.h"
+#include "mapdata.h"
 #include "pimpl.h"
 #include "point.h"
 #include "type_id.h"
@@ -468,6 +469,8 @@ class game
          */
         void unload_npcs();
     public:
+        static tripoint find_closest_stair( const tripoint &near_this, const ter_bitflags stair_type );
+        void suggest_auto_walk_to_stairs( Character &u, map &m, const std::string &direction );
         /** Unloads, then loads the NPCs */
         void reload_npcs();
         /** Add follower id to set of followers. */

--- a/src/game.h
+++ b/src/game.h
@@ -237,6 +237,7 @@ class game
         void vertical_move( int z, bool force, bool peeking = false );
         void start_hauling( const tripoint &pos );
         /** Returns the other end of the stairs (if any). May query, affect u etc.  */
+        std::optional<tripoint> find_stairs( map &mp, int z_after, bool peeking );
         std::optional<tripoint> find_or_make_stairs( map &mp, int z_after, bool &rope_ladder,
                 bool peeking );
         /** Actual z-level movement part of vertical_move. Doesn't include stair finding, traps etc. */


### PR DESCRIPTION
## Purpose of change (The Why)
Adds a QoL feature inspired (almost directly taken) from Caves of Qud - when the player isn't near a staircase, the game will now prompt the user if they want to walk up to the closest terrain change tile.
## Describe the solution (The How)
Add a popup that lets the user select yes or no, if they select yes make them auto-walk to the closest visible staircase within a radius of 40 tiles. If no staircase is visible, the popup will not show up.
## Describe alternatives you've considered
Adding furniture, but I don't know how easy it is to iterate over furniture tiles like it is normal tiles - I pretty much just ripped the existing code from monmove.
## Testing
Created a stairs up and stairs down tile in a field, with a wall in between. When my character had line of sight to either staircase and I pressed < or >, I received a popup as expected. When behind cover, or none were visible, I did not receive the popup. (as expected)
## Additional context
![image](https://github.com/user-attachments/assets/9ea8b3cb-1571-4bea-8fc9-4faf7344a8f6)
![image](https://github.com/user-attachments/assets/a21f96f3-35d1-43da-9557-a764b6cd69b9)
Note that this is likely to cause merge conflicts with my flight PR. Should be an easy fix, but we're going to leave this as  a draft until then just in case.
## Checklist
### Mandatory
- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
### Optional
- [X] This PR ports commits from DDA or other cataclysm forks.
  - [X] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [X] I have linked the URL of original PR(s) in the description.
<!--
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->