### PR TITLE
docs: document sprite selection on spells

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -69,7 +69,8 @@ In `data/json/debug_spells.json` there is a template spell, copied here for your
   "sound_description": "a whoosh", // the sound description. in the form of "You hear %s" by default it is "an explosion"
   "sound_ambient": true, // whether or not this is treated as an ambient sound or not
   "sound_id": "misc", // the sound id
-  "sound_variant": "shockwave" // the sound variant
+  "sound_variant": "shockwave", // the sound variant
+  "sprite": "fd_electricity", // This changes the spell sprite to any valid field ID. Do not use with NO_EXPLOSION_VFX
   "learn_spells": { "acid_resistance_greater": 15 } // You learn the specified spell once your level in this spell is greater than or equal to the number shown.
 }
 ```


### PR DESCRIPTION
## Purpose of change (The Why)

It was an average Wednesday, which meant I got mad that another spell code field went undocumented. I documented sprite

## Describe the solution (The How)

Writes the actual documentation

## Describe alternatives you've considered

I make YOU, the reader, do it.

## Testing

No

## Additional context

https://youtu.be/lcBUNSbMW3k?t=4509

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.