### PR TITLE
fix: typo FLAMABLE_ASH -> FLAMMABLE_ASH

### DIFF
--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -1063,7 +1063,7 @@
     "flags": [
       "PLACE_ITEM",
       "TRANSPARENT",
-      "FLAMABLE_ASH",
+      "FLAMMABLE_ASH",
       "MOUNTABLE",
       "ALLOW_FIELD_EFFECT",
       "EASY_DECONSTRUCT",


### PR DESCRIPTION
## Purpose of change (The Why)
Found typo in flags for `f_butcher_rack`

## Describe the solution (The How)
`"FLAMABLE_ASH" -> "FLAMMABLE_ASH"`

## Testing
No testing, `"FLAMABLE_ASH"` isn't referenced anywhere within the game while `"FLAMMABLE_ASH"` is so it should properly apply the relevant effect now.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
