### PR TITLE
feat(balance): tone down cotton seed quantities

### DIFF
--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -183,7 +183,7 @@
     "price": "50 cent",
     "name": { "str_sp": "cotton seeds" },
     "description": "Some cotton seeds.  Can be processed to produce an edible oil.",
-    "charges": 8,
+    "charges": 2,
     "stack_size": 40,
     "seed_data": { "plant_name": "cotton", "fruit": "cotton_boll", "byproducts": [ "withered" ], "grow": "20 days" }
   },

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -91,7 +91,7 @@
     "time": "54 m",
     "autolearn": true,
     "charges": 4,
-    "byproducts": [ [ "seed_cotton_boll", 2 ] ],
+    "byproducts": [ [ "seed_cotton_boll", 1 ] ],
     "components": [ [ [ "cotton_boll", 1 ] ] ]
   },
   {
@@ -103,7 +103,7 @@
     "time": "9 m",
     "autolearn": true,
     "charges": 4,
-    "byproducts": [ [ "seed_cotton_boll", 2 ] ],
+    "byproducts": [ [ "seed_cotton_boll", 1 ] ],
     "tools": [ [ [ "carding_paddles", -1 ] ] ],
     "components": [ [ [ "cotton_boll", 1 ] ] ]
   },


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Processing cotton bolls into balls yields 4 cotton balls per craft...and 16 cotton seeds. You'll very rapidly be left drowning in seeds after one modest harvest.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Toned down `charges` of cotton seeds from 8 to 1, matching the majority of seed items in the game. Noteworth is that canola seeds use this amount too, despite also being geared toward cooking oil being a primaey crafting purpose.
2. Set by-products for the two cotton ball recipes to only give 1 stack of seeds, not 2. Most likely the by-products were erroneously assuming that by-product count is number of units and not number of charge stacks.

Net effect is processing 1 cotton boll yields 4 cotton balls and 2 seeds, and harvesting cotton will give 2 seeds per stack of 8 bolls generated (which will still be greatly supplemented by seeds from the 8-16 bolls you tend to get per plant).

## Describe alternatives you've considered

1. Making cotton bolls not yield any seeds when processed, which isn't _realimsic_ but no other crop in the game grants seeds when put through its main crafting use like this, instead relying on explicit recipes to pick out seeds if you find the plant somewhere and want to bootstrap farming.
2. Toning down the stack size of cotton bolls themselves might also be good, because even with this change one stack of 8 bolls gives you 16 seeds when processed, which is still doubling your seed investment but at least it's not giving you 64 of the lil fuckers per stack of cotton bolls anymore.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
3. Ported changes to playthrough build and load-tested
4. Harvested one of the cotton plants I had in said save, got 4 seeds and 16 bolls.
5. Processed one of the bolls, no longer get 4 times as many seeds as balls anymore.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
