### PR TITLE
feat(port): per category spawnrate control in world options

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -288,6 +288,25 @@ item in `data/json/items/bionics.json`. Even for a faulty bionic.
   "category": "MUTCAT_BIRD",
   "strength": 1
 }
+
+### Item Category
+
+When you sort your inventory by category, these are the categories that are displayed.
+| Identifier | Description
+|---         |---
+| id         | Unique ID. Must be one continuous word, use underscores if necessary
+| name       | The name of the category. This is what shows up in-game when you open the inventory.
+| zone       | The corresponding loot_zone (see loot_zones.json)
+| sort_rank  | Used to sort categories when displaying.  Lower values are shown first
+
+
+```C++
+{
+    "id":"ammo",
+    "name": "AMMO",
+    "zone": "LOOT_AMMO",
+    "sort_rank": -21
+}
 ```
 
 ### Disease

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -292,20 +292,22 @@ item in `data/json/items/bionics.json`. Even for a faulty bionic.
 ### Item Category
 
 When you sort your inventory by category, these are the categories that are displayed.
-| Identifier | Description
-|---         |---
-| id         | Unique ID. Must be one continuous word, use underscores if necessary
-| name       | The name of the category. This is what shows up in-game when you open the inventory.
-| zone       | The corresponding loot_zone (see loot_zones.json)
-| sort_rank  | Used to sort categories when displaying.  Lower values are shown first
-
+| Identifier      | Description
+|---              |---
+| id              | Unique ID. Must be one continuous word, use underscores if necessary
+| name            | The name of the category. This is what shows up in-game when you open the inventory.
+| zone            | The corresponding loot_zone (see loot_zones.json)
+| sort_rank       | Used to sort categories when displaying.  Lower values are shown first
+| priority_zones  | When set, items in this category will be sorted to the priority zone if the conditions are met. If the user does not have the priority zone in the zone manager, the items get sorted into zone set in the 'zone' property. It is a list of objects. Each object has 3 properties: ID: The id of a LOOT_ZONE (see LOOT_ZONES.json), filthy: boolean. setting this means filthy items of this category will be sorted to the priority zone, flags: array of flags
+|spawn_rate       | Sets amount of items from item category that might spawn.  Checks for `spawn_rate` value for item category.  If `spawn_chance` is less than 1.0, it will make a random roll (0.1-1.0) to check if the item will have a chance to spawn.  If `spawn_chance` is more than or equal to 1.0, it will add a chance to spawn additional items from the same category.  Items will be taken from item group which original item was located in.  Therefore this parameter won't affect chance to spawn additional items for items set to spawn solitary in mapgen (e.g. through use of `item` or `place_item`).
 
 ```C++
 {
-    "id":"ammo",
-    "name": "AMMO",
-    "zone": "LOOT_AMMO",
-    "sort_rank": -21
+  "id":"armor",
+  "name": "ARMOR",
+  "zone": "LOOT_ARMOR",
+  "sort_rank": -21,
+  "priority_zones": [ { "id": "LOOT_FARMOR", "filthy": true, "flags": [ "RAINPROOF" ] } ],
 }
 ```
 

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -279,7 +279,7 @@ item in `data/json/items/bionics.json`. Even for a faulty bionic.
 | category   | Mutation category needed to dream.                                   |
 | strength   | Mutation category strength required (1 = 20-34, 2 = 35-49, 3 = 50+). |
 
-```json
+````json
 {
   "messages": [
     "You have a strange dream about birds.",
@@ -309,7 +309,7 @@ When you sort your inventory by category, these are the categories that are disp
   "sort_rank": -21,
   "priority_zones": [ { "id": "LOOT_FARMOR", "filthy": true, "flags": [ "RAINPROOF" ] } ],
 }
-```
+````
 
 ### Disease
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5936,8 +5936,17 @@ bool item::goes_bad() const
     return is_food() && get_comestible()->spoils != 0_turns;
 }
 
-bool item::goes_bad_after_opening() const
+bool item::goes_bad_after_opening( bool strict ) const
 {
+    // check if this item is explicitly a canning-type item: eg, it preserves contents
+    if( strict ) {
+        if( type->container && type->container->preserves &&
+            !contents.empty() && contents.front().goes_bad() ) {
+            return true;
+        }
+    } else {
+        return false;
+    }
     return goes_bad() || ( type->container && type->container->preserves &&
                            !contents.empty() && contents.front().goes_bad() );
 }

--- a/src/item.h
+++ b/src/item.h
@@ -925,7 +925,7 @@ class item : public location_visitable<item>, public game_object<item>
         bool goes_bad() const;
 
         /** whether an item is perishable (can rot), even if it is currently in a preserving container */
-        bool goes_bad_after_opening() const;
+        bool goes_bad_after_opening( bool strict = false ) const;
 
         /** Get the shelf life of the item*/
         time_duration get_shelf_life() const;

--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -48,6 +48,7 @@ void item_category::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "sort_rank", sort_rank_ );
     optional( jo, was_loaded, "priority_zones", zone_priority_ );
     optional( jo, was_loaded, "zone", zone_, std::nullopt );
+    optional( jo, was_loaded, "spawn_rate", spawn_rate, 1.0f );
 }
 
 bool item_category::operator<( const item_category &rhs ) const
@@ -99,4 +100,9 @@ std::optional<zone_type_id> item_category::priority_zone( const item &it ) const
 int item_category::sort_rank() const
 {
     return sort_rank_;
+}
+
+float item_category::get_spawn_rate() const
+{
+    return spawn_rate;
 }

--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -48,7 +48,6 @@ void item_category::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "sort_rank", sort_rank_ );
     optional( jo, was_loaded, "priority_zones", zone_priority_ );
     optional( jo, was_loaded, "zone", zone_, std::nullopt );
-    optional( jo, was_loaded, "spawn_rate", spawn_rate, 1.0f );
 }
 
 bool item_category::operator<( const item_category &rhs ) const
@@ -100,9 +99,4 @@ std::optional<zone_type_id> item_category::priority_zone( const item &it ) const
 int item_category::sort_rank() const
 {
     return sort_rank_;
-}
-
-float item_category::get_spawn_rate() const
-{
-    return spawn_rate;
 }

--- a/src/item_category.h
+++ b/src/item_category.h
@@ -35,6 +35,8 @@ class item_category
         translation name_;
         /** Used to sort categories when displaying.  Lower values are shown first. */
         int sort_rank_ = 0;
+         /** Global spawn rate for items from category */
+        float spawn_rate = 1.0f;
 
         std::optional<zone_type_id> zone_;
         std::vector<zone_priority_data> zone_priority_;
@@ -59,6 +61,7 @@ class item_category
         std::optional<zone_type_id> priority_zone( const item &it ) const;
         std::optional<zone_type_id> zone() const;
         int sort_rank() const;
+        float get_spawn_rate() const;
 
         /**
          * Comparison operators

--- a/src/item_category.h
+++ b/src/item_category.h
@@ -35,7 +35,7 @@ class item_category
         translation name_;
         /** Used to sort categories when displaying.  Lower values are shown first. */
         int sort_rank_ = 0;
-         /** Global spawn rate for items from category */
+        /** Global spawn rate for items from category */
         float spawn_rate = 1.0f;
 
         std::optional<zone_type_id> zone_;

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -47,6 +47,7 @@ using ItemList = std::vector<item *>;
  */
 std::vector<detached_ptr<item>> items_from( const item_group_id &group_id,
                              const time_point &birthday );
+
 /**
  * Same as above but with implicit birthday at turn 0.
  */

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4425,8 +4425,8 @@ detached_ptr<item> map::spawn_an_item( const tripoint &p, detached_ptr<item> &&n
 
 float map::item_category_spawn_rate( const item &itm )
 {
-    const item_category_id &cat = itm.get_category_of_contents().id;
-    const float spawn_rate = cat.obj().get_spawn_rate();
+    const std::string &cat = itm.get_category().id.c_str();
+    const float spawn_rate = get_option<float>( "SPAWN_RATE_" + cat );
 
     return spawn_rate > 1.0f ? roll_remainder( spawn_rate ) : spawn_rate;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -50,6 +50,7 @@
 #include "input.h"
 #include "int_id.h"
 #include "item.h"
+#include "item_category.h"
 #include "item_contents.h"
 #include "item_factory.h"
 #include "item_group.h"
@@ -4420,6 +4421,14 @@ detached_ptr<item> map::spawn_an_item( const tripoint &p, detached_ptr<item> &&n
     spawned_item->set_damage( damlevel );
 
     return add_item_or_charges( p, std::move( spawned_item ) );
+}
+
+float map::item_category_spawn_rate( const item &itm )
+{
+    const item_category_id &cat = itm.get_category_of_contents().id;
+    const float spawn_rate = cat.obj().get_spawn_rate();
+
+    return spawn_rate > 1.0f ? roll_remainder( spawn_rate ) : spawn_rate;
 }
 
 std::vector<detached_ptr<item>> map::spawn_items( const tripoint &p,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4426,7 +4426,14 @@ detached_ptr<item> map::spawn_an_item( const tripoint &p, detached_ptr<item> &&n
 float map::item_category_spawn_rate( const item &itm )
 {
     const std::string &cat = itm.get_category().id.c_str();
-    const float spawn_rate = get_option<float>( "SPAWN_RATE_" + cat );
+    float spawn_rate = get_option<float>( "SPAWN_RATE_" + cat );
+    if( itm.goes_bad() ) {
+        const float spawn_rate_mod = get_option<float>( "SPAWN_RATE_perishables" );
+        spawn_rate += spawn_rate_mod;
+    } else if( itm.goes_bad_after_opening( true ) ) {
+        const float spawn_rate_mod = get_option<float>( "SPAWN_RATE_perishables_canned" );
+        spawn_rate += spawn_rate_mod;
+    }
 
     return spawn_rate > 1.0f ? roll_remainder( spawn_rate ) : spawn_rate;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4429,10 +4429,12 @@ float map::item_category_spawn_rate( const item &itm )
     float spawn_rate = get_option<float>( "SPAWN_RATE_" + cat );
     if( itm.goes_bad() ) {
         const float spawn_rate_mod = get_option<float>( "SPAWN_RATE_perishables" );
-        spawn_rate += spawn_rate_mod;
+        spawn_rate = spawn_rate / 2;
+        spawn_rate += spawn_rate_mod / 2;
     } else if( itm.goes_bad_after_opening( true ) ) {
         const float spawn_rate_mod = get_option<float>( "SPAWN_RATE_perishables_canned" );
-        spawn_rate += spawn_rate_mod;
+        spawn_rate = spawn_rate / 2;
+        spawn_rate += spawn_rate_mod / 2;
     }
 
     return spawn_rate > 1.0f ? roll_remainder( spawn_rate ) : spawn_rate;

--- a/src/map.h
+++ b/src/map.h
@@ -1251,6 +1251,15 @@ class map
         detached_ptr<item> add_item_or_charges( point p, detached_ptr<item> &&obj, bool overflow = true ) {
             return add_item_or_charges( tripoint( p, abs_sub.z ), std::move( obj ), overflow );
         }
+        
+        /**
+         * Checks for spawn_rate value for item category of 'itm'.
+         * If spawn_rate is less than 1.0, it will make a random roll (0.1-1.0) to check if the item will have a chance to spawn.
+         * If spawn_rate is more than or equal to 1.0, it will make item spawn that many times (using roll_remainder).
+        */
+        float item_category_spawn_rate( const item &itm );
+
+
 
         /**
          * Place an item on the map, despite the parameter name, this is not necessarily a new item.

--- a/src/map.h
+++ b/src/map.h
@@ -1251,7 +1251,7 @@ class map
         detached_ptr<item> add_item_or_charges( point p, detached_ptr<item> &&obj, bool overflow = true ) {
             return add_item_or_charges( tripoint( p, abs_sub.z ), std::move( obj ), overflow );
         }
-        
+
         /**
          * Checks for spawn_rate value for item category of 'itm'.
          * If spawn_rate is less than 1.0, it will make a random roll (0.1-1.0) to check if the item will have a chance to spawn.
@@ -1355,6 +1355,12 @@ class map
         */
         std::vector<item *> put_items_from_loc( const item_group_id &loc, const tripoint &p,
                                                 const time_point &turn = calendar::start_of_cataclysm );
+
+        std::vector<item *> put_filtered_items_from_loc(
+            const item_group_id &loc,
+            const tripoint &p,
+            const time_point &turn,
+            const item_category_id &filter_cat );
 
         // Similar to spawn_an_item, but spawns a list of items, or nothing if the list is empty.
         std::vector<detached_ptr<item>> spawn_items( const tripoint &p,

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6266,8 +6266,43 @@ std::vector<item *> map::place_items( const item_group_id &loc, const int chance
             tries++;
         } while( is_valid_terrain( p ) && tries < 20 );
         if( tries < 20 ) {
-            auto put = put_items_from_loc( loc, tripoint( p, abs_sub.z ), turn );
-            res.insert( res.end(), put.begin(), put.end() );
+            for( const item &itm : item_group::items_from( group_id, turn, spawn_flags::use_spawn_rate ) ) {
+                const float item_cat_spawn_rate = std::max( 0.0f, item_category_spawn_rate( itm ) );
+                // for items with category spawn rate less than or equal to 1, roll a dice to see if they should spawn
+                if( item_cat_spawn_rate <= 1 ) {
+                    if( rng_float( 0.1f, 1 ) <= item_cat_spawn_rate ) {
+                         item &it = add_item_or_charges( p, itm );
+                        if( !it.is_null() ) {
+                            res.push_back( &it );
+                        }
+                    }
+                    // for items with category spawn rate more than 1, spawn item at least one time...
+                } else {
+                    item &it = add_item_or_charges( p, itm );
+                    if( !it.is_null() ) {
+                        res.push_back( &it );
+                    }
+
+                    // ...then create a list with items from the same item group and remove all items with differing category from that list
+                    // so if the original item was e.g. from 'guns' category, the list will contain only items from the 'guns' category...
+                    Item_list extra_spawn = item_group::items_from( group_id, turn, spawn_flags::use_spawn_rate );
+                    extra_spawn.erase( std::remove_if( extra_spawn.begin(), extra_spawn.end(), [&itm]( item & it ) {
+                        return it.get_category_of_contents() != itm.get_category_of_contents();
+                    } ), extra_spawn.end() );
+
+                    // ...then add a chance to spawn additional items from the list, amount is based on the item category spawn rate
+                    for( int i = 0; i < item_cat_spawn_rate; i++ ) {
+                        for( const item &it : extra_spawn ) {
+                            if( rng( 1, 100 ) <= chance ) {
+                                item &new_item = add_item_or_charges( p, it );
+                                if( !new_item.is_null() ) {
+                                    res.push_back( &new_item );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
     for( auto e : res ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2433,76 +2433,120 @@ void options_manager::add_options_world_default()
                                             to_translation( "Spawn rate for item categories. Values ≤ 1.0 represent a chance to spawn. >1.0 means extra spawns. Set to 0.0 to disable spawning items from that category." ) ),
     [&]( const std::string & page_id ) {
 
-        add( "SPAWN_RATE_guns", page_id, "GUNS",
-             "Spawn rate for items from GUNS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_magazines", page_id, "MAGAZINES",
-             "Spawn rate for items from MAGAZINES category.",
-             0.0, 20.0, 1.0, 0.01 );
-
         add( "SPAWN_RATE_ammo", page_id, "AMMO",
              "Spawn rate for items from AMMO category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_weapons", page_id, "WEAPONS",
-             "Spawn rate for items from WEAPONS category.",
+        add( "SPAWN_RATE_artifacts", page_id, "ARTIFACTS",
+             "Spawn rate for items from ARTIFACTS category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_tools", page_id, "OTHER TOOLS",
-             "Spawn rate for items from OTHER TOOLS category.",
+        add( "SPAWN_RATE_battery", page_id, "BATTERIES",
+             "Spawn rate for items from BATTERIES category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_tools_entry", page_id, "ENTRY TOOLS",
-             "Spawn rate for items from ENTRY TOOLS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_tools_workshop", page_id, "WORKSHOP TOOLS",
-             "Spawn rate for items from WORKSHOP TOOLS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_tools_cooking", page_id, "COOKING TOOLS",
-             "Spawn rate for items from COOKING TOOLS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_tools_chemistry", page_id, "CHEMISTRY TOOLS",
-             "Spawn rate for items from CHEMISTRY TOOLS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_tools_farming", page_id, "FARM TOOLS",
-             "Spawn rate for items from FARM TOOLS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_deployables", page_id, "DEPLOYABLES",
-             "Spawn rate for items from DEPLOYABLES category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_electronics", page_id, "ELECTRONICS",
-             "Spawn rate for items from ELECTRONICS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_clothing", page_id, "CLOTHING",
-             "Spawn rate for items from CLOTHING category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_food", page_id, "FOOD",
-             "Spawn rate for items from FOOD category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_cooking_ingredients", page_id, "COOKING INGREDIENTS",
-             "Spawn rate for items from COOKING INGREDIENTS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_drugs", page_id, "DRUGS",
-             "Spawn rate for items from DRUGS category.",
+        add( "SPAWN_RATE_bionics", page_id, "BIONICS",
+             "Spawn rate for items from BIONICS category.",
              0.0, 20.0, 1.0, 0.01 );
 
         add( "SPAWN_RATE_books", page_id, "BOOKS",
              "Spawn rate for items from BOOKS category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_spellbooks", page_id, "SPELLBOOKS",
-             "Spawn rate for items from SPELLBOOKS category.",
+        add( "SPAWN_RATE_perishables_canned", page_id, "CANNED PERISHABLES",
+             "Spawn rate for items from CANNED PERISHABLES category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_ceramics", page_id, "CERAMIC SCRAP",
+             "Spawn rate for items from CERAMIC SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_chems", page_id, "CHEMICAL STUFF",
+             "Spawn rate for items from CHEMICAL STUFF category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_tools_chemistry", page_id, "CHEMISTRY TOOLS",
+             "Spawn rate for items from CHEMISTRY TOOLS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_clothing", page_id, "CLOTHING",
+             "Spawn rate for items from CLOTHING category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_container", page_id, "CONTAINER",
+             "Spawn rate for items from CONTAINER category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_cooking_ingredients", page_id, "COOKING INGREDIENTS",
+             "Spawn rate for items from COOKING INGREDIENTS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_tools_cooking", page_id, "COOKING TOOLS",
+             "Spawn rate for items from COOKING TOOLS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_deployables", page_id, "DEPLOYABLES",
+             "Spawn rate for items from DEPLOYABLES category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_drugs", page_id, "DRUGS",
+             "Spawn rate for items from DRUGS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_electronics", page_id, "ELECTRONIC SCRAP",
+             "Spawn rate for items from ELECTRONIC SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_electronics", page_id, "ELECTRONICS",
+             "Spawn rate for items from ELECTRONICS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_tools_entry", page_id, "ENTRY TOOLS",
+             "Spawn rate for items from ENTRY TOOLS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_fabric", page_id, "FABRICS",
+             "Spawn rate for items from FABRICS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_tools_farming", page_id, "FARM TOOLS",
+             "Spawn rate for items from FARM TOOLS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_food", page_id, "FOOD",
+             "Spawn rate for items from FOOD category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_fuel", page_id, "FUEL",
+             "Spawn rate for items from FUEL category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_glass", page_id, "GLASS SCRAP",
+             "Spawn rate for items from GLASS SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_guns", page_id, "GUNS",
+             "Spawn rate for items from GUNS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_leather", page_id, "LEATHER SCRAP",
+             "Spawn rate for items from LEATHER SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_magazines", page_id, "MAGAZINES",
+             "Spawn rate for items from MAGAZINES category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_maps", page_id, "MAPS",
+             "Spawn rate for items from MAPS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_metal", page_id, "METAL SCRAP",
+             "Spawn rate for items from METAL SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_misc", page_id, "MISC SCRAP",
+             "Spawn rate for items from MISC SCRAP category.",
              0.0, 20.0, 1.0, 0.01 );
 
         add( "SPAWN_RATE_mods", page_id, "MODS",
@@ -2513,93 +2557,64 @@ void options_manager::add_options_world_default()
              "Spawn rate for items from MUTAGENS category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_bionics", page_id, "BIONICS",
-             "Spawn rate for items from BIONICS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_veh_parts", page_id, "VEHICLE PARTS",
-             "Spawn rate for items from VEHICLE PARTS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
         add( "SPAWN_RATE_other", page_id, "OTHER",
              "Spawn rate for items from OTHER category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_fuel", page_id, "FUEL",
-             "Spawn rate for items from FUEL category.",
+        add( "SPAWN_RATE_tools", page_id, "OTHER TOOLS",
+             "Spawn rate for items from OTHER TOOLS category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_seeds", page_id, "SEEDS",
-             "Spawn rate for items from SEEDS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_chems", page_id, "CHEMICAL STUFF",
-             "Spawn rate for items from CHEMICAL STUFF category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_battery", page_id, "BATTERIES",
-             "Spawn rate for items from BATTERIES category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_spare_parts", page_id, "SPARE PARTS",
-             "Spawn rate for items from SPARE PARTS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_scrap_metal", page_id, "METAL SCRAP",
-             "Spawn rate for items from METAL SCRAP category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_scrap_electronics", page_id, "ELECTRONIC SCRAP",
-             "Spawn rate for items from ELECTRONIC SCRAP category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_scrap_fabric", page_id, "FABRICS",
-             "Spawn rate for items from FABRICS category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_scrap_wood", page_id, "WOOD SCRAP",
-             "Spawn rate for items from WOOD SCRAP category.",
+        // this needs special handling since it uses .goes_bad() instead of an actual group
+        // this needs special handling since it uses .goes_bad() instead of an actual group
+        add( "SPAWN_RATE_perishables", page_id, "PERISHABLES",
+             "Spawn rate for items from PERISHABLES category.",
              0.0, 20.0, 1.0, 0.01 );
 
         add( "SPAWN_RATE_scrap_plastic", page_id, "PLASTIC SCRAP",
              "Spawn rate for items from PLASTIC SCRAP category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_scrap_ceramics", page_id, "CERAMIC SCRAP",
-             "Spawn rate for items from CERAMIC SCRAP category.",
-             0.0, 20.0, 1.0, 0.01 );
-
-        add( "SPAWN_RATE_scrap_glass", page_id, "GLASS SCRAP",
-             "Spawn rate for items from GLASS SCRAP category.",
+        add( "SPAWN_RATE_rocks", page_id, "ROCKS",
+             "Spawn rate for items from ROCKS category.",
              0.0, 20.0, 1.0, 0.01 );
 
         add( "SPAWN_RATE_scrap_rubber", page_id, "RUBBER SCRAP",
              "Spawn rate for items from RUBBER SCRAP category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_scrap_leather", page_id, "LEATHER SCRAP",
-             "Spawn rate for items from LEATHER SCRAP category.",
+        add( "SPAWN_RATE_seeds", page_id, "SEEDS",
+             "Spawn rate for items from SEEDS category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_scrap_misc", page_id, "MISC SCRAP",
-             "Spawn rate for items from MISC SCRAP category.",
+        add( "SPAWN_RATE_spare_parts", page_id, "SPARE PARTS",
+             "Spawn rate for items from SPARE PARTS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_spellbooks", page_id, "SPELLBOOKS",
+             "Spawn rate for items from SPELLBOOKS category.",
              0.0, 20.0, 1.0, 0.01 );
 
         add( "SPAWN_RATE_valuables", page_id, "VALUABLES",
              "Spawn rate for items from VALUABLES category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_container", page_id, "CONTAINER",
-             "Spawn rate for items from CONTAINER category.",
+        add( "SPAWN_RATE_veh_parts", page_id, "VEHICLE PARTS",
+             "Spawn rate for items from VEHICLE PARTS category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_rocks", page_id, "ROCKS",
-             "Spawn rate for items from ROCKS category.",
+        add( "SPAWN_RATE_weapons", page_id, "WEAPONS",
+             "Spawn rate for items from WEAPONS category.",
              0.0, 20.0, 1.0, 0.01 );
 
-        add( "SPAWN_RATE_maps", page_id, "MAPS",
-             "Spawn rate for items from MAPS category.",
+        add( "SPAWN_RATE_scrap_wood", page_id, "WOOD SCRAP",
+             "Spawn rate for items from WOOD SCRAP category.",
              0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_tools_workshop", page_id, "WORKSHOP TOOLS",
+             "Spawn rate for items from WORKSHOP TOOLS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
 
     } );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2410,11 +2410,6 @@ void options_manager::add_options_world_default()
          0.0, 10.0, 1.0, 0.01, COPT_NO_HIDE
        );
 
-    add( "ITEM_SPAWNRATE", world_default, translate_marker( "Item spawn scaling factor" ),
-         translate_marker( "A scaling factor that determines density of item spawns." ),
-         0.01, 10.0, 1.0, 0.01
-       );
-
     add( "NPC_DENSITY", world_default, translate_marker( "NPC spawn rate scaling factor" ),
          translate_marker( "A scaling factor that determines density of dynamic NPC spawns." ),
          0.0, 100.0, 0.1, 0.01
@@ -2425,6 +2420,188 @@ void options_manager::add_options_world_default()
          translate_marker( "A scaling factor that determines the time between monster upgrades.  A higher number means slower evolution.  Set to 0.00 to turn off monster upgrades." ),
          0.0, 100, 2.0, 0.01
        );
+
+    add_empty_line();
+
+    add( "ITEM_SPAWNRATE", world_default,
+         "Item spawn scaling factor",
+         "A scaling factor that determines density of item spawns. A higher number means more items.",
+         0.01, 10.0, 1.0, 0.01 );
+
+    add_option_group( world_default, Group( "item_category_spawn_rate",
+                                            to_translation( "Item category spawn rate" ),
+                                            to_translation( "Spawn rate for item categories. Values ≤ 1.0 represent a chance to spawn. >1.0 means extra spawns. Set to 0.0 to disable spawning items from that category." ) ),
+    [&]( const std::string & page_id ) {
+
+        add( "SPAWN_RATE_guns", page_id, "GUNS",
+             "Spawn rate for items from GUNS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_magazines", page_id, "MAGAZINES",
+             "Spawn rate for items from MAGAZINES category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_ammo", page_id, "AMMO",
+             "Spawn rate for items from AMMO category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_weapons", page_id, "WEAPONS",
+             "Spawn rate for items from WEAPONS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_tools", page_id, "OTHER TOOLS",
+             "Spawn rate for items from OTHER TOOLS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_tools_entry", page_id, "ENTRY TOOLS",
+             "Spawn rate for items from ENTRY TOOLS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_tools_workshop", page_id, "WORKSHOP TOOLS",
+             "Spawn rate for items from WORKSHOP TOOLS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_tools_cooking", page_id, "COOKING TOOLS",
+             "Spawn rate for items from COOKING TOOLS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_tools_chemistry", page_id, "CHEMISTRY TOOLS",
+             "Spawn rate for items from CHEMISTRY TOOLS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_tools_farming", page_id, "FARM TOOLS",
+             "Spawn rate for items from FARM TOOLS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_deployables", page_id, "DEPLOYABLES",
+             "Spawn rate for items from DEPLOYABLES category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_electronics", page_id, "ELECTRONICS",
+             "Spawn rate for items from ELECTRONICS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_clothing", page_id, "CLOTHING",
+             "Spawn rate for items from CLOTHING category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_food", page_id, "FOOD",
+             "Spawn rate for items from FOOD category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_cooking_ingredients", page_id, "COOKING INGREDIENTS",
+             "Spawn rate for items from COOKING INGREDIENTS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_drugs", page_id, "DRUGS",
+             "Spawn rate for items from DRUGS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_books", page_id, "BOOKS",
+             "Spawn rate for items from BOOKS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_spellbooks", page_id, "SPELLBOOKS",
+             "Spawn rate for items from SPELLBOOKS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_mods", page_id, "MODS",
+             "Spawn rate for items from MODS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_mutagen", page_id, "MUTAGENS",
+             "Spawn rate for items from MUTAGENS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_bionics", page_id, "BIONICS",
+             "Spawn rate for items from BIONICS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_veh_parts", page_id, "VEHICLE PARTS",
+             "Spawn rate for items from VEHICLE PARTS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_other", page_id, "OTHER",
+             "Spawn rate for items from OTHER category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_fuel", page_id, "FUEL",
+             "Spawn rate for items from FUEL category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_seeds", page_id, "SEEDS",
+             "Spawn rate for items from SEEDS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_chems", page_id, "CHEMICAL STUFF",
+             "Spawn rate for items from CHEMICAL STUFF category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_battery", page_id, "BATTERIES",
+             "Spawn rate for items from BATTERIES category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_spare_parts", page_id, "SPARE PARTS",
+             "Spawn rate for items from SPARE PARTS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_metal", page_id, "METAL SCRAP",
+             "Spawn rate for items from METAL SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_electronics", page_id, "ELECTRONIC SCRAP",
+             "Spawn rate for items from ELECTRONIC SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_fabric", page_id, "FABRICS",
+             "Spawn rate for items from FABRICS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_wood", page_id, "WOOD SCRAP",
+             "Spawn rate for items from WOOD SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_plastic", page_id, "PLASTIC SCRAP",
+             "Spawn rate for items from PLASTIC SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_ceramics", page_id, "CERAMIC SCRAP",
+             "Spawn rate for items from CERAMIC SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_glass", page_id, "GLASS SCRAP",
+             "Spawn rate for items from GLASS SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_rubber", page_id, "RUBBER SCRAP",
+             "Spawn rate for items from RUBBER SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_leather", page_id, "LEATHER SCRAP",
+             "Spawn rate for items from LEATHER SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_scrap_misc", page_id, "MISC SCRAP",
+             "Spawn rate for items from MISC SCRAP category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_valuables", page_id, "VALUABLES",
+             "Spawn rate for items from VALUABLES category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_container", page_id, "CONTAINER",
+             "Spawn rate for items from CONTAINER category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_rocks", page_id, "ROCKS",
+             "Spawn rate for items from ROCKS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_maps", page_id, "MAPS",
+             "Spawn rate for items from MAPS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+    } );
 
     add_empty_line();
 


### PR DESCRIPTION
## Purpose of change (The Why)

Ports a few DDA PR's:
https://github.com/CleverRaven/Cataclysm-DDA/pull/37346/
https://github.com/CleverRaven/Cataclysm-DDA/pull/37407/
https://github.com/CleverRaven/Cataclysm-DDA/pull/62583/
https://github.com/CleverRaven/Cataclysm-DDA/pull/64586/

## Describe the solution (The How)
Documents `Item Category` ripped directly from these DDA PR's. As far as I can tell, it is accurate to our own but probably does need checked over.

Separates item spawnrates into categories and displays them in the World Settings using our own categories instead of DDA categories. (of course)
## Describe alternatives you've considered
Giving up because of pointers
## Testing

Set books to 0.0, teleported to a bookstore or library, confirmed no books spawned. Set books to 20.0 and confirmed that a large amount spawned, however I have not done any calculations or verification that this is exactly 20x, and there seemed to be an issue raised on the original PR regarding this.

Set perishables to 20x and confirmed that it increased specifically perishable spawns.

## Additional context

The spawning function probably needs a bit more polishing and definitely a good review, I've been grinding at it for like a day and a half since I've been having trouble with pointers. (DDA codebase has the relevant function return an item, and we return a detached_ptr<item>)

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/7932b172-32f2-4434-ae77-ad11f9795b31)

![image](https://github.com/user-attachments/assets/c2a9865b-cbc9-4ee1-930b-751f1935e227)

</details>

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [X] This PR ports commits from DDA or other cataclysm forks.
  - [X] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.

<!--
please remove sections irrelevant to this PR.

  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
