### PR TITLE
fix: Fix trying to remove effects that aren't present in `Creature::process_effects()`

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1435,7 +1435,10 @@ void Creature::process_effects()
             }
             // Add any effects that others remove to the removal list
             for( const efftype_id &removed_effect : _it.second.get_removes_effects() ) {
-                to_remove.emplace_back( removed_effect, bodypart_str_id::NULL_ID(), false );
+                // Don't try to remove it if it isn't present
+                if ( has_effect( removed_effect ) ) {
+                    to_remove.emplace_back( removed_effect, bodypart_str_id::NULL_ID(), false );
+                }
             }
             effect &e = _it.second;
             const int prev_int = e.get_intensity();
@@ -1470,7 +1473,8 @@ void Creature::process_effects()
             }
 
             if( !found ) {
-                debugmsg( "Couldn't find effect to remove %s", r.type.str() );
+                // Effect somehow went missing between previous loop and now
+                debugmsg( "Couldn't find effect assigned to be removed %s", r.type.str() );
             }
         }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1436,7 +1436,7 @@ void Creature::process_effects()
             // Add any effects that others remove to the removal list
             for( const efftype_id &removed_effect : _it.second.get_removes_effects() ) {
                 // Don't try to remove it if it isn't present
-                if ( has_effect( removed_effect ) ) {
+                if( has_effect( removed_effect ) ) {
                     to_remove.emplace_back( removed_effect, bodypart_str_id::NULL_ID(), false );
                 }
             }


### PR DESCRIPTION
## Purpose of change (The Why)

RoyalFox discovered a nasty bug with one of her effects that was meant to remove some of her effects that happen to have add_on_remove defined which caused the game to spit out a debug message per removed effect EVERY TURN AFTER THEY GOT REMOVED.

As it turns out, the game tried to remove effects that weren't even present on the player because it just assumed all the effects that are removed by another effect should be removed.

## Describe the solution (The How)

Made it so that the handling for effects that remove other effects only adds to the removal queue if the effect that should be removed is actually present.

Also adjusted the debug message slightly to better indicate that it is now instead indicating that an effect that was found earlier was not found for that function.

## Describe alternatives you've considered

- Remove debug message entirely because the effects not being present will not actually break anything so far as I can tell

## Testing

It compiles.

Further testing coming from RoyalFox since she discovered the issue

## Additional context

Coolthulu is once again not-so-cool, smh.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
