### PR TITLE
feat: Allow spells to scale based on caster's stats

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -32,6 +32,7 @@ In `data/json/debug_spells.json` there is a template spell, copied here for your
     "FOOT_R"
   ], // body parts affected by effects
   "spell_class": "NONE", //
+  "stat": "STR", // The stat that the spell uses for scaling. STR, PER, INT, or DEX
   "base_casting_time": 100, // this is the casting time (in moves)
   "base_energy_cost": 10, // the amount of energy (of the requisite type) to cast the spell
   "energy_source": "MANA", // the type of energy used to cast the spell. types are: MANA, BIONIC, HP, STAMINA, FATIGUE, NONE (none will not use mana)

--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -32,7 +32,7 @@ In `data/json/debug_spells.json` there is a template spell, copied here for your
     "FOOT_R"
   ], // body parts affected by effects
   "spell_class": "NONE", //
-  "stat": "STR", // The stat that the spell uses for scaling. STR, PER, INT, or DEX
+  "scale_str": true, // The spell will scale off of strength. Also valid: scale_dex, scale_per, scale_int
   "base_casting_time": 100, // this is the casting time (in moves)
   "base_energy_cost": 10, // the amount of energy (of the requisite type) to cast the spell
   "energy_source": "MANA", // the type of energy used to cast the spell. types are: MANA, BIONIC, HP, STAMINA, FATIGUE, NONE (none will not use mana)

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -491,19 +491,21 @@ character_stat spell::stat() const {
     return type->stat;
 }
 
-double spell::get_stat_mult(bool decrease, const Character &guy) const {
-    int stat_val;
+int spell::get_stat_value(const Character &guy) const {
     switch( stat() ) {
-        case character_stat::STRENGTH : stat_val = guy.get_str();
-        case character_stat::PERCEPTION : stat_val = guy.get_per();
-        case character_stat::INTELLIGENCE : stat_val = guy.get_int();
-        case character_stat::DEXTERITY : stat_val = guy.get_dex();
-        default : stat_val = 8;
+        case character_stat::STRENGTH : return guy.get_str();
+        case character_stat::PERCEPTION : return guy.get_per();
+        case character_stat::INTELLIGENCE : return guy.get_int();
+        case character_stat::DEXTERITY : return guy.get_dex();
+        default : return 8;
     }
+}
+
+double spell::get_stat_mult(bool decrease, const Character &guy) const {
     if (decrease) {
-        return (1 - (0.1 * (stat_val - 8)));
+        return std::max((1.0 - (0.1 * (get_stat_value(guy) - 8))), 0.1); // Max is necessary to avoid negatives / 0
     }
-    return (1 + (0.1 * (stat_val - 8))); // No else block needed because return early above
+    return (1.0 + (0.1 * (get_stat_value(guy) - 8))); // No else block needed because return early above
 }
 
 int spell::field_intensity() const
@@ -871,10 +873,18 @@ float spell::spell_fail( const Character &guy ) const
 
     int stat_val;
     switch( stat() ) {
-        case character_stat::STRENGTH : stat_val = guy.get_str();
-        case character_stat::PERCEPTION : stat_val = guy.get_per();
-        case character_stat::INTELLIGENCE : stat_val = guy.get_int();
-        case character_stat::DEXTERITY : stat_val = guy.get_dex();
+        case character_stat::STRENGTH : 
+            stat_val = guy.get_str();
+            break;
+        case character_stat::PERCEPTION : 
+            stat_val = guy.get_per();
+            break;
+        case character_stat::DEXTERITY : 
+            stat_val = guy.get_dex();
+            break;
+        case character_stat::INTELLIGENCE:
+            stat_val = guy.get_int();
+            break;
         default : stat_val = 0; // if no stat set, it shouldn't contribute
     }
     // formula is based on the following:

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <array>
-#include <character_stat.h>
 #include <cmath>
 #include <cstdlib>
 #include <memory>
@@ -15,6 +14,7 @@
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "character.h"
+#include "character_stat.h"
 #include "color.h"
 #include "crafting.h"
 #include "craft_command.h"

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -268,7 +268,7 @@ void spell_type::load( const JsonObject &jo, const std::string & )
     }
 
     const auto stat_reader = enum_flags_reader<character_stat> {"stat"};
-    optional(jo, was_loaded, "stat", stat, stat_reader, character_stat::DUMMY_STAT);
+    optional( jo, was_loaded, "stat", stat, stat_reader, character_stat::DUMMY_STAT );
 
     const auto effect_targets_reader = enum_flags_reader<valid_target> { "effect_targets" };
     optional( jo, was_loaded, "effect_filter", effect_targets, effect_targets_reader );
@@ -487,25 +487,35 @@ skill_id spell::skill() const
     return type->skill;
 }
 
-character_stat spell::stat() const {
+character_stat spell::stat() const
+{
     return type->stat;
 }
 
-int spell::get_stat_value(const Character &guy) const {
+int spell::get_stat_value( const Character &guy ) const
+{
     switch( stat() ) {
-        case character_stat::STRENGTH : return guy.get_str();
-        case character_stat::PERCEPTION : return guy.get_per();
-        case character_stat::INTELLIGENCE : return guy.get_int();
-        case character_stat::DEXTERITY : return guy.get_dex();
-        default : return 8;
+        case character_stat::STRENGTH :
+            return guy.get_str();
+        case character_stat::PERCEPTION :
+            return guy.get_per();
+        case character_stat::INTELLIGENCE :
+            return guy.get_int();
+        case character_stat::DEXTERITY :
+            return guy.get_dex();
+        default :
+            return 8;
     }
 }
 
-double spell::get_stat_mult(bool decrease, const Character &guy) const {
-    if (decrease) {
-        return std::max((1.0 - (0.1 * (get_stat_value(guy) - 8))), 0.1); // Max is necessary to avoid negatives / 0
+double spell::get_stat_mult( bool decrease, const Character &guy ) const
+{
+    if( decrease ) {
+        return std::max( ( 1.0 - ( 0.1 * ( get_stat_value( guy ) - 8 ) ) ),
+                         0.1 ); // Max is necessary to avoid negatives / 0
     }
-    return (1.0 + (0.1 * (get_stat_value(guy) - 8))); // No else block needed because return early above
+    return ( 1.0 + ( 0.1 * ( get_stat_value( guy ) -
+                             8 ) ) ); // No else block needed because return early above
 }
 
 int spell::field_intensity() const
@@ -551,8 +561,8 @@ int spell::damage_as_character( const Character &guy ) const
         total_damage += weapon_damage;
     }
 
-    if( stat() != character_stat::DUMMY_STAT ){
-        total_damage *= get_stat_mult(false, guy);
+    if( stat() != character_stat::DUMMY_STAT ) {
+        total_damage *= get_stat_mult( false, guy );
     }
 
     return std::round( total_damage );
@@ -736,7 +746,7 @@ int spell::energy_cost( const Character &guy ) const
     }
 
     if( stat() != character_stat::DUMMY_STAT ) {
-        cost *= get_stat_mult(true, guy);
+        cost *= get_stat_mult( true, guy );
     }
 
     return cost;
@@ -837,7 +847,7 @@ int spell::casting_time( const Character &guy ) const
         casting_time = std::round( casting_time * 1.5 );
     }
     if( stat() != character_stat::DUMMY_STAT ) {
-        casting_time *= get_stat_mult(true, guy);
+        casting_time *= get_stat_mult( true, guy );
     }
     return casting_time;
 }
@@ -873,19 +883,20 @@ float spell::spell_fail( const Character &guy ) const
 
     int stat_val;
     switch( stat() ) {
-        case character_stat::STRENGTH : 
+        case character_stat::STRENGTH :
             stat_val = guy.get_str();
             break;
-        case character_stat::PERCEPTION : 
+        case character_stat::PERCEPTION :
             stat_val = guy.get_per();
             break;
-        case character_stat::DEXTERITY : 
+        case character_stat::DEXTERITY :
             stat_val = guy.get_dex();
             break;
         case character_stat::INTELLIGENCE:
             stat_val = guy.get_int();
             break;
-        default : stat_val = 0; // if no stat set, it shouldn't contribute
+        default :
+            stat_val = 0; // if no stat set, it shouldn't contribute
     }
     // formula is based on the following:
     // exponential curve
@@ -1872,8 +1883,9 @@ void spellcasting_callback::draw_spell_info( const spell &sp, const uilist *menu
                             _( "Blocker mutations" ), enumerate_traits( sp.get_blocker_muts() ) ) );
     line += fold_and_print( w_menu, point( h_col1, line++ ), info_width, gray, string_format( "%s: %s",
                             _( "Skill" ), sp.skill() ) );
-    
-    std::string stat_text = (sp.stat() == character_stat::DUMMY_STAT) ? "None" : io::enum_to_string<character_stat>(sp.stat());
+
+    std::string stat_text = ( sp.stat() == character_stat::DUMMY_STAT ) ? "None" :
+                            io::enum_to_string<character_stat>( sp.stat() );
     line += fold_and_print( w_menu, point( h_col1, line++ ), info_width, gray, string_format( "%s: %s",
                             _( "Stat" ), stat_text ) );
 

--- a/src/magic.h
+++ b/src/magic.h
@@ -11,6 +11,7 @@
 
 #include "bodypart.h"
 #include "catalua_type_operators.h"
+#include "character_stat.h"
 #include "damage.h"
 #include "enum_bitset.h"
 #include "event_bus.h"
@@ -156,6 +157,8 @@ class spell_type
         // spell sound effect
         translation sound_description;
         skill_id skill;
+        // Stat used for scaling
+        character_stat stat;
 
         // Mutations that block the spell from being cast
         std::set<trait_id> blocker_mutations;
@@ -337,6 +340,8 @@ class spell
         int min_leveled_aoe() const;
         // minimum duration including levels (moves)
         int min_leveled_duration() const;
+        // get the multiplier to spell stats from character stats
+        double get_stat_mult(bool decrease, const Character &guy) const;
 
     public:
         spell() = default;
@@ -421,6 +426,8 @@ class spell
         trait_id spell_class() const;
         // get skill id
         skill_id skill() const;
+        // get stat
+        character_stat stat() const;
         // get spell effect string (from type)
         std::string effect() const;
         // get spell effect_str data

--- a/src/magic.h
+++ b/src/magic.h
@@ -11,7 +11,6 @@
 
 #include "bodypart.h"
 #include "catalua_type_operators.h"
-#include "character_stat.h"
 #include "damage.h"
 #include "enum_bitset.h"
 #include "event_bus.h"
@@ -157,8 +156,12 @@ class spell_type
         // spell sound effect
         translation sound_description;
         skill_id skill;
-        // Stat used for scaling
-        character_stat stat;
+
+        // scale based on stats
+        bool scale_str;
+        bool scale_dex;
+        bool scale_per;
+        bool scale_int;
 
         // Mutations that block the spell from being cast
         std::set<trait_id> blocker_mutations;
@@ -340,8 +343,8 @@ class spell
         int min_leveled_aoe() const;
         // minimum duration including levels (moves)
         int min_leveled_duration() const;
-        // get stat value
-        int get_stat_value( const Character &guy ) const;
+        // get the sum of the deltas of relevant stats away from 8
+        int get_stats_deltas(const Character &guy) const;
         // get the multiplier to spell stats from character stats
         double get_stat_mult( bool decrease, const Character &guy ) const;
 
@@ -428,8 +431,6 @@ class spell
         trait_id spell_class() const;
         // get skill id
         skill_id skill() const;
-        // get stat
-        character_stat stat() const;
         // get spell effect string (from type)
         std::string effect() const;
         // get spell effect_str data

--- a/src/magic.h
+++ b/src/magic.h
@@ -340,6 +340,8 @@ class spell
         int min_leveled_aoe() const;
         // minimum duration including levels (moves)
         int min_leveled_duration() const;
+        // get stat value
+        int get_stat_value(const Character &guy) const;
         // get the multiplier to spell stats from character stats
         double get_stat_mult(bool decrease, const Character &guy) const;
 

--- a/src/magic.h
+++ b/src/magic.h
@@ -341,9 +341,9 @@ class spell
         // minimum duration including levels (moves)
         int min_leveled_duration() const;
         // get stat value
-        int get_stat_value(const Character &guy) const;
+        int get_stat_value( const Character &guy ) const;
         // get the multiplier to spell stats from character stats
-        double get_stat_mult(bool decrease, const Character &guy) const;
+        double get_stat_mult( bool decrease, const Character &guy ) const;
 
     public:
         spell() = default;


### PR DESCRIPTION
## Purpose of change (The Why)

Another addition in my quest to allow for everything needed to make fully physical techniques in the spell system, as well as enabling more cool features with spells in general.

## Describe the solution (The How)

This allows a spell to scale based off your Strength, Perception, Dexterity, and/or Intelligence. Damage goes up 10% for every point over 8 in every relevant stat you have, and down 10% for every point under 8 you have. Casting time and cost goes down 10% for every point over 8, and up for every point under 8 (with a cap on the high end to prevent values going negative).

Also causes failure rates to correctly use the scaling stats. Note, however, that to preserve consistency I made it so that not setting any stats means that stats contribute 0 to your spell failure rate. (For the prior mentioned areas of scaling, it produces a 0% change)

Also adds the stats to the spell's info in the spell menu, as well as adding the skill since it wasn't there previously and is worth knowing

## Describe alternatives you've considered

- Do the scaling by 5% / some other amount of % instead of 10%
- Make it so that the current behavior of intelligence being the default for spell failure is continued

Every mod but Magical Nights seems to use NO_FAIL anyway, and I'd argue a change from the previous default here is fine.

## Testing

It compiles, and making Smite scale based on Strength made it have all the proper scalings. Testing giving both per and int scaling to a spell worked as expected

## Additional context

With the solution to allow multiple stats to be scaled off of, in theory it can really mess up fail percentage. However, fail percentage is weird anyway and expected usecase is not more than two stats at a time. (Where it still has an effect compared to one stat, but not as much)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
