### PR TITLE
fix: stop cancelling fun by turning scouters into active geiger counters

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -3080,7 +3080,6 @@
     "use_action": [
       "PORTABLE_GAME",
       "WEATHER_TOOL",
-      "GEIGER",
       "RADIOCONTROL",
       { "type": "gps_device", "radius": 40, "additional_charges_per_tile": 0.1 },
       {
@@ -3117,7 +3116,6 @@
     "use_action": [
       "PORTABLE_GAME",
       "WEATHER_TOOL",
-      "GEIGER",
       "RADIOCONTROL",
       { "type": "gps_device", "radius": 120, "additional_charges_per_tile": 0.1 },
       {


### PR DESCRIPTION
## Purpose of change (The Why)

Fun is illegal, as you are all aware. That's why the code forcibly sets an item to an active geiger counter if it's used to scan for radiation and has the item use. Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/6778

## Describe the solution (The How)

Takes off geiger usage.

## Describe alternatives you've considered

Letting it fester until someone fixes the iuse because I don't know how. But we don't maintain noob traps.

## Testing

No need in this case. It's either THIS, or THIS doing it. 

```cpp
// Otherwise, we're activating the geiger counter
    if( it->typeId() == itype_geiger_on ) {
        add_msg( _( "The geiger counter's SCANNING LED turns off." ) );
        it->convert( itype_geiger_off );
        it->deactivate();
        return 0;
    }
```

```cpp
case 2:
            p->add_msg_if_player( _( "The geiger counter's scan LED turns on." ) );
            it->convert( itype_geiger_on );
            it->activate();
            break;
```

## Additional context


## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.