### PR TITLE
feat(balance): change vorpalization requirements

### DIFF
--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -773,8 +773,8 @@ void mdeath::jabberwock( monster &z )
     player *ch = dynamic_cast<player *>( z.get_killer() );
 
     bool vorpal = ch && ch->is_player() &&
-                  ch->primary_weapon().has_flag( STATIC( flag_id( "DIAMOND" ) ) ) &&
-                  ch->primary_weapon().volume() > 750_ml;
+                  ( ch->primary_weapon().damage_melee(DT_CUT) >= ( ch->primary_weapon().damage_melee(DT_BASH) * 1.5 ) ) &&
+                  ch->primary_weapon().volume() > 500_ml;
 
     if( vorpal && !ch->primary_weapon().has_technique( matec_id( "VORPAL" ) ) ) {
         if( ch->sees( z ) ) {

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -773,7 +773,8 @@ void mdeath::jabberwock( monster &z )
     player *ch = dynamic_cast<player *>( z.get_killer() );
 
     bool vorpal = ch && ch->is_player() &&
-                  ( ch->primary_weapon().damage_melee(DT_CUT) >= ( ch->primary_weapon().damage_melee(DT_BASH) * 1.5 ) ) &&
+                  ( ch->primary_weapon().damage_melee( DT_CUT ) >= ( ch->primary_weapon().damage_melee(
+                              DT_BASH ) * 1.5 ) ) &&
                   ch->primary_weapon().volume() > 500_ml;
 
     if( vorpal && !ch->primary_weapon().has_technique( matec_id( "VORPAL" ) ) ) {


### PR DESCRIPTION
## Purpose of change (The Why)

It's rare enough to meet a Jabberwock as it is, and there is no real reason for vorpalization to require a weapon to be CVD'd.

Vorpalization does not make sense for weapons that do not have much cutting damage due to how the technique works, and in general does not make sense for weapons whose primary focus is cutting.

500 mL seems to be a nicer cutoff, that way knives can (in theory at least) also become vorpalized (without leading to too much shenanigans with unfitting items being vorpalized)

## Describe the solution (The How)

- Remove CVD requirement for a weapon to be vorpalized
- Add a requirement that cut damage must be at least 1.5x larger than bash damage on the weapon
- Lower volume requirement to 500 mL instead of 750 mL

## Describe alternatives you've considered

- Put a raw cutting damage requirement instead of a requirement that it be over bash by a certain amount
- Include piercing damage (and potentially adjust the technique to affect it too)

## Testing

It compiles without being angry at it

## Additional context

May many more blades now go Snicker-snack

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

