### PR TITLE
mods: Create Lethal Zombies

### DIFF
--- a/data/mods/lethal_zeds/modinfo.json
+++ b/data/mods/lethal_zeds/modinfo.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "LethalZombies",
+    "name": "<color_red>Lethal Zombies</color>",
+    "authors": [ "RoyalFox" ],
+    "maintainers": [ "RoyalFox" ],
+    "description": "For an uncompromising and brutal experience.",
+    "category": "content",
+    "dependencies": [ "bn" ]
+  }
+]

--- a/data/mods/lethal_zeds/monster overwrites.json
+++ b/data/mods/lethal_zeds/monster overwrites.json
@@ -1,0 +1,609 @@
+[
+  {
+   "id": "zombie_thrown_rock",
+   "copy-from": "fake_item",
+   "type": "GUN",
+   "name": { "str": "zombie rock gun" },
+   "description": "This is a bug if you have this. No recovery on rocks, we don't want a deluge of stone.",
+   "weight": "1 g",
+   "volume": "1 L",
+   "price": "2 USD",
+   "price_postapoc": "2 USD",
+   "material": [ "steel" ],
+   "color": "yellow",
+   "range": 10,
+   "skill": "throw",
+   "ranged_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 10 } ],
+   "dispersion": 3000,
+   "modes": [ [ "DEFAULT", "semi", 1 ] ],
+   "loudness": 1,
+   "flags": [ "NEVER_JAMS", "NO_UNLOAD" ]
+  },
+  {
+    "id": "mon_zombie",
+    "copy-from": "mon_zombie",
+    "type": "MONSTER",
+    "hp": 90,
+    "melee_skill": 7,
+    "melee_dice": 5,
+    "grab_strength": 3,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [ 
+    {
+      "type": "bite",
+      "move_cost": 80,
+      "cooldown": 4,
+      "no_infection_chance": 2,
+      "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
+    },
+    {
+      "type": "gun",
+      "cooldown": 7,
+      "move_cost": 100,
+      "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+      "gun_type": "zombie_thrown_rock",
+      "no_ammo_sound": "",
+      "require_targeting_player": false,
+      "ranges": [ [ 1, 6, "DEFAULT" ] ],
+      "fake_dex": 5,
+      "fake_per": 5,
+      "description": "The zombie throws a rock!",
+      "no_crits": true
+    },
+      [ "GRAB", 2 ], 
+      [ "scratch", 10 ]
+    ]
+  },
+  {
+    "id": "mon_zombie_prisoner",
+    "copy-from": "mon_zombie_prisoner",
+    "type": "MONSTER",
+    "melee_skill": 8,
+    "melee_dice": 5,
+    "grab_strength": 3,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [ 
+      {
+        "type": "bite",
+        "move_cost": 80,
+        "cooldown": 4,
+        "no_infection_chance": 2,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
+      },
+      [ "GRAB", 2 ], 
+      [ "scratch", 10 ]
+    ]
+  },
+  {
+    "id": "mon_zombie_cop",
+    "copy-from": "mon_zombie_cop",
+    "type": "MONSTER",
+    "hp": 90,
+    "melee_skill": 8,
+    "melee_dice": 4,
+    "grab_strength": 3,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+      [ "GRAB", 2 ], 
+      {
+        "type": "gun",
+        "cooldown": 7,
+        "move_cost": 100,
+        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+        "gun_type": "zombie_thrown_rock",
+        "no_ammo_sound": "",
+        "require_targeting_player": false,
+        "ranges": [ [ 1, 6, "DEFAULT" ] ],
+        "fake_dex": 5,
+        "fake_per": 5,
+        "description": "The zombie throws a rock!",
+        "no_crits": true
+      }
+    ]
+  },
+  {
+    "id": "mon_zombie_crawler",
+    "copy-from": "mon_zombie_crawler",
+    "type": "MONSTER",
+    "melee_skill": 3,
+    "melee_dice": 3,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [ 
+    {
+      "type": "bite",
+      "move_cost": 120,
+      "cooldown": 5,
+      "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
+    },
+      [ "scratch", 10 ]
+    ]
+  },
+  {
+    "id": "mon_zombie_fat",
+    "copy-from": "mon_zombie_fat",
+    "type": "MONSTER",
+    "melee_skill": 7,
+    "melee_dice": 3,
+    "grab_strength": 3,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+      {
+        "type": "bite",
+        "move_cost": 80,
+        "cooldown": 4,
+        "no_infection_chance": 2,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
+      },
+    {
+      "type": "gun",
+      "cooldown": 7,
+      "move_cost": 100,
+      "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+      "gun_type": "zombie_thrown_rock",
+      "no_ammo_sound": "",
+      "require_targeting_player": false,
+      "ranges": [ [ 1, 6, "DEFAULT" ] ],
+      "fake_dex": 5,
+      "fake_per": 5,
+      "description": "The zombie throws a rock!",
+      "no_crits": true
+    },
+    [ "GRAB", 2 ], 
+    [ "scratch", 10 ] 
+    ]
+  },
+  {
+    "id": "mon_zombie_fireman",
+    "copy-from": "mon_zombie_fireman",
+    "type": "MONSTER",
+    "melee_dice": 4,
+    "grab_strength": 4,
+    "hp": 90,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+    [ "GRAB", 2 ], 
+    {
+      "type": "gun",
+      "cooldown": 7,
+      "move_cost": 100,
+      "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+      "gun_type": "zombie_thrown_rock",
+      "no_ammo_sound": "",
+      "require_targeting_player": false,
+      "ranges": [ [ 1, 6, "DEFAULT" ] ],
+      "fake_dex": 5,
+      "fake_per": 5,
+      "description": "The zombie throws a rock!",
+      "no_crits": true
+    },
+    [ "scratch", 5 ]
+    ]
+  },
+  {
+    "id": "mon_zombie_hazmat",
+    "copy-from": "mon_zombie_hazmat",
+    "type": "MONSTER",
+    "melee_skill": 4,
+    "melee_dice": 4,
+    "grab_strength": 3,
+    "hp": 90,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 7,
+        "move_cost": 100,
+        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+        "gun_type": "zombie_thrown_rock",
+        "no_ammo_sound": "",
+        "require_targeting_player": false,
+        "ranges": [ [ 1, 6, "DEFAULT" ] ],
+        "fake_dex": 5,
+        "fake_per": 5,
+        "description": "The zombie throws a rock!",
+        "no_crits": true
+      }
+    ]
+  },
+  {
+    "id": "mon_zombie_rot",
+    "copy-from": "mon_zombie_rot",
+    "type": "MONSTER",
+    "melee_skill": 6,
+    "melee_dice": 4,
+    "hp": 70,
+    "extend": { "flags": [ "GOODHEARING", "VENOM" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+      {
+        "type": "bite",
+        "move_cost": 80,
+        "cooldown": 4,
+        "no_infection_chance": 1,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
+      },
+      {
+        "type": "gun",
+        "cooldown": 7,
+        "move_cost": 100,
+        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+        "gun_type": "zombie_thrown_rock",
+        "no_ammo_sound": "",
+        "require_targeting_player": false,
+        "ranges": [ [ 1, 6, "DEFAULT" ] ],
+        "fake_dex": 5,
+        "fake_per": 5,
+        "description": "The zombie throws a rock!",
+        "no_crits": true
+      }
+    ]
+  },
+  {
+    "id": "mon_zombie_swat",
+    "copy-from": "mon_zombie_swat",
+    "type": "MONSTER",
+    "melee_dice": 5,
+    "melee_skill": 8,
+    "grab_strength": 3,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 7,
+        "move_cost": 100,
+        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+        "gun_type": "zombie_thrown_rock",
+        "no_ammo_sound": "",
+        "require_targeting_player": false,
+        "ranges": [ [ 1, 6, "DEFAULT" ] ],
+        "fake_dex": 5,
+        "fake_per": 5,
+        "description": "The zombie throws a rock!",
+        "no_crits": true
+      }
+    ]
+  },
+  {
+    "id": "mon_zombie_tough",
+    "copy-from": "mon_zombie_tough",
+    "type": "MONSTER",
+    "melee_skill": 8,
+    "melee_dice": 5,
+    "grab_strength": 3,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [ 
+      {
+        "type": "bite",
+        "move_cost": 80,
+        "cooldown": 4,
+        "no_infection_chance": 2,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
+      },
+    {
+      "type": "gun",
+      "cooldown": 7,
+      "move_cost": 100,
+      "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+      "gun_type": "zombie_thrown_rock",
+      "no_ammo_sound": "",
+      "require_targeting_player": false,
+      "ranges": [ [ 1, 6, "DEFAULT" ] ],
+      "fake_dex": 5,
+      "fake_per": 5,
+      "description": "The zombie throws a rock!",
+      "no_crits": true
+    },
+    [ "GRAB", 2 ], 
+    [ "scratch", 20 ]
+    ]
+  },
+  {
+    "id": "mon_zombie_soldier",
+    "copy-from": "mon_zombie_soldier",
+    "type": "MONSTER",
+    "melee_damage": [ { "damage_type": "bash", "amount": 3, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "melee_skill": 8,
+    "melee_dice": 5
+  },
+  {
+    "id": "mon_zombie_soldier_blackops_1",
+    "copy-from": "mon_zombie_soldier_blackops_1",
+    "type": "MONSTER",
+    "melee_damage": [ { "damage_type": "bash", "amount": 3, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "melee_skill": 10,
+    "melee_dice": 6
+  },
+  {
+    "id": "mon_zombie_brute_ninja",
+    "copy-from": "mon_zombie_brute_ninja",
+    "type": "MONSTER",
+    "melee_damage": [ { "damage_type": "bash", "amount": 3, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "melee_skill": 9,
+    "melee_dice": 6
+  },
+  {
+    "id": "mon_zombie_shady",
+    "copy-from": "mon_zombie_shady",
+    "type": "MONSTER",
+    "melee_damage": [ { "damage_type": "bash", "amount": 1, "armor_penetration": 2, "armor_multiplier": 0.2 } ],
+    "melee_skill": 8,
+    "melee_dice": 5
+  },
+  {
+    "id": "mon_zombie_brute",
+    "copy-from": "mon_zombie_brute",
+    "type": "MONSTER",
+    "melee_skill": 8,
+    "melee_dice": 5,
+    "grab_strength": 4,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+      [ "GRAB", 2 ], 
+      {
+        "type": "bite",
+        "move_cost": 80,
+        "cooldown": 4,
+        "no_infection_chance": 2,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 10, "armor_penetration": 8 } ]
+      },
+      {
+        "type": "gun",
+        "cooldown": 7,
+        "move_cost": 100,
+        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+        "gun_type": "zombie_thrown_rock",
+        "no_ammo_sound": "",
+        "require_targeting_player": false,
+        "ranges": [ [ 1, 6, "DEFAULT" ] ],
+        "fake_dex": 5,
+        "fake_per": 5,
+        "description": "The zombie throws a rock!",
+        "no_crits": true
+      } 
+    ]
+  },
+  {
+    "id": "mon_zombie_brute_grappler",
+    "copy-from": "mon_zombie_brute_grappler",
+    "type": "MONSTER",
+    "hp": 320,
+    "melee_skill": 10,
+    "melee_dice": 5,
+    "grab_strength": 4,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+      [ "GRAB", 2 ], 
+      {
+        "type": "bite",
+        "move_cost": 80,
+        "cooldown": 4,
+        "no_infection_chance": 2,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 10, "armor_penetration": 8 } ]
+      },
+      {
+        "type": "gun",
+        "cooldown": 7,
+        "move_cost": 100,
+        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+        "gun_type": "zombie_thrown_rock",
+        "no_ammo_sound": "",
+        "require_targeting_player": false,
+        "ranges": [ [ 1, 6, "DEFAULT" ] ],
+        "fake_dex": 5,
+        "fake_per": 5,
+        "description": "The zombie throws a rock!",
+        "no_crits": true
+      }
+    ]
+  },
+  {
+    "id": "mon_zombie_hulk",
+    "copy-from": "mon_zombie_hulk",
+    "type": "MONSTER",
+    "melee_dice": 6,
+    "grab_strength": 8,
+    "hp": 540,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 7,
+        "move_cost": 100,
+        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+        "gun_type": "zombie_thrown_rock",
+        "no_ammo_sound": "",
+        "require_targeting_player": false,
+        "ranges": [ [ 1, 6, "DEFAULT" ] ],
+        "fake_dex": 5,
+        "fake_per": 5,
+        "description": "The zombie throws a rock!",
+        "no_crits": true
+      }
+    ]
+  },
+  {
+    "id": "mon_zombie_hunter",
+    "copy-from": "mon_zombie_hunter",
+    "type": "MONSTER",
+    "melee_dice": 5,
+    "grab_strength": 2,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+      [ "GRAB", 2 ], 
+      {
+        "type": "bite",
+        "move_cost": 80,
+        "cooldown": 4,
+        "no_infection_chance": 2,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
+      },
+      {
+        "type": "gun",
+        "cooldown": 7,
+        "move_cost": 100,
+        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+        "gun_type": "zombie_thrown_rock",
+        "no_ammo_sound": "",
+        "require_targeting_player": false,
+        "ranges": [ [ 1, 6, "DEFAULT" ] ],
+        "fake_dex": 5,
+        "fake_per": 5,
+        "description": "The zombie throws a rock!",
+        "no_crits": true
+      }
+    ]
+  },
+  {
+    "id": "mon_zombie_runner",
+    "copy-from": "mon_zombie_runner",
+    "type": "MONSTER",
+    "melee_skill": 7,
+    "melee_dice": 6,
+    "grab_strength": 2,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+      [ "GRAB", 2 ], 
+      {
+        "type": "bite",
+        "move_cost": 80,
+        "cooldown": 2,
+        "no_infection_chance": 2,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 4, "armor_penetration": 8 } ]
+      },
+      {
+        "type": "gun",
+        "cooldown": 6,
+        "move_cost": 100,
+        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+        "gun_type": "zombie_thrown_rock",
+        "no_ammo_sound": "",
+        "require_targeting_player": false,
+        "ranges": [ [ 1, 6, "DEFAULT" ] ],
+        "fake_dex": 5,
+        "fake_per": 5,
+        "description": "The zombie throws a rock!",
+        "no_crits": true
+      }
+    ]
+  },
+  {
+    "id": "mon_zombie_predator",
+    "copy-from": "mon_zombie_predator",
+    "type": "MONSTER",
+    "melee_skill": 9,
+    "melee_dice": 6,
+    "grab_strength": 2,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
+    "special_attacks": [
+      [ "GRAB", 2 ]
+    ]
+  },
+  {
+    "id": "mon_zombie_miner",
+    "copy-from": "mon_zombie_miner",
+    "type": "MONSTER",
+    "melee_skill": 6,
+    "melee_dice": 6,
+    "grab_strength": 3,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "melee_damage": [ { "damage_type": "stab", "amount": 6, "armor_penetration": 5, "armor_multiplier": 0.1 } ],
+    "special_attacks": [ 
+    [ "GRAB", 2 ], 
+    {
+      "type": "gun",
+      "cooldown": 7,
+      "move_cost": 100,
+      "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+      "gun_type": "zombie_thrown_rock",
+      "no_ammo_sound": "",
+      "require_targeting_player": false,
+      "ranges": [ [ 1, 6, "DEFAULT" ] ],
+      "fake_dex": 5,
+      "fake_per": 5,
+      "description": "The zombie throws a rock!",
+      "no_crits": true
+    }
+    ]
+  },
+  {
+    "id": "mon_zombie_dog",
+    "copy-from": "mon_zombie_dog",
+    "type": "MONSTER",
+    "melee_skill": 8,
+    "melee_dice": 2,
+    "hp": 70,
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "special_attacks": [ 
+      {
+        "type": "bite",
+        "move_cost": 80,
+        "cooldown": 4,
+        "no_infection_chance": 2,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
+      }
+    ]
+  },
+  {
+    "id": "mon_dog_skeleton",
+    "copy-from": "mon_dog_skeleton",
+    "type": "MONSTER",
+    "melee_skill": 8,
+    "melee_dice": 2,
+    "hp": 60,
+    "melee_damage": [ { "damage_type": "bash", "amount": 1, "armor_penetration": 2, "armor_multiplier": 0.2 } ],
+    "extend": { "flags": [ "GOODHEARING" ] }
+  },
+  {
+    "id": "mon_dog_zombie_cop",
+    "copy-from": "mon_dog_zombie_cop",
+    "type": "MONSTER",
+    "melee_skill": 8,
+    "melee_dice": 2,
+    "hp": 70,
+    "melee_damage": [ { "damage_type": "bash", "amount": 1, "armor_penetration": 2, "armor_multiplier": 0.2 } ],
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "special_attacks": [ 
+      {
+        "type": "bite",
+        "move_cost": 80,
+        "cooldown": 4,
+        "no_infection_chance": 2,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
+      }
+    ]
+  },
+  {
+    "id": "mon_dog_zombie_rot",
+    "copy-from": "mon_dog_zombie_rot",
+    "type": "MONSTER",
+    "melee_skill": 7,
+    "melee_dice": 2,
+    "hp": 70,
+    "melee_damage": [ { "damage_type": "bash", "amount": 1, "armor_penetration": 2, "armor_multiplier": 0.2 } ],
+    "extend": { "flags": [ "GOODHEARING" ] },
+    "special_attacks": [ 
+      {
+        "type": "bite",
+        "move_cost": 80,
+        "cooldown": 4,
+        "no_infection_chance": 2,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
+      }
+    ]
+  }
+]

--- a/doc/src/assets/semantic.json
+++ b/doc/src/assets/semantic.json
@@ -64,6 +64,7 @@
     "mods/teleportation_tech",
     "mods/test_data",
     "mods/udp_redux",
+    "mods/LethalZombies",
     "mods"
   ]
 }


### PR DESCRIPTION
## Purpose of change (The Why)

I've been messing with Deadlier Zombies for a long time now. It's a good time to create a lite BN version. People seem to enjoy it. I decided to create a new experience of danger, one that is completely rebuilt and separate from my other changes.
![image](https://github.com/user-attachments/assets/1953a3a5-743d-4dd9-81a3-ec9a9564c89c)


## Describe the solution (The How)

This isn't a port of Deadlier Zombies. This is a fully new version, I handmade something without radiation effects and without changes to scratch attack. Deadlier Zombies was more of me deciding to rebalance the zombies as a whole including taking off flashlights from ferals plus explosions, night invisibility, and fear paralyze. This is just changes to zombies.

A lot of zombies have more damage, more skill at melee or dodge, a ton of them do chip damage in melee to avoid armor problems. A lot of them throw rocks to prevent too much spear cheese as you can't avoid 100% of all damage with spears. Zombies generally grab bite and scratch more which causes more bleeds and infections. Some have more health. Some get good hearing.

Overall this fixes the general problems with BN being too easy, players will come to appreciate or avoid it depending on what they enjoy. Outpacing evolution won't be much of a problem when the mod ensures base enemies are much more terrifying.

## Describe alternatives you've considered

Continuing to work on the side.

## Testing

It works fine. It's not going to have the radiation loop or the other changes of Deadlier zombies, so it's mostly just bigger numbers.

## Additional context

## Checklist
### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.