### PR TITLE
feat: Add rail laser sight recipe

### DIFF
--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -1016,6 +1016,31 @@
     ]
   },
   {
+    "result": "rail_laser_sight",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "electronics",
+    "difficulty": 6,
+    "skills_required": [ [ "fabrication", 4 ], [ "gun", 2 ] ],
+    "time": "1 h",
+    "autolearn": true,
+    "reversible": true,
+    "book_learn": [ [ "manual_rifle", 6 ], [ "textbook_anarch", 3 ] ],
+    "tools": [ [ [ "large_repairkit", 25 ], [ "small_repairkit", 45 ] ], [ [ "mold_plastic", -1 ] ] ],
+    "components": [
+      [ [ "e_scrap", 4 ] ],
+      [ [ "solder_wire", 10 ] ],
+      [ [ "cable", 5 ] ],
+      [ [ "diamond", 1 ], [ "sapphire", 1 ], [ "ruby", 1 ] ],
+      [ [ "light_minus_battery_cell", 1 ] ],
+      [ [ "plastic_chunk", 5 ] ],
+      [ [ "circuit", 1 ] ],
+      [ [ "lens", 1 ] ],
+      [ [ "amplifier", 1 ] ]
+    ]
+  },
+  {
     "result": "mod_makeshift_capacitor",
     "type": "recipe",
     "category": "CC_WEAPON",


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Resolves #6789 
Underbarrel laser sight had a recipe and disassembly recipe, but rail laser sight did not
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Copied the underbarrel laser sight recipe to make the rail laser sight craftable.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Maybe give the rail laser sight a different crafting recipe or make the two laser sights be convertible from to the other.

## Testing

Opened the crafting menu, verified rail laser sight crafting recipe was present.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

This is my first time contributing to Cataclysm. Please let me know if I did anything wrong.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
