### PR TITLE
ci: fix deprecated astyle options

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -25,8 +25,7 @@
 --indent-switches
 
 # indent later lines of multi-line preprocessor directives
-# to be deprecated by --indent-preproc-define
---indent-preprocessor
+--indent-preproc-define
 
 # indent comments on column 1 to match the code block they are in
 --indent-col1-comments
@@ -37,8 +36,8 @@
 # add space around operators with two operands
 --pad-oper
 
-# add brackets to unbracketed one line conditional statements
---add-brackets
+# add braces to unbraced one line conditional statements
+--add-braces
 
 # replaces tabs with spaces in non-indent sections, except in strings
 --convert-tabs


### PR DESCRIPTION
## Purpose of change (The Why)

Some options used in `.astylerc` have been deprecated for ~10 years!

## Describe the solution (The How)

Update the options used.

## Describe alternatives you've considered

None

## Testing

Check if the `astyle` step throws errors.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
