### PR TITLE
build: use portable shell syntax in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -994,20 +994,20 @@ install: version $(TARGET)
 	mkdir -p $(DATA_PREFIX)
 	mkdir -p $(BIN_PREFIX)
 	install --mode=755 $(TARGET) $(BIN_PREFIX)
-	cp -R --no-preserve=ownership data/font $(DATA_PREFIX)
-	cp -R --no-preserve=ownership data/json $(DATA_PREFIX)
-	cp -R --no-preserve=ownership data/mods $(DATA_PREFIX)
-	cp -R --no-preserve=ownership data/names $(DATA_PREFIX)
-	cp -R --no-preserve=ownership data/raw $(DATA_PREFIX)
-	cp -R --no-preserve=ownership data/motd $(DATA_PREFIX)
-	cp -R --no-preserve=ownership data/credits $(DATA_PREFIX)
-	cp -R --no-preserve=ownership data/title $(DATA_PREFIX)
-	cp -R --no-preserve=ownership data/help $(DATA_PREFIX)
+	cp -R data/font $(DATA_PREFIX)
+	cp -R data/json $(DATA_PREFIX)
+	cp -R data/mods $(DATA_PREFIX)
+	cp -R data/names $(DATA_PREFIX)
+	cp -R data/raw $(DATA_PREFIX)
+	cp -R data/motd $(DATA_PREFIX)
+	cp -R data/credits $(DATA_PREFIX)
+	cp -R data/title $(DATA_PREFIX)
+	cp -R data/help $(DATA_PREFIX)
 ifeq ($(TILES), 1)
-	cp -R --no-preserve=ownership gfx $(DATA_PREFIX)
+	cp -R gfx $(DATA_PREFIX)
 endif
 ifeq ($(SOUND), 1)
-	cp -R --no-preserve=ownership data/sound $(DATA_PREFIX)
+	cp -R data/sound $(DATA_PREFIX)
 endif
 	install --mode=644 data/changelog.txt data/cataicon.ico \
                    LICENSE.txt LICENSE-OFL-Terminus-Font.txt -t $(DATA_PREFIX)
@@ -1173,8 +1173,10 @@ endif
 
 style-json: json_blacklist $(JSON_FORMATTER_BIN)
 ifndef CROSS
-	find data -name "*.json" -print0 | grep -v -z -F -f json_blacklist | \
-	  xargs -0 -L 1 $(JSON_FORMATTER_BIN)
+	find data -name "*.json" | grep -F -v -f json_blacklist | \
+	while IFS="" read -r file; do \
+		[ -f "$$file" ] && $(JSON_FORMATTER_BIN) "$$file"; \
+	done
 else
 	@echo Cannot run json formatter in cross compiles.
 endif


### PR DESCRIPTION
## Purpose of change (The Why)

Some flags used in Makefile are non-portable, such as:

- `grep -z`
- `xargs -L`
- `cp --no-preserve=ownership`

Reduces dependencies, such that distributions using coreutils such as busybox, instead of GNU may build cataclysm-bn without needing patching.

In addition, `--no-preserve=ownership` is more of a downstream packaging thing, and generally not required. IMO it is unusual to see upstream and best to leave it out.

Overall, these changes do not functionally change anything, except for simplifying dependencies and allowing more platforms to be able to build C:BN, at no cost.

## Describe the solution (The How)

Modified some of those parts to use POSIX-compliant language, on Linux.

## Describe alternatives you've considered

None

## Testing

Sucessfully built on linux system without GNU coreutils extensions.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
