### PR TITLE
feat: restock text & shop restock multiplier world option

### DIFF
--- a/data/json/npcs/cabin_chemist/cabin_chemist.json
+++ b/data/json/npcs/cabin_chemist/cabin_chemist.json
@@ -48,6 +48,7 @@
     "responses": [
       { "text": "Who are you?", "topic": "TALK_NPC_CABIN_CHEMIST_STORY" },
       { "text": "What is this place?", "topic": "TALK_NPC_CABIN_CHEMIST_HOME" },
+      { "text": "Brewed anything new lately?", "topic": "TALK_NPC_CABIN_CHEMIST_ASK_INTERVAL" },
       { "text": "Care to trade?", "topic": "TALK_NPC_CABIN_CHEMIST_INTRO", "effect": "start_trade" },
       {
         "text": "I'd like to buy in bulk.",
@@ -61,6 +62,12 @@
       },
       { "text": "I gotta go.", "topic": "TALK_DONE" }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_NPC_CABIN_CHEMIST_ASK_INTERVAL",
+    "dynamic_line": "Unfortunately, I'm still gathering resources and cooking new stuff.  Maybe ask again after <interval>.",
+    "responses": [ { "text": "Alright.  thanks nonetheless.", "topic": "TALK_NPC_CABIN_CHEMIST_INTRO" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
@@ -161,6 +161,12 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_ISHERWOOD_CLAIRE_RESTOCK",
+    "dynamic_line": "Around <interval>.",
+    "responses": [ { "text": "Alright then, bye.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_ISHERWOOD_CLAIRE_TALK1",
     "dynamic_line": "I live here with my husband, Jack.  He is working out in his shop.",
     "responses": [

--- a/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
@@ -124,6 +124,7 @@
         "opinion": { "trust": -20, "value": -20 },
         "condition": { "u_is_wearing": "badge_marshal" }
       },
+      { "text": "Hey, when would more of this stuff be ready?", "topic": "TALK_ISHERWOOD_CLAIRE_RESTOCK" },
       {
         "text": "Hi, nice farm you have here.",
         "topic": "TALK_ISHERWOOD_CLAIRE_TALK1",
@@ -150,6 +151,7 @@
         "topic": "TALK_ISHERWOOD_CLAIRE",
         "condition": { "not": { "u_is_wearing": "badge_marshal" } }
       },
+      { "text": "Hey, when would more of this stuff be ready?", "topic": "TALK_ISHERWOOD_CLAIRE_RESTOCK" },
       {
         "text": "I'd better get going.",
         "topic": "TALK_DONE",

--- a/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
@@ -275,6 +275,7 @@
       { "text": "A farm must be a pretty safe place these days.", "topic": "TALK_CLAIRE_FARM" },
       { "text": "You are lucky to have your family still together.", "topic": "TALK_ISHERWOOD_CLAIRE2" },
       { "text": "Let's trade.", "effect": "start_trade", "topic": "TALK_ISHERWOOD_CLAIRE" },
+      { "text": "Hey, when would more of this stuff be ready?", "topic": "TALK_ISHERWOOD_CLAIRE_RESTOCK" },
       { "text": "Can I do anything for you?", "topic": "TALK_MISSION_LIST" },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
@@ -98,12 +98,19 @@
         "effect": "start_trade",
         "condition": { "not": { "u_is_wearing": "badge_marshal" } }
       },
+      { "text": "When will your cows produce again?", "topic": "TALK_ISHERWOOD_EDDIE_RESTOCK" },
       {
         "text": "I'd better get going.",
         "topic": "TALK_DONE",
         "condition": { "not": { "u_is_wearing": "badge_marshal" } }
       }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ISHERWOOD_EDDIE_RESTOCK",
+    "dynamic_line": "If the cows don't get anything nasty it should be around <interval>.",
+    "responses": [ { "text": "Cheers, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
@@ -255,12 +255,19 @@
         "effect": "start_trade",
         "condition": { "not": { "u_is_wearing": "badge_marshal" } }
       },
+      { "text": "Hey, when would more of this stuff be ready?", "topic": "TALK_ISHERWOOD_JACK_RESTOCK" },
       {
         "text": "I'd better get going.",
         "topic": "TALK_DONE",
         "condition": { "not": { "u_is_wearing": "badge_marshal" } }
       }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ISHERWOOD_JACK_RESTOCK",
+    "dynamic_line": "Around <interval>.",
+    "responses": [ { "text": "Alright then, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
@@ -258,6 +258,7 @@
       },
       { "text": "Can I do anything for the center?", "topic": "TALK_MISSION_LIST" },
       { "text": "Let's trade then.", "effect": "start_trade", "topic": "TALK_EVAC_MERCHANT" },
+      { "text": "When will you have new stuff in stock?", "topic": "TALK_FREE_MERCHANTS_MERCHANT_ASKED_RESTOCK" },
       {
         "text": "What's with these 'free merchant certified notes'?",
         "topic": "TALK_EVAC_MERCHANT_MERCH",
@@ -266,6 +267,18 @@
       { "text": "What's your story?", "topic": "TALK_EVAC_MERCHANT_BACKGROUND" },
       { "text": "What was it you were saying before?", "topic": "TALK_NONE" },
       { "text": "Well, I'd better be going.  Bye.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_FREE_MERCHANTS_MERCHANT_ASKED_RESTOCK",
+    "type": "talk_topic",
+    "dynamic_line": [
+      "Next shipment should arrive in around <interval>.",
+      "Stick around for <interval>, there will surely be something you'd like."
+    ],
+    "responses": [
+      { "text": "Actually, I wanted to ask…", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },
+      { "text": "Thanks, I will make sure to check back.  Farewell.", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
@@ -258,7 +258,7 @@
       },
       { "text": "Can I do anything for the center?", "topic": "TALK_MISSION_LIST" },
       { "text": "Let's trade then.", "effect": "start_trade", "topic": "TALK_EVAC_MERCHANT" },
-      { "text": "When will you have new stuff in stock?", "topic": "TALK_FREE_MERCHANTS_MERCHANT_ASKED_RESTOCK" },
+      { "text": "When will you have new stuff in stock?", "topic": "TALK_EVAC_MERCHANT_ASKED_RESTOCK" },
       {
         "text": "What's with these 'free merchant certified notes'?",
         "topic": "TALK_EVAC_MERCHANT_MERCH",
@@ -270,14 +270,14 @@
     ]
   },
   {
-    "id": "TALK_FREE_MERCHANTS_MERCHANT_ASKED_RESTOCK",
+    "id": "TALK_EVAC_MERCHANT_ASKED_RESTOCK",
     "type": "talk_topic",
     "dynamic_line": [
       "Next shipment should arrive in around <interval>.",
       "Stick around for <interval>, there will surely be something you'd like."
     ],
     "responses": [
-      { "text": "Actually, I wanted to ask…", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },
+      { "text": "Actually, I wanted to ask…", "topic": "TALK_EVAC_MERCHANT" },
       { "text": "Thanks, I will make sure to check back.  Farewell.", "topic": "TALK_DONE" }
     ]
   },

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -111,8 +111,15 @@
     "dynamic_line": "I burn down buildings and sell the Free Merchants the materials.  No, seriously.  If you've seen burned wreckage in place of suburbs or even see the pile of rebar for sale, that's probably me.  They've kept me well off in exchange, I guess.",
     "responses": [
       { "text": "I'll buy.", "effect": "start_trade", "topic": "TALK_ARSONIST" },
+      { "text": "When will you have more materials in?", "topic": "TALK_ARSONIST_RESTOCK" },
       { "text": "Who needs rebar?", "topic": "TALK_ARSONIST_DOING_REBAR" }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ARSONIST_RESTOCK",
+    "dynamic_line": "Around <interval>.",
+    "responses": [ { "text": "Alright then, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "MISSION_ARSONIST_1_AMMONIUM_NITRATE",

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_hunter.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_hunter.json
@@ -57,7 +57,16 @@
     "id": "TALK_EVAC_HUNTER_SALE",
     "type": "talk_topic",
     "dynamic_line": "Sure, just bagged a fresh batch of meat.  You may want to grill it up before it gets too, uh… 'tender'.",
-    "responses": [ { "text": "…", "effect": "start_trade", "topic": "TALK_EVAC_HUNTER" } ]
+    "responses": [
+      { "text": "…", "effect": "start_trade", "topic": "TALK_EVAC_HUNTER" },
+      { "text": "Know when you'll get more?", "topic": "TALK_EVAC_HUNTER_RESTOCK" }
+    ]
+  },
+  {
+    "id": "TALK_EVAC_HUNTER_RESTOCK",
+    "type": "talk_topic",
+    "dynamic_line": "Around <interval>.",
+    "responses": [ { "text": "Thanks for the info, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_EVAC_HUNTER_ADVICE",

--- a/data/json/npcs/robofac/NPC_ROBOFAC_INTERCOM.json
+++ b/data/json/npcs/robofac/NPC_ROBOFAC_INTERCOM.json
@@ -294,6 +294,11 @@
         "effect": "start_trade"
       },
       {
+        "text": "Know when you'll get another shipment?",
+        "condition": { "npc_has_var": "npc_intercom_trade", "type": "dialogue", "context": "intercom", "value": "yes" },
+        "topic": "TALK_ROBOFAC_INTERCOM_RESTOCK"
+      },
+      {
         "text": "It's the apocalypse out here!  Please let me in!",
         "condition": {
           "and": [
@@ -401,7 +406,16 @@
       "effect": { "npc_add_var": "npc_intercom_trade", "type": "dialogue", "context": "intercom", "value": "yes" },
       "sentinel": "intercom_trade"
     },
-    "responses": [ { "text": "…", "effect": "start_trade", "topic": "TALK_DONE" } ]
+    "responses": [
+      { "text": "…", "effect": "start_trade", "topic": "TALK_DONE" },
+      { "text": "Know when you'll get another shipment?", "topic": "TALK_ROBOFAC_INTERCOM_RESTOCK" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_RESTOCK",
+    "type": "talk_topic",
+    "dynamic_line": "Around <interval>, if the caravan doesn't run into trouble.",
+    "responses": [ { "text": "Thanks for the info, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ASK",

--- a/data/json/npcs/robofac/ROBOFAC_SURFACE_FREEMERCHANT.json
+++ b/data/json/npcs/robofac/ROBOFAC_SURFACE_FREEMERCHANT.json
@@ -99,9 +99,16 @@
     },
     "responses": [
       { "text": "Let's trade.", "effect": "start_trade", "topic": "TALK_ROBOFAC_FREE_MERCHANT" },
+      { "text": "When is the next shipment?", "topic": "TALK_ROBOFAC_FREE_MERCHANT_INTERVAL" },
       { "text": "What are you doing here?", "topic": "TALK_ROBOFAC_FREE_MERCHANT_DOING" },
       { "text": "Well, bye.", "topic": "TALK_DONE" }
     ]
+  },
+  {
+    "id": "TALK_ROBOFAC_FREE_MERCHANT_INTERVAL",
+    "type": "talk_topic",
+    "dynamic_line": "Around <interval>, if the caravan doesn't run into trouble.",
+    "responses": [ { "text": "Thanks for the info, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_ROBOFAC_FREE_MERCHANT_DOING",

--- a/data/json/npcs/scrap_trader/scrap_trader.json
+++ b/data/json/npcs/scrap_trader/scrap_trader.json
@@ -125,6 +125,7 @@
     "dynamic_line": [ "Anything else you need?" ],
     "responses": [
       { "text": "No, that's all.", "topic": "TALK_DONE" },
+      { "text": "Find anything good?", "topic": "TALK_SCRAP_TRADER_ASK_INTERVAL" },
       {
         "text": "I'd like some specialty metals.",
         "topic": "TALK_SCRAP_TRADER_BULK_SELL_SPECIALTY",
@@ -210,5 +211,11 @@
         "topic": "TALK_SCRAP_TRADER_BULK_SELL_END"
       }
     ]
+  },
+  {
+    "id": "TALK_SCRAP_TRADER_ASK_INTERVAL",
+    "type": "talk_topic",
+    "dynamic_line": "Nope, although I have a really good claim by the river.  Gonna go fetch them soon, be right back in <interval>.",
+    "responses": [ { "text": "Well, good luck.", "topic": "TALK_NPC_SCRAP_TRADER" } ]
   }
 ]

--- a/data/json/npcs/scrap_trader/scrap_trader.json
+++ b/data/json/npcs/scrap_trader/scrap_trader.json
@@ -87,6 +87,7 @@
     "dynamic_line": [ "Sure thing.  I've got a few things on hand, sold in batches of 10-piece each.  What'll ya have?" ],
     "responses": [
       { "text": "Nevermind.", "topic": "TALK_NONE" },
+      { "text": "Find anything good?", "topic": "TALK_SCRAP_TRADER_ASK_INTERVAL" },
       {
         "text": "I'd like some specialty metals.",
         "topic": "TALK_SCRAP_TRADER_BULK_SELL_SPECIALTY",
@@ -125,7 +126,6 @@
     "dynamic_line": [ "Anything else you need?" ],
     "responses": [
       { "text": "No, that's all.", "topic": "TALK_DONE" },
-      { "text": "Find anything good?", "topic": "TALK_SCRAP_TRADER_ASK_INTERVAL" },
       {
         "text": "I'd like some specialty metals.",
         "topic": "TALK_SCRAP_TRADER_BULK_SELL_SPECIALTY",

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_scavenger.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_scavenger.json
@@ -19,6 +19,7 @@
       { "text": "What is your job here?", "topic": "TALK_RANCH_SCAVENGER_1_JOB" },
       { "text": "Do you need any help?", "topic": "TALK_RANCH_SCAVENGER_1_HIRE" },
       { "text": "Let's see what you've managed to find.", "topic": "TALK_RANCH_SCAVENGER_1", "effect": "start_trade" },
+      { "text": "Any lucky find?", "topic": "TALK_RANCH_SCAVENGER_ASK_RESTOCK" },
       { "text": "I've got to go…", "topic": "TALK_DONE" }
     ]
   },
@@ -36,6 +37,12 @@
       { "text": "What kind of tasks do you have for me?", "topic": "TALK_MISSION_LIST" },
       { "text": "No, thanks.", "topic": "TALK_RANCH_SCAVENGER_1" }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_RANCH_SCAVENGER_ASK_RESTOCK",
+    "dynamic_line": "Nope, current run hasn't returned yet.  Come back in <interval>.  You might find something you like.",
+    "responses": [ { "text": "Alright, thanks.", "topic": "TALK_RANCH_SCAVENGER_1" } ]
   },
   {
     "id": "MISSION_RANCH_SCAVENGER_1",

--- a/data/mods/Aftershock/npcs/prepnet_dialogue.json
+++ b/data/mods/Aftershock/npcs/prepnet_dialogue.json
@@ -101,8 +101,15 @@
         "text": "Crypto coins?  Are you insane, there isn't any global internet now.",
         "topic": "TALK_PrepNet_gardener_currency"
       },
-      { "text": "What can I buy here?", "effect": "start_trade", "topic": "TALK_PrepNet_gardener_1" }
+      { "text": "What can I buy here?", "effect": "start_trade", "topic": "TALK_PrepNet_gardener_1" },
+      { "text": "When will you have more?", "topic": "TALK_PrepNet_gardener_restock" }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PrepNet_gardener_restock",
+    "dynamic_line": "Around <interval>.",
+    "responses": [ { "text": "Alright then, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
@@ -122,7 +129,8 @@
     "dynamic_line": "We use so-called crypto coins for money here.  They were a pre-Cataclysm attempt to abstract money even further and create electronic cash.  Now it's a joke because we use physical coins.  Barter only gets you so far.  And one day we'll have the Net back up.",
     "responses": [
       { "text": "Oh, okay.", "topic": "TALK_PrepNet_gardener_1" },
-      { "text": "What can I buy here?", "effect": "start_trade", "topic": "TALK_PrepNet_gardener_1" }
+      { "text": "What can I buy here?", "effect": "start_trade", "topic": "TALK_PrepNet_gardener_1" },
+      { "text": "When will you have more?", "topic": "TALK_PrepNet_gardener_restock" }
     ]
   },
   {

--- a/data/mods/Aftershock/npcs/whately_generic_dialogue.json
+++ b/data/mods/Aftershock/npcs/whately_generic_dialogue.json
@@ -82,8 +82,15 @@
     "dynamic_line": "Then let's see what you've got to trade.",
     "responses": [
       { "text": "It was worth a try.", "topic": "TALK_WHATELY_1" },
-      { "text": "What can I buy here?", "effect": "start_trade", "topic": "TALK_WHATELY_1" }
+      { "text": "What can I buy here?", "effect": "start_trade", "topic": "TALK_WHATELY_1" },
+      { "text": "When will you have more in stock?", "topic": "TALK_WHATELY_restock" }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_WHATELY_restock",
+    "dynamic_line": "Around <interval>.",
+    "responses": [ { "text": "Alright then, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2888,6 +2888,14 @@ void monster::drop_items_on_death()
     g->m.spawn_items( pos(), std::move( items ) );
 }
 
+std::string npc::get_restock_interval() const
+{
+    time_duration const restock_remaining =
+        restock - calendar::turn;
+    std::string restock_rem = to_string( restock_remaining );
+    return restock_rem;
+}
+
 void monster::process_one_effect( effect &it, bool is_new )
 {
     // Monsters don't get trait-based reduction, but they do get effect based reduction

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2888,14 +2888,6 @@ void monster::drop_items_on_death()
     g->m.spawn_items( pos(), std::move( items ) );
 }
 
-std::string npc::get_restock_interval() const
-{
-    time_duration const restock_remaining =
-        restock - calendar::turn;
-    std::string restock_rem = to_string( restock_remaining );
-    return restock_rem;
-}
-
 void monster::process_one_effect( effect &it, bool is_new )
 {
     // Monsters don't get trait-based reduction, but they do get effect based reduction

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1790,6 +1790,14 @@ void npc::shop_restock()
     }
 }
 
+std::string npc::get_restock_interval() const
+{
+    time_duration const restock_remaining =
+        restock - calendar::turn;
+    std::string restock_rem = to_string( restock_remaining );
+    return restock_rem;
+}
+
 int npc::minimum_item_value() const
 {
     // TODO: Base on inventory

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1718,13 +1718,15 @@ int npc::max_willing_to_owe() const
 
 void npc::shop_restock()
 {
-    const time_duration restock_delay = 3_days;
-
-    if( restock != calendar::turn_zero && ( calendar::turn - restock ) < restock_delay ) {
+    if( ( restock != calendar::turn_zero ) &&
+        ( ( calendar::turn - restock ) < 3_days * get_option<float>( "RESTOCK_DELAY_MULT" ) ) ) {
         return;
     }
 
-    restock = calendar::turn + restock_delay;
+    restock = calendar::turn + 3_days * get_option<float>( "RESTOCK_DELAY_MULT" );
+    if( is_player_ally() ) {
+        return;
+    }
 
     const item_group_id &from = myclass->get_shopkeeper_items();
     if( from == item_group_id( "EMPTY_GROUP" ) ) {
@@ -1793,9 +1795,11 @@ void npc::shop_restock()
 
 std::string npc::get_restock_interval() const
 {
-    time_duration const restock_remaining =
-        restock - calendar::turn;
+    time_duration const restock_remaining = restock - calendar::turn;
     std::string restock_rem = to_string( restock_remaining );
+    if( restock_remaining < -1_seconds ) {
+        debugmsg( "Restock not scheduled or negative.  Open the shop first." );
+    }
     return restock_rem;
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -53,6 +53,7 @@
 #include "mtype.h"
 #include "mutation.h"
 #include "npc_class.h"
+#include "options.h"
 #include "output.h"
 #include "overmap.h"
 #include "overmapbuffer.h"
@@ -321,7 +322,7 @@ void npc::load_npc_template( const string_id<npc_template> &ident )
     attitude = tguy.attitude;
     mission = tguy.mission;
     // If we're a shopkeeper force spawn of shopkeeper items here
-    if( mission == NPC_MISSION_SHOPKEEP ) {
+    if( is_shopkeeper() ) {
         const item_group_id &from = myclass->get_shopkeeper_items();
         if( from != item_group_id( "EMPTY_GROUP" ) ) {
             inv_clear();
@@ -1717,21 +1718,21 @@ int npc::max_willing_to_owe() const
 
 void npc::shop_restock()
 {
-    if( ( restock != calendar::turn_zero ) && ( ( calendar::turn - restock ) < 3_days ) ) {
+    const time_duration restock_delay = 3_days;
+
+    if( restock != calendar::turn_zero && ( calendar::turn - restock ) < restock_delay ) {
         return;
     }
 
-    restock = calendar::turn + 3_days;
-    if( is_player_ally() ) {
-        return;
-    }
+    restock = calendar::turn + restock_delay;
+
     const item_group_id &from = myclass->get_shopkeeper_items();
     if( from == item_group_id( "EMPTY_GROUP" ) ) {
         return;
     }
 
     units::volume total_space = volume_capacity();
-    if( mission == NPC_MISSION_SHOPKEEP ) {
+    if( is_shopkeeper() ) {
         total_space = units::from_liter( 5000 );
     }
 
@@ -1739,7 +1740,7 @@ void npc::shop_restock()
     int shop_value = 75000;
     if( my_fac ) {
         shop_value = my_fac->wealth * 0.0075;
-        if( mission == NPC_MISSION_SHOPKEEP && !my_fac->currency.is_empty() ) {
+        if( is_shopkeeper() && !my_fac->currency.is_empty() ) {
             item *my_currency = item::spawn_temporary( my_fac->currency );
             if( !my_currency->is_null() ) {
                 my_currency->set_owner( *this );
@@ -1796,6 +1797,12 @@ std::string npc::get_restock_interval() const
         restock - calendar::turn;
     std::string restock_rem = to_string( restock_remaining );
     return restock_rem;
+}
+
+bool npc::is_shopkeeper() const
+{
+    const item_group_id &from = myclass->get_shopkeeper_items();
+    return mission == NPC_MISSION_SHOPKEEP || from != item_group_id( "EMPTY_GROUP" );
 }
 
 int npc::minimum_item_value() const

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1797,9 +1797,6 @@ std::string npc::get_restock_interval() const
 {
     time_duration const restock_remaining = restock - calendar::turn;
     std::string restock_rem = to_string( restock_remaining );
-    if( restock_remaining < -1_seconds ) {
-        debugmsg( "Restock not scheduled or negative.  Open the shop first." );
-    }
     return restock_rem;
 }
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -877,6 +877,7 @@ class npc : public player
         // Re-roll the inventory of a shopkeeper
         void shop_restock();
         std::string get_restock_interval() const;
+        bool is_shopkeeper() const;
         // Use and assessment of items
         // The minimum value to want to pick up an item
         int minimum_item_value() const;

--- a/src/npc.h
+++ b/src/npc.h
@@ -876,6 +876,7 @@ class npc : public player
         void talk_to_u( bool radio_contact = false );
         // Re-roll the inventory of a shopkeeper
         void shop_restock();
+        std::string get_restock_interval() const;
         // Use and assessment of items
         // The minimum value to want to pick up an item
         int minimum_item_value() const;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1798,7 +1798,8 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me,
             npc *guy = const_cast<npc *>( me.as_npc() ); // remove const-ness from pointer
             time_duration const restock_remaining = guy->restock - calendar::turn;
             // reset if the restock rate is higher than the possible max, or null (setting has changed or not oponed shop yet)
-            if( restock_remaining < -1_seconds || restock_remaining > 3_days * get_option<float>( "RESTOCK_DELAY_MULT" ) ) {
+            if( restock_remaining < -1_seconds ||
+                restock_remaining > 3_days * get_option<float>( "RESTOCK_DELAY_MULT" ) ) {
                 guy->restock = calendar::turn + 3_days * get_option<float>( "RESTOCK_DELAY_MULT" );
             }
             phrase.replace( fa, l, guy->get_restock_interval() );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1793,6 +1793,9 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me,
             item *tmp = item::spawn_temporary( item_type );
             tmp->charges = u.charges_of( item_type );
             phrase.replace( fa, l, format_money( tmp->price( true ) ) );
+        } else if( tag == "<interval>" ) {
+            const npc *guy = dynamic_cast<const npc *>( &me );
+            phrase.replace( fa, l, guy->get_restock_interval() );
         } else if( !tag.empty() ) {
             debugmsg( "Bad tag.  '%s' (%d - %d)", tag.c_str(), fa, fb );
             phrase.replace( fa, fb - fa + 1, "????" );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -56,6 +56,7 @@
 #include "npc_class.h"
 #include "npctalk.h"
 #include "npctrade.h"
+#include "options.h"
 #include "output.h"
 #include "pimpl.h"
 #include "player.h"
@@ -1794,7 +1795,12 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me,
             tmp->charges = u.charges_of( item_type );
             phrase.replace( fa, l, format_money( tmp->price( true ) ) );
         } else if( tag == "<interval>" ) {
-            const npc *guy = me.as_npc();
+            npc *guy = const_cast<npc *>( me.as_npc() ); // remove const-ness from pointer
+            time_duration const restock_remaining = guy->restock - calendar::turn;
+            // reset if the restock rate is higher than the possible max, or null (setting has changed or not oponed shop yet)
+            if( restock_remaining < -1_seconds || restock_remaining > 3_days * get_option<float>( "RESTOCK_DELAY_MULT" ) ) {
+                guy->restock = calendar::turn + 3_days * get_option<float>( "RESTOCK_DELAY_MULT" );
+            }
             phrase.replace( fa, l, guy->get_restock_interval() );
         } else if( !tag.empty() ) {
             debugmsg( "Bad tag.  '%s' (%d - %d)", tag.c_str(), fa, fb );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1794,7 +1794,7 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me,
             tmp->charges = u.charges_of( item_type );
             phrase.replace( fa, l, format_money( tmp->price( true ) ) );
         } else if( tag == "<interval>" ) {
-            const npc *guy = dynamic_cast<const npc *>( &me );
+            const npc *guy = me.as_npc();
             phrase.replace( fa, l, guy->get_restock_interval() );
         } else if( !tag.empty() ) {
             debugmsg( "Bad tag.  '%s' (%d - %d)", tag.c_str(), fa, fb );

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -166,7 +166,7 @@ std::vector<item_pricing> npc_trading::init_buying( Character &buyer, Character 
 
     //nearby items owned by the NPC will only show up in
     //the trade window if the NPC is also a shopkeeper
-    if( np.mission == NPC_MISSION_SHOPKEEP ) {
+    if( np.is_shopkeeper() ) {
         for( map_cursor &cursor : map_selector( seller.pos(), PICKUP_RANGE ) ) {
             cursor.visit_items( [&check_item]( item * node ) {
                 check_item( {node}, 1 );
@@ -486,7 +486,7 @@ bool trading_window::perform_trade( npc &np, const std::string &deal )
     weight_left = np.weight_capacity() - np.weight_carried();
 
     // Shopkeeps are happy to have large inventories.
-    if( np.mission == NPC_MISSION_SHOPKEEP ) {
+    if( np.is_shopkeeper() ) {
         volume_left = 5000_liter;
         weight_left = 5000_kilogram;
     }
@@ -682,7 +682,7 @@ void trading_window::update_npc_owed( npc &np )
 bool npc_trading::trade( npc &np, int cost, const std::string &deal )
 {
     // Only allow actual shopkeepers to refresh their inventory like this
-    if( np.mission == NPC_MISSION_SHOPKEEP ) {
+    if( np.is_shopkeeper() ) {
         np.shop_restock();
     }
     //np.drop_items( np.weight_carried() - np.weight_capacity(),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2514,6 +2514,11 @@ void options_manager::add_options_world_default()
          false
        );
 
+    add( "RESTOCK_DELAY_MULT", world_default, translate_marker( "Merchant restock rate" ),
+         translate_marker( "A scaling factor that determines restock rate of merchants." ),
+         0.01, 10.0, 1.0, 0.01
+       );
+
     add_empty_line();
 
     add( "RAD_MUTATION", world_default, translate_marker( "Mutations by radiation" ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2426,6 +2426,11 @@ void options_manager::add_options_world_default()
          0.0, 100, 2.0, 0.01
        );
 
+    add( "RESTOCK_DELAY_MULT", world_default, translate_marker( "Merchant restock scaling factor" ),
+         translate_marker( "A scaling factor that determines restock rate of merchants." ),
+         0.01, 10.0, 1.0, 0.01
+       );
+
     add_empty_line();
 
     add( "MONSTER_SPEED", world_default, translate_marker( "Monster speed" ),
@@ -2512,11 +2517,6 @@ void options_manager::add_options_world_default()
     add( "RANDOM_NPC", world_default, translate_marker( "Random NPCs" ),
          translate_marker( "If true, the game will randomly spawn NPCs during gameplay." ),
          false
-       );
-
-    add( "RESTOCK_DELAY_MULT", world_default, translate_marker( "Merchant restock rate" ),
-         translate_marker( "A scaling factor that determines restock rate of merchants." ),
-         0.01, 10.0, 1.0, 0.01
        );
 
     add_empty_line();


### PR DESCRIPTION
## Purpose of change (The Why)
More options exposed to the player is a good thing, and QOL change to allow asking a merchant when they will restock.
ports: https://github.com/https://github.com/CleverRaven/Cataclysm-DDA/pull/68218/ and very partially ports: https://github.com/https://github.com/CleverRaven/Cataclysm-DDA/pull/62009 (only the is_shopkeeper(). some of the other changes we don't have and will need other prior PR's to even start on)
## Describe the solution (The How)
Adds a new `<interval>` parse_tag that allows the NPC to get the current time left until restock.
Updates relevant shops. I may have missed some, as I just ported what DDA had and did a quick overview of ours.

Adds a world option "Merchant restock rate" which allows the player to specify a multiplier from 0.01 to 10.00. This is based on the usual 3 day restock rate of merchants. (eg: 0.01 = 43.2 minutes and 10.00 = 30 days aka 1 season)
## Describe alternatives you've considered
Porting the JSON merchant rates as well, but that can probably be separate. This PR should be simple enough to integrate into that if/when we decide to port it.
## Testing
Spawned in refugee center, spoke to the merchants there: arsonist and the main merchant. Observed that the rates seem to change properly and I can ask them how long it will be until restock with no errors.

Spawned in aftershock buildings, observed that the merchants seem broken, however my changes I made worked as expected. (The broken merchants are not related to this PR)
## Additional context
Aftershock merchants seem to be broken (no fruits or survivor stuff?), and the NC_HUNTER that spawns at the refugee center seems to be broken (no meat?). After testing the latest release, neither of these changes seem related to my PR as they are present there as well.
Please let me know if I missed any merchants or added the new text to the wrong merchant. In my testing and to my knowledge, I have not, but that's why we test things
![image](https://github.com/user-attachments/assets/dfd3cf43-03b4-428d-adfc-0cd71645e3e4)
![image](https://github.com/user-attachments/assets/69a57c41-453a-4439-a10c-6b91b4b26e02)
![image](https://github.com/user-attachments/assets/74f122ac-731c-422f-bdcc-3f371354c284)
## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [X] This PR ports commits from DDA or other cataclysm forks.
  - [X] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [X] I have linked the URL of original PR(s) in the description.
<!--
please remove sections irrelevant to this PR.

- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
