### PR TITLE
fix: peanut butter is made of nut

### DIFF
--- a/data/json/items/comestibles/drink_other.json
+++ b/data/json/items/comestibles/drink_other.json
@@ -147,7 +147,7 @@
     "volume": "250 ml",
     "comestible_type": "DRINK",
     "container": "jar_glass_sealed",
-    "primary_material": "junk",
+    "material": ["junk", "nut"],
     "quench": -2,
     "calories": 190,
     "charges": 8,

--- a/data/json/items/comestibles/drink_other.json
+++ b/data/json/items/comestibles/drink_other.json
@@ -147,7 +147,7 @@
     "volume": "250 ml",
     "comestible_type": "DRINK",
     "container": "jar_glass_sealed",
-    "material": ["junk", "nut"],
+    "material": [ "junk", "nut" ],
     "quench": -2,
     "calories": 190,
     "charges": 8,

--- a/data/json/items/comestibles/drink_other.json
+++ b/data/json/items/comestibles/drink_other.json
@@ -159,7 +159,7 @@
   {
     "id": "peanutbutter_imitation",
     "type": "COMESTIBLE",
-    "name": "imitation peanutbutter",
+    "name": "imitation peanut butter",
     "description": "A thick, nutty brown paste.",
     "copy-from": "peanutbutter"
   },

--- a/data/json/items/comestibles/sandwich.json
+++ b/data/json/items/comestibles/sandwich.json
@@ -265,7 +265,7 @@
     "description": "Some peanut butter smothered between two pieces of bread.  Not very filling and will stick to the roof of your mouth like glue.",
     "price": "175 cent",
     "price_postapoc": "175 cent",
-    "material": [ "wheat" ],
+    "material": [ "wheat", "nut" ],
     "volume": "500 ml",
     "fun": 3,
     "vitamins": [ [ "calcium", 10 ], [ "iron", 28 ], [ "wheat_allergen", 1 ] ],
@@ -277,7 +277,7 @@
     "copy-from": "sandwich_pb",
     "name": { "str": "PB&J sandwich", "str_pl": "PB&J sandwiches" },
     "description": "A delicious peanut butter and jelly sandwich.  It reminds you of the times your mother would make you lunch.",
-    "material": [ "fruit", "wheat" ],
+    "material": [ "fruit", "wheat", "nut" ],
     "fun": 6,
     "vitamins": [ [ "vitC", 3 ], [ "calcium", 7 ], [ "iron", 14 ], [ "wheat_allergen", 1 ], [ "fruit_allergen", 1 ] ]
   },
@@ -288,7 +288,7 @@
     "name": { "str": "PB&H sandwich", "str_pl": "PB&H sandwiches" },
     "calories": 150,
     "description": "Some damned fool put honey on this peanut butter sandwich, who in their right mind- oh wait this is pretty good.",
-    "material": [ "wheat", "honey" ],
+    "material": [ "wheat", "honey", "nut" ],
     "fun": 6,
     "vitamins": [ [ "calcium", 8 ], [ "iron", 16 ], [ "wheat_allergen", 1 ] ]
   },
@@ -299,7 +299,7 @@
     "name": { "str": "PB&M sandwich", "str_pl": "PB&M sandwiches" },
     "calories": 170,
     "description": "Who knew you could mix maple syrup and peanut butter to create yet another different sandwich?",
-    "material": [ "wheat" ],
+    "material": [ "wheat", nut ],
     "fun": 6,
     "vitamins": [ [ "calcium", 12 ], [ "iron", 28 ], [ "wheat_allergen", 1 ] ]
   },

--- a/data/json/items/comestibles/sandwich.json
+++ b/data/json/items/comestibles/sandwich.json
@@ -299,7 +299,7 @@
     "name": { "str": "PB&M sandwich", "str_pl": "PB&M sandwiches" },
     "calories": 170,
     "description": "Who knew you could mix maple syrup and peanut butter to create yet another different sandwich?",
-    "material": [ "wheat", nut ],
+    "material": [ "wheat", "nut" ],
     "fun": 6,
     "vitamins": [ [ "calcium", 12 ], [ "iron", 28 ], [ "wheat_allergen", 1 ] ]
   },


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

1. After noticing that carnivores were able to eat peanut butter, I quickly realized that peanut butter and peanut butter sandwiches did not have `nut` in their materials.
2. Imitation peanut butter was misspelled as "imitation peanutbutter".

## Describe the solution (The How)

1. Add `nut` to their materials 
2. Add space between "peanut" and "butter".

## Describe alternatives you've considered

Adding futher more nut containing foods to justify creating a nut allergy mutation that can be picked as a starting trait.

## Testing

spawned in
peanut butter, imitation peanut butter, and peanut butter products are now made of nut
carnivores can no longer eat peanut butter

## Additional context

It's odd that there hasn't already been a nut allergy trait, given how prominant of a food source nuts are in the Fall, and how common the allergy is in real life.

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
