### PR TITLE
fix: temporarily remove massive electric grids from locations

### DIFF
--- a/data/json/overmap/overmap_special/aircraft_carrier.json
+++ b/data/json/overmap/overmap_special/aircraft_carrier.json
@@ -201,6 +201,6 @@
     "city_distance": [ -1, 1000 ],
     "locations": [ "lake_surface" ],
     "occurrences": [ 75, 100 ],
-    "flags": [ "CLASSIC", "LAKE", "MAN_MADE", "UNIQUE", "MILITARY", "ELECTRIC_GRID", "GLOBALLY_UNIQUE" ]
+    "flags": [ "CLASSIC", "LAKE", "MAN_MADE", "UNIQUE", "MILITARY", "GLOBALLY_UNIQUE" ]
   }
 ]

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1796,7 +1796,7 @@
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 50, 100 ],
-    "flags": [ "ELECTRIC_GRID", "UNIQUE", "GLOBALLY_UNIQUE" ]
+    "flags": [ "UNIQUE", "GLOBALLY_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -1982,7 +1982,7 @@
     "city_distance": [ 3, -1 ],
     "rotate": false,
     "occurrences": [ 30, 100 ],
-    "flags": [ "UNIQUE", "ELECTRIC_GRID" ]
+    "flags": [ "UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -3025,7 +3025,7 @@
     "city_distance": [ 10, -1 ],
     "occurrences": [ 30, 100 ],
     "rotate": false,
-    "flags": [ "LAB", "UNIQUE", "ELECTRIC_GRID" ]
+    "flags": [ "LAB", "UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -3134,7 +3134,7 @@
     ],
     "locations": [ "land" ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "LAB", "ELECTRIC_GRID" ]
+    "flags": [ "LAB" ]
   },
   {
     "type": "overmap_special",
@@ -5631,7 +5631,7 @@
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 10, 100 ],
-    "flags": [ "MILITARY", "UNIQUE", "ELECTRIC_GRID" ]
+    "flags": [ "MILITARY", "UNIQUE" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
## Purpose of change (The Why)

Ref Center lags when you try going into it, and the aircraft carrier almost crashed my PC. We found out it was the grid doing it after profiling it with tracy.

## Describe the solution (The How)

Just delete the electric grid flag from places that have way too big of grids until a better fix happens.

!!! THIS SHOULD PROBABLY BE REVERTED AFTER A FIX !!!

## Describe alternatives you've considered

None due to severity of this problem.

## Testing
No lag
<img width="2049" height="1203" alt="image" src="https://github.com/user-attachments/assets/3d015ff6-0e6e-47dc-b2f9-be0a6eb39c95" />


## Additional context
https://www.youtube.com/watch?v=6KezlDabqfY

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.