### PR TITLE
feat(balance): remove fear of fire from multiple zombie animals

### DIFF
--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -183,7 +183,6 @@
     "harvest": "zombie_tooth_fur",
     "special_attacks": [ [ "HOWL", 10 ] ],
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
-    "fear_triggers": [ "FIRE" ],
     "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "KEENNOSE", "BASHES", "POISON", "NO_BREATHE", "REVIVES" ]
   },
@@ -217,7 +216,6 @@
     "vision_night": 5,
     "harvest": "zombie_tooth_fur_large",
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
-    "fear_triggers": [ "FIRE" ],
     "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON" ]
   },
@@ -249,7 +247,6 @@
     "path_settings": { "max_dist": 10 },
     "special_attacks": [ { "type": "bite", "cooldown": 2 } ],
     "anger_triggers": [ "PLAYER_WEAK", "PLAYER_CLOSE" ],
-    "fear_triggers": [ "FIRE" ],
     "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "KEENNOSE", "BLEED", "BASHES", "POISON", "NO_BREATHE", "REVIVES" ],
     "//": "1d8->2d5, minor bonus over 1d9"
@@ -281,7 +278,6 @@
     "vision_night": 5,
     "harvest": "zombie_leather",
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
-    "fear_triggers": [ "FIRE" ],
     "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "SWIMS" ]
   },
@@ -314,7 +310,6 @@
     "vision_night": 5,
     "harvest": "zombie_fur_large",
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
-    "fear_triggers": [ "FIRE" ],
     "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES" ]
   },
@@ -347,7 +342,6 @@
     "harvest": "zombie_tooth_fur",
     "special_attacks": [ { "type": "leap", "cooldown": 10, "max_range": 5 } ],
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
-    "fear_triggers": [ "FIRE" ],
     "death_function": [ "NORMAL" ],
     "flags": [
       "SEES",


### PR DESCRIPTION
## Purpose of change (The Why)
They're zombies, they shouldn't have that kind of fear.
## Describe the solution (The How)
Remove the "fear_triggers" "FIRE" from the following monsters:
grim howler
zombear
festering boar
zombeaver
antlered horror
decayed pouncer
## Describe alternatives you've considered
none
## Testing
No errors when starting a new game.
## Additional context
none
## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.