### PR TITLE
fix(mods/lethal_zeds): Stop rock guns from bypassing terrain

### DIFF
--- a/data/mods/lethal_zeds/monster_overwrites.json
+++ b/data/mods/lethal_zeds/monster_overwrites.json
@@ -13,6 +13,7 @@
     "color": "yellow",
     "range": 10,
     "skill": "throw",
+    "ammo_effects": [ "NO_PENETRATE_OBSTACLES" ],
     "ranged_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 10 } ],
     "dispersion": 3000,
     "modes": [ [ "DEFAULT", "semi", 1 ] ],


### PR DESCRIPTION
## Purpose of change (The Why)

I made a fake rock gun from what I learned with fake rifles, rather than wholesale copy feral rocks. This means I didn't realize I had to use NO_PENETRATE_OBSTACLES and it wasn't caught in reviewing.

## Describe the solution (The How)

Adds NO_PENETRATE_OBSTACLES as an ammo effect. Reopened from https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6800 because of weird makefile changes when I merged changes.

## Describe alternatives you've considered

Magical Night wizard ferals that teleport rocks through walls.

## Testing

Ferals already use this flag.

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
