### PR TITLE
fix: vandalized shelter always has working computer

### DIFF
--- a/data/json/mapgen/nested/shelter_nested.json
+++ b/data/json/mapgen/nested/shelter_nested.json
@@ -456,10 +456,20 @@
         "+": [ "t_door_c", "t_door_b" ],
         "=": [ "t_door_b", "t_door_locked_interior", "t_door_c", "t_door_o" ],
         "*": "t_ladder_up",
-        "6": [ "t_console", "t_console_broken" ],
+        "6": [ "t_console" ],
         "x": "t_console_broken"
       },
       "furniture": { "b": "f_bench", "c": "f_cupboard", "l": [ [ "f_locker", 2 ], "f_wreckage" ], "S": "f_sink", "%": "f_trashcan" },
+      "computers": {
+        "6": {
+          "name": "Evac shelter computer",
+          "options": [
+            { "name": "Emergency Message", "action": "emerg_mess" },
+            { "name": "Disable External Power", "action": "complete_disable_external_power" },
+            { "name": "Contact Us", "action": "emerg_ref_center" }
+          ]
+        }
+      },
       "items": {
         "l": { "item": "shelter_supplies", "chance": 40 },
         "c": [ { "item": "trash", "chance": 1 }, { "item": "softdrugs", "chance": 2 }, { "item": "shelter_supplies", "chance": 10 } ],


### PR DESCRIPTION
## Purpose of change (The Why)

<img width="383" height="182" alt="image" src="https://github.com/user-attachments/assets/fdfce131-8ea6-4317-bae1-efce7d77d577" />


## Describe the solution (The How)

I decided to always let it spawn a working console while also making sure it actually always generates with a use prompt

## Describe alternatives you've considered

Nah

## Testing
## Additional context

<img width="494" height="306" alt="image" src="https://github.com/user-attachments/assets/e4da30a9-3d7e-400c-80b7-8d589abe8374" />


## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.