### PR TITLE
fix: typos in radiation platform desc.

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -636,7 +636,7 @@
     "id": "t_rad_platform",
     "looks_like": "t_blue_floor",
     "name": "radiation platform",
-    "description": "A dual purpose platform that serves as a containment, and as a device that exposes items places on in to the radioactive source, by temporarily hoisting the radioactive material stored within.  Operated from external console.",
+    "description": "A dual-purpose platform that exposes items placed on it to a radioactive source by temporarily hoisting the radioactive material stored within, while also safely containing all objects to avoid contaminating its surroundings. Operated from an external console.",
     "symbol": "0",
     "color": "light_blue",
     "move_cost": 100,

--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -636,7 +636,7 @@
     "id": "t_rad_platform",
     "looks_like": "t_blue_floor",
     "name": "radiation platform",
-    "description": "A dual-purpose platform that exposes items placed on it to a radioactive source by temporarily hoisting the radioactive material stored within, while also safely containing all objects to avoid contaminating its surroundings. Operated from an external console.",
+    "description": "A dual-purpose platform that exposes items placed on it to a radioactive source by temporarily hoisting the radioactive material stored within, while also safely containing all objects to avoid contaminating its surroundings.  Operated from an external console.",
     "symbol": "0",
     "color": "light_blue",
     "move_cost": 100,


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Radiation platform's description is made up of broken english.

## Describe the solution (The How)

copy DDA's description

## Describe alternatives you've considered

Continue giving Godzilla a stroke

## Testing

1. Spawned in
2. Looked at radiation platform
3. Its description now reads smoothly

## Additional context

I couldn't find the original DDA PR wherein this new description was introduced, otherwise I would have linked it.

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.