### PR TITLE
refactor: Kill off 32-bit builds and begin sunsetting outdated build docs

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -53,12 +53,6 @@ jobs:
             os: windows-latest
             ext: zip
             content: application/zip
-          - name: Windows Tiles x32 MSVC
-            artifact: windows-tiles-x32-msvc
-            arch: x86
-            os: windows-latest
-            ext: zip
-            content: application/zip
           - name: Linux Tiles x64
             os: ubuntu-latest
             android: none
@@ -101,12 +95,6 @@ jobs:
             os: ubuntu-latest
             android: arm64
             artifact: android-x64
-            ext: apk
-            content: application/apk
-          - name: Android x32
-            os: ubuntu-latest
-            android: arm32
-            artifact: android-x32
             ext: apk
             content: application/apk
           - name: Android Bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,12 +102,6 @@ jobs:
             os: windows-latest
             ext: zip
             content: application/zip
-          - name: Windows Tiles x32 MSVC
-            artifact: windows-tiles-x32-msvc
-            arch: x86
-            os: windows-latest
-            ext: zip
-            content: application/zip
           - name: Linux Tiles x64
             os: ubuntu-latest
             android: none
@@ -150,12 +144,6 @@ jobs:
             os: ubuntu-latest
             android: arm64
             artifact: android-x64
-            ext: apk
-            content: application/apk
-          - name: Android x32
-            os: ubuntu-latest
-            android: arm32
-            artifact: android-x32
             ext: apk
             content: application/apk
           - name: Android Bundle

--- a/doc/src/content/docs/en/dev/guides/building/cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/cmake.md
@@ -76,21 +76,6 @@ If you plan on using `tiles`, make sure you have the latest [WSL 2 that supports
 2. Install CataclysmBN build deps:
 
 ```
-pacman -S mingw-w64-i686-toolchain msys/git \
-   	  mingw-w64-i686-cmake \
-   	  mingw-w64-i686-SDL2_{image,mixer,ttf} \
-   	  ncurses-devel \
-      gettext \
-      base-devel
-```
-
-This should get your environment set up to build console and tiles version of windows.
-
-:::caution
-
-This is only for 32bit builds. 64bit requires the x86_64 instead of the i686 packages listed above:
-
-```sh
 pacman -S mingw-w64-x86_64-toolchain msys/git \
    	  mingw-w64-x86_64-cmake \
    	  mingw-w64-x86_64-SDL2_{image,mixer,ttf} \
@@ -99,7 +84,7 @@ pacman -S mingw-w64-x86_64-toolchain msys/git \
       base-devel
 ```
 
-:::
+This should get your environment set up to build console and tiles version of windows.
 
 :::note
 

--- a/doc/src/content/docs/en/dev/guides/building/cygwin.md
+++ b/doc/src/content/docs/en/dev/guides/building/cygwin.md
@@ -2,6 +2,12 @@
 title: Cygwin
 ---
 
+:::caution
+
+Cygwin build has not been tested in a very long time, and this article is mostly kept around for posterity
+
+:::
+
 This guide contains instructions for compiling Cataclysm-BN on Windows under Cygwin.
 
 :::note

--- a/doc/src/content/docs/en/dev/guides/building/makefile.md
+++ b/doc/src/content/docs/en/dev/guides/building/makefile.md
@@ -230,16 +230,12 @@ MXE can be either installed from MXE apt repository (much faster) or compiled fr
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
 sudo add-apt-repository "deb [arch=amd64] https://pkg.mxe.cc/repos/apt `lsb_release -sc` main"
 sudo apt-get update
-sudo apt-get install astyle bzip2 git make mxe-{i686,x86-64}-w64-mingw32.static-{sdl2,sdl2-ttf,sdl2-image,sdl2-mixer}
+sudo apt-get install astyle bzip2 git make mxe-x86-64-w64-mingw32.static-{sdl2,sdl2-ttf,sdl2-image,sdl2-mixer}
 ```
-
-If you are not planning on building for both 32-bit and 64-bit, you might want to adjust the last
-apt-get invocation to install only `i686` or `x86-64` packages.
 
 Edit your `~/.profile` as follows:
 
 ```sh
-export PLATFORM_32="/usr/lib/mxe/usr/bin/i686-w64-mingw32.static-"
 export PLATFORM_64="/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.static-"
 ```
 
@@ -260,7 +256,7 @@ mkdir -p ~/src
 cd ~/src
 git clone https://github.com/mxe/mxe.git
 cd mxe
-make -j$((`nproc`+0)) MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' sdl2 sdl2_ttf sdl2_image sdl2_mixer sqlite
+make -j$((`nproc`+0)) MXE_TARGETS='x86_64-w64-mingw32.static' sdl2 sdl2_ttf sdl2_image sdl2_mixer sqlite
 ```
 
 Building all these packages from MXE might take a while, even on a fast computer. Be patient; the
@@ -272,7 +268,6 @@ MXE_TARGETS.
 Edit your `~/.profile` as follows:
 
 ```sh
-export PLATFORM_32="~/src/mxe/usr/bin/i686-w64-mingw32.static-"
 export PLATFORM_64="~/src/mxe/usr/bin/x86_64-w64-mingw32.static-"
 ```
 
@@ -280,10 +275,7 @@ This is to ensure that the variables for the `make` command will not get reset a
 
 ### Building (SDL)
 
-Run one of the following commands based on your targeted environment:
-
 ```sh
-make -j$((`nproc`+0)) CROSS="${PLATFORM_32}" TILES=1 SOUND=1 RELEASE=1 BACKTRACE=0 PCH=0 bindist
 make -j$((`nproc`+0)) CROSS="${PLATFORM_64}" TILES=1 SOUND=1 RELEASE=1 BACKTRACE=0 PCH=0 bindist
 ```
 

--- a/doc/src/content/docs/en/dev/guides/building/msys.md
+++ b/doc/src/content/docs/en/dev/guides/building/msys.md
@@ -2,6 +2,12 @@
 title: MSYS2
 ---
 
+:::caution
+
+This set of instructions for MSYS2 have not been updated in a long time. The preferred instructions for building with MSYS2 are instead found in [CMake](./cmake#windows-environment-msys2)
+
+:::
+
 This guide contains instructions for compiling Cataclysm-BN on 64bit Windows under MSYS2.
 
 :::warning


### PR DESCRIPTION
## Purpose of change (The Why)

Anyone who uses 32 bit Windows should be expected to compile themselves and be geek enough to do so. We already only have 64 bit builds for the other two desktop OSes, Windows might as well join them.

Android has also been looking to sunset 32 bit applications in general, and it only makes sense to axe 32 bit in general rather than leave a single bit hanging on.

Certain build docs, such as the old info for MSYS, deserve a warning that they have not been reviewed in a while (and will likely be properly sunset in the future)

## Describe the solution (The How)

- Removes 32 bit builds from github
- Removes instructions for building 32 bit in relevant build docs
- Add cautionary warning to top of Cygwin and old MSYS2 to note they have not been reviewed in a while.

## Describe alternatives you've considered

- Split the MSYS and Cygwin changes off into their own PR

Valid, but the overall goal of simplifying builds and their documentation still stands.

## Testing

Should logically not impact any of the other builds.

## Additional context

I doubt playing the game on 32 bit would even be a good experience and would probably cause some strange bugs.

Windows build docs probably need an overhaul in general if we can find interested parties, and I suspect we may start advising people to use MSYS2 or MSBuild (or both) if they want to build their own Windows-native versions based on  our current issues that people are encountering with Visual Studio based building.

Arguably a small step towards getting builds more simplified for the eventual CMake-ifying.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a PR that modifies build process or code organization.
  - [x] Please document the changes in the appropriate location in the `doc/` folder.
  - [x] If the change alters versions of software required to build or work with the game, please document it.
