### PR TITLE
fix: adds "SOIL" spawn rate category, fix total spawnrate scaling

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5948,10 +5948,11 @@ bool item::goes_bad_after_opening( bool strict ) const
         if( type->container && type->container->preserves &&
             !contents.empty() && contents.front().goes_bad() ) {
             return true;
+        } else {
+            return false;
         }
-    } else {
-        return false;
     }
+
     return goes_bad() || ( type->container && type->container->preserves &&
                            !contents.empty() && contents.front().goes_bad() );
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4427,14 +4427,14 @@ float map::item_category_spawn_rate( const item &itm )
 {
     const std::string &cat = itm.get_category().id.c_str();
     float spawn_rate = get_option<float>( "SPAWN_RATE_" + cat );
-    if( itm.goes_bad() ) {
-        const float spawn_rate_mod = get_option<float>( "SPAWN_RATE_perishables" );
-        spawn_rate = spawn_rate / 2;
-        spawn_rate += spawn_rate_mod / 2;
-    } else if( itm.goes_bad_after_opening( true ) ) {
-        const float spawn_rate_mod = get_option<float>( "SPAWN_RATE_perishables_canned" );
-        spawn_rate = spawn_rate / 2;
-        spawn_rate += spawn_rate_mod / 2;
+
+    // strictly search for canned foods only in the first check
+    if( itm.goes_bad_after_opening( true ) ) {
+        float spawn_rate_mod = get_option<float>( "SPAWN_RATE_perishables_canned" );
+        spawn_rate *= spawn_rate_mod;
+    } else if( itm.goes_bad() ) {
+        float spawn_rate_mod = get_option<float>( "SPAWN_RATE_perishables" );
+        spawn_rate *= spawn_rate_mod;
     }
 
     return spawn_rate > 1.0f ? roll_remainder( spawn_rate ) : spawn_rate;

--- a/src/map.h
+++ b/src/map.h
@@ -1259,8 +1259,6 @@ class map
         */
         float item_category_spawn_rate( const item &itm );
 
-
-
         /**
          * Place an item on the map, despite the parameter name, this is not necessarily a new item.
          * WARNING: does -not- check volume or stack charges. player functions (drop etc) should use
@@ -1355,12 +1353,6 @@ class map
         */
         std::vector<item *> put_items_from_loc( const item_group_id &loc, const tripoint &p,
                                                 const time_point &turn = calendar::start_of_cataclysm );
-
-        std::vector<item *> put_filtered_items_from_loc(
-            const item_group_id &loc,
-            const tripoint &p,
-            const time_point &turn,
-            const item_category_id &filter_cat );
 
         // Similar to spawn_an_item, but spawns a list of items, or nothing if the list is empty.
         std::vector<detached_ptr<item>> spawn_items( const tripoint &p,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2566,7 +2566,6 @@ void options_manager::add_options_world_default()
              0.0, 20.0, 1.0, 0.01 );
 
         // this needs special handling since it uses .goes_bad() instead of an actual group
-        // this needs special handling since it uses .goes_bad() instead of an actual group
         add( "SPAWN_RATE_perishables", page_id, "PERISHABLES",
              "Spawn rate for items from PERISHABLES category.",
              0.0, 20.0, 1.0, 0.01 );
@@ -2585,6 +2584,10 @@ void options_manager::add_options_world_default()
 
         add( "SPAWN_RATE_seeds", page_id, "SEEDS",
              "Spawn rate for items from SEEDS category.",
+             0.0, 20.0, 1.0, 0.01 );
+
+        add( "SPAWN_RATE_soil", page_id, "SOIL",
+             "Spawn rate for items from SOIL category.",
              0.0, 20.0, 1.0, 0.01 );
 
         add( "SPAWN_RATE_spare_parts", page_id, "SPARE PARTS",


### PR DESCRIPTION
## Purpose of change (The Why)
In my initial PR I missed the new `SOIL` category, left in an unusued function, and I also broke spawnrate scaling. This fixes those issues. Additionally, it improves the perishables/canned logic and fixes another change I made that may have affected canning rotten food.
## Describe the solution (The How)
Revert a few changes and ensure the code quality is better now.
## Describe alternatives you've considered
## Testing
Spawned at the bottom of a mine, and ensured the issue related to the missing category no longer shows. Canned perishables and perishables seem to spawn less/more if you turn their rates up or down, but for whatever reason can't be completely disabled. This may be related to SUS_fridge type categories being placed differently or related to the bug mentioned by Pyrocyonae in the last PR's discussion, I am unsure.
## Additional context
I still haven't quite cracked the issue with canned and perishables categories, but I figured breaking total item spawnrates was a good enough reason to rush this PR through first.
## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
