### PR TITLE
build: Kill 32 bit experimental builds

### DIFF
--- a/.github/workflows/experimental-release.yml
+++ b/.github/workflows/experimental-release.yml
@@ -23,12 +23,6 @@ jobs:
             os: windows-latest
             ext: zip
             content: application/zip
-          - name: Windows Tiles x32 MSVC
-            artifact: windows-tiles-x32-msvc
-            arch: x86
-            os: windows-latest
-            ext: zip
-            content: application/zip
           - name: Linux Tiles x64
             os: ubuntu-latest
             android: none
@@ -71,12 +65,6 @@ jobs:
             os: ubuntu-latest
             android: arm64
             artifact: android-x64
-            ext: apk
-            content: application/apk
-          - name: Android x32
-            os: ubuntu-latest
-            android: arm32
-            artifact: android-x32
             ext: apk
             content: application/apk
           - name: Android Bundle


### PR DESCRIPTION
## Purpose of change (The Why)

#6811 missed a spot

## Describe the solution (The How)

Kill 32 bit experimental builds too

## Describe alternatives you've considered

Leave them be, for it to be truly experimental / for us to know when exactly we break 32 bit support by accident

## Testing

Reading

## Additional context

In my defense, the experimental build isn't the most prominent

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
