### PR TITLE
feat: disable typewriter rule check

### DIFF
--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -9,7 +9,6 @@
 #include "language.h"
 #include "rng.h"
 #include "string_utils.h"
-#include "text_style_check.h"
 
 // int version/generation that is incremented each time language is changed
 // used to invalidate translation cache
@@ -264,43 +263,6 @@ void translation::deserialize( JsonIn &jsin )
             log_error( "Please use \"str_sp\" instead of \"str\" and \"str_pl\" "
                        "for text with identical singular and plural forms",
                        0 );
-        }
-        if( !raw_pl ) {
-            // Check for punctuation and spacing. Strings with plural forms are
-            // curently simple names, for which these checks are not necessary.
-            const auto text_style_callback =
-                [&log_error]
-                ( const text_style_fix type, const std::string & msg,
-                  const std::u32string::const_iterator & beg, const std::u32string::const_iterator & /*end*/,
-                  const std::u32string::const_iterator & /*at*/,
-                  const std::u32string::const_iterator & from, const std::u32string::const_iterator & to,
-                  const std::string & fix
-            ) {
-                std::string err;
-                switch( type ) {
-                    case text_style_fix::removal:
-                        err = msg + "\n"
-                              + "    Suggested fix: remove \"" + utf32_to_utf8( std::u32string( from, to ) ) + "\"\n"
-                              + "    At the following position (marked with caret)";
-                        break;
-                    case text_style_fix::insertion:
-                        err = msg + "\n"
-                              + "    Suggested fix: insert \"" + fix + "\"\n"
-                              + "    At the following position (marked with caret)";
-                        break;
-                    case text_style_fix::replacement:
-                        err = msg + "\n"
-                              + "    Suggested fix: replace \"" + utf32_to_utf8( std::u32string( from, to ) )
-                              + "\" with \"" + fix + "\"\n"
-                              + "    At the following position (marked with caret)";
-                        break;
-                }
-                log_error( err, std::distance( beg, to ) );
-            };
-
-            const std::u32string raw32 = utf8_to_utf32( raw );
-            text_style_check<std::u32string::const_iterator>( raw32.cbegin(), raw32.cend(),
-                    fix_end_of_string_spaces::yes, escape_unicode::no, text_style_callback );
         }
     }
 #endif

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -11,7 +11,7 @@
 #include "type_id.h"
 
 template<typename T>
-void test_serialization( const T &val, const std::string &s )
+static void test_serialization( const T &val, const std::string &s )
 {
     CAPTURE( val );
     {
@@ -85,7 +85,7 @@ static void test_translation_text_style_check( Matcher &&matcher, const std::str
     CHECK_THAT( dmsg, matcher );
 }
 
-TEST_CASE( "translation_text_style_check", "[json][translation]" )
+TEST_CASE( "translation_text_style_check", "[json][translation][.]" )
 {
     // this test case is mainly for checking the caret position.
     // the text style check itself is tested in the lit test of clang-tidy.
@@ -172,7 +172,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         R"({"str": "\u2026foo. bar."})" ); // NOLINT(cata-text-style)
 }
 
-TEST_CASE( "translation_text_style_check_error_recovery", "[json][translation]" )
+TEST_CASE( "translation_text_style_check_error_recovery", "[json][translation][.]" )
 {
     restore_on_out_of_scope<error_log_format_t> restore_error_log_format( error_log_format );
     error_log_format = error_log_format_t::human_readable;

--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -17,7 +17,6 @@ set(CataAnalyzerSrc
     SimplifyPointConstructorsCheck.cpp
     StringLiteralIterator.cpp
     TestFilenameCheck.cpp
-    TextStyleCheck.cpp
     TranslatorCommentsCheck.cpp
     UnusedStaticsCheck.cpp
     UseLocalizedSortingCheck.cpp

--- a/tools/clang-tidy-plugin/CataTidyModule.cpp
+++ b/tools/clang-tidy-plugin/CataTidyModule.cpp
@@ -11,7 +11,6 @@
 #include "PointInitializationCheck.h"
 #include "SimplifyPointConstructorsCheck.h"
 #include "TestFilenameCheck.h"
-#include "TextStyleCheck.h"
 #include "TranslatorCommentsCheck.h"
 #include "UnusedStaticsCheck.h"
 #include "UseLocalizedSortingCheck.h"
@@ -51,7 +50,6 @@ class CataModule : public ClangTidyModule
             CheckFactories.registerCheck<SimplifyPointConstructorsCheck>(
                 "cata-simplify-point-constructors" );
             CheckFactories.registerCheck<TestFilenameCheck>( "cata-test-filename" );
-            CheckFactories.registerCheck<TextStyleCheck>( "cata-text-style" );
             CheckFactories.registerCheck<TranslatorCommentsCheck>( "cata-translator-comments" );
             CheckFactories.registerCheck<UnusedStaticsCheck>( "cata-unused-statics" );
             CheckFactories.registerCheck<UseLocalizedSortingCheck>( "cata-use-localized-sorting" );


### PR DESCRIPTION

## Purpose of change (The Why)

resolves #6814

## Describe the solution (The How)

removed its invocation. kept the typewriter rule checker as we may want to rewire it into single space in the future

## Describe alternatives you've considered

comment it out? idk

## Testing

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/57acd063-189d-4ca5-b77a-2dcc99225892" />

loaded gun that has description with broken spacing without issues.
<img width="1497" height="1570" alt="image" src="https://github.com/user-attachments/assets/82a37247-c32c-4485-a996-266caf0c630b" />

ran clang-tidy with cata plugin and it didn't trigger warnings

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

