### PR TITLE
feat(balance): Make stat scaling percentages for magic an external option

### DIFF
--- a/data/json/game_balance.json
+++ b/data/json/game_balance.json
@@ -250,5 +250,12 @@
     "info": "The integer flat rate for mana regen (per hour) that should be used as a baseline if enabled.",
     "stype": "int",
     "value": 100
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "MAGIC_STAT_SCALING_PERCENT",
+    "info": "The percentage bonus (or malus) that each point away from the base 8 should get you (i.e. 10 is 10%).",
+    "stype": "int",
+    "value": 10
   }
 ]

--- a/data/mods/StatsThroughSkills/modinfo.json
+++ b/data/mods/StatsThroughSkills/modinfo.json
@@ -35,5 +35,11 @@
     "skills": [ "archery", "gun", "launcher", "pistol", "rifle", "shotgun", "smg" ],
     "skill_offset": -3,
     "scaling_power": 0.4
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "MAGIC_STAT_SCALING_PERCENT",
+    "stype": "int",
+    "value": 5
   }
 ]

--- a/data/mods/stats_through_kills/modinfo.json
+++ b/data/mods/stats_through_kills/modinfo.json
@@ -14,5 +14,11 @@
     "name": "STATS_THROUGH_KILLS",
     "stype": "bool",
     "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "MAGIC_STAT_SCALING_PERCENT",
+    "stype": "int",
+    "value": 5
   }
 ]

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -508,11 +508,12 @@ int spell::get_stats_deltas( const Character &guy ) const
 
 double spell::get_stat_mult( bool decrease, const Character &guy ) const
 {
+    double percent = get_option<int>("MAGIC_STAT_SCALING_PERCENT") / 100.0;
     if( decrease ) {
-        return std::max( ( 1.0 - ( 0.1 * get_stats_deltas( guy ) ) ),
+        return std::max( ( 1.0 - ( percent * get_stats_deltas( guy ) ) ),
                          0.1 ); // Max is necessary to avoid negatives / 0
     }
-    return ( 1.0 + ( 0.1 * get_stats_deltas(
+    return ( 1.0 + ( percent * get_stats_deltas(
                          guy ) ) ); // No else block needed because return early above
 }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -508,7 +508,7 @@ int spell::get_stats_deltas( const Character &guy ) const
 
 double spell::get_stat_mult( bool decrease, const Character &guy ) const
 {
-    double percent = get_option<int>("MAGIC_STAT_SCALING_PERCENT") / 100.0;
+    double percent = get_option<int>( "MAGIC_STAT_SCALING_PERCENT" ) / 100.0;
     if( decrease ) {
         return std::max( ( 1.0 - ( percent * get_stats_deltas( guy ) ) ),
                          0.1 ); // Max is necessary to avoid negatives / 0


### PR DESCRIPTION
## Purpose of change (The Why)

Stats Through Kills and Stats Through Skills can make mages a little too strong too easily.

I decided it'd be better to do as an external option rather than hardcoding in that the stats-through-X mods cause the rate to be halved.

## Describe the solution (The How)

Adds `MAGIC_STAT_SCALING_PERCENT` as an external option, defaulted to 10 but set to 5 in STK and STS. 

## Describe alternatives you've considered

- Make the option directly a float

I felt that this method (integer converted to float) is more clear, especially regarding precision.

## Testing

It compiles, the math checks out, and this change is very simple conceptually

## Additional context

Admittedly balance should not necessarily be assumed with STK / STS in the first place, but I still think it's a good idea so that other mods can adjust the values in theory too.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
