### PR TITLE
feat(mods/MonsterGirls): Update Harpy Description due to gaining flight

### DIFF
--- a/data/mods/Monster_Girls/thresh_mutation.json
+++ b/data/mods/Monster_Girls/thresh_mutation.json
@@ -70,7 +70,7 @@
     "id": "THRESH_HARPY",
     "name": { "str": "Harpy" },
     "points": 1,
-    "description": "Sadly, it looks like all those myths got it wrong about flying.  Well, at least you *think* so.  Maybe with some extra practice and some dieting, you can one day take to the sky unaided!",
+    "description": "The Wright Brothers **wish** they could have flown like you do.  The zombies stand no chance, now that you can swoop down from above!  Part of you wishes you could build a house on a floating sky island, though…",
     "valid": false,
     "purifiable": false,
     "threshold": true,


### PR DESCRIPTION
## Purpose of change (The Why)

Flight got merged, so harpies can fly now.

## Describe the solution (The How)

Update description to reference their ability to fly and make a new joke.

## Describe alternatives you've considered

- Deliberately remove flight for them for some reason

## Testing

I read

## Additional context

I also realized bunnygirls currently do not appear to have dreams set. I must check to see if vanilla bunny mutants have any to cannibalize.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
