### PR TITLE
feat(mods/MonsterGirls): Add bunnygirl dreams

### DIFF
--- a/data/mods/Monster_Girls/dreams.json
+++ b/data/mods/Monster_Girls/dreams.json
@@ -67,6 +67,12 @@
   },
   {
     "type": "dream",
+    "messages": [ "You have a strange dream about bunnies.", "Your dreams give you a joyful bouncy feeling." ],
+    "category": "BUNNYGIRL",
+    "strength": 1
+  },
+  {
+    "type": "dream",
     "messages": [
       "You have strange dreams of soaring through the sky.",
       "In a dream, you see a curiously harpy-like reflection of yourself."
@@ -151,6 +157,16 @@
       "Whilst dreaming, you see yourself… but with a pair of fox ears on your head?"
     ],
     "category": "KITSUNE",
+    "strength": 2
+  },
+  {
+    "type": "dream",
+    "messages": [
+      "You have a vivid dream of returning to your cozy warren.",
+      "You have a vivid dream of eating a nice, big, orange carrot.  It looks bigger than you!",
+      "Whilst dreaming, you see yourself… but with a pair of large bunny ears on your head?"
+    ],
+    "category": "BUNNYGIRL",
     "strength": 2
   },
   {
@@ -244,6 +260,15 @@
       "You vividly dream of… a wedding altar?!?"
     ],
     "category": "KITSUNE",
+    "strength": 3
+  },
+  {
+    "type": "dream",
+    "messages": [
+      "You vividly dream of skipping away from a big, scary predator.",
+      "It's like your stamina never ends, you wish you had this much energy outside of the dream world!"
+    ],
+    "category": "BUNNYGIRL",
     "strength": 3
   },
   {
@@ -351,6 +376,16 @@
       "You dream of sharing your love of mischief with a partner."
     ],
     "category": "KITSUNE",
+    "strength": 4
+  },
+  {
+    "type": "dream",
+    "messages": [
+      "You dream of sticking your finger down the barrel of that mean ol' farmer's shotgun, just like a certain cartoon character.",
+      "Look at all those cute babies!  If their dreams are anything like yours, it's no wonder your wild cousins are so fecund.",
+      "You dream about farming your very own near-limitless supply of carrots."
+    ],
+    "category": "BUNNYGIRL",
     "strength": 4
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

Bunnygirls had no dreams.

## Describe the solution (The How)

Give bunnygirls dreams

## Describe alternatives you've considered

- Wait for Vanilla / donate some to Vanilla

## Testing

I read, and this was a simple copy-paste then swap text from how Kitsune are formatted.

## Additional context

I tried to not lean *too* much into the adult side of jokes about bunnies / bunnygirls. (At least not yet)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

