### PR TITLE
fix: Allow players to climb again

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10145,7 +10145,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
         }
     }
 
-    if( !force && movez == 1 && !m.has_flag( "GOES_UP", u.pos() ) &&
+    if( !climbing && !force && movez == 1 && !m.has_flag( "GOES_UP", u.pos() ) &&
         !u.is_underwater() ) {
 
         const tripoint dest = u.pos() + tripoint_above;


### PR DESCRIPTION
## Purpose of change (The Why)

fixes #6833

Allows players to climb when they could not before due to changes made during the flight PR 

## Describe the solution (The How)

Re-add a climbing check that was removed for some incomprehensible reason during the flight PR.

## Describe alternatives you've considered

- Make shmakota do it as penance

## Testing

I loaded into the game, and could once again climb up downspouts and trees.

Also, I tested it with flight enabled: Flight takes priority over climbing anyway.

## Additional context

The fact it was so simple is both infuriating as well as joy-inducing

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

