### PR TITLE
feat: make superalloy pet armor craftable

### DIFF
--- a/data/json/items/armor/pets_medium_quadruped_armor.json
+++ b/data/json/items/armor/pets_medium_quadruped_armor.json
@@ -156,16 +156,15 @@
     "copy-from": "medium_quadruped_armor",
     "color": "light_cyan",
     "name": { "str": "superalloy medium quadruped armor" },
-    "description": "A thin mesh interwoven with superalloy plates and pouches for military working medium quadrupeds that covers from the dewlap to the croup, down to the elbows.  You could put this on a friendly medium quadruped.",
+    "description": "A thin mesh interwoven with superalloy plates for military working medium quadrupeds that covers from the dewlap to the croup, down to the elbows.  You could put this on a friendly medium quadruped.",
     "looks_like": "chitin_armor_medium_quadruped",
     "price": "2500 USD",
     "price_postapoc": "100 USD",
     "material": [ "superalloy" ],
-    "weight": "20 kg",
+    "weight": "26 kg",
     "volume": "150 L",
     "material_thickness": 5,
-    "environmental_protection": 3,
-    "storage": "50 L"
+    "environmental_protection": 3
   },
   {
     "id": "saddlebag",

--- a/data/json/items/armor/pets_small_quadruped_armor.json
+++ b/data/json/items/armor/pets_small_quadruped_armor.json
@@ -124,16 +124,15 @@
     "copy-from": "small_quadruped_armor",
     "color": "light_cyan",
     "name": { "str": "superalloy small quadruped armor" },
-    "description": "A thin mesh interwoven with superalloy plates and pouches for military working small quadrupeds that covers from the dewlap to the croup, down to the elbows.  You could put this on a friendly small quadruped.",
+    "description": "A thin mesh interwoven with superalloy plates for military working small quadrupeds that covers from the dewlap to the croup, down to the elbows.  You could put this on a friendly small quadruped.",
     "looks_like": "chitin_armor_small_quadruped",
     "price": "1300 USD",
     "price_postapoc": "50 USD",
     "material": [ "superalloy" ],
-    "weight": "3125 g",
+    "weight": "6100 g",
     "volume": "4500 ml",
     "material_thickness": 4,
-    "environmental_protection": 3,
-    "storage": "25 L"
+    "environmental_protection": 3
   },
   {
     "id": "saddlebag_small_quadruped",

--- a/data/json/recipes/animals/medium_quadruped_armor.json
+++ b/data/json/recipes/animals/medium_quadruped_armor.json
@@ -162,5 +162,18 @@
     "autolearn": true,
     "using": [ [ "sewing_standard", 30 ] ],
     "components": [ [ [ "duct_tape", 350 ] ], [ [ "bag_plastic", 70 ] ], [ [ "fabric_standard", 70, "LIST" ] ] ]
+  },
+  {
+    "result": "superalloy_armor_medium_quadruped",
+    "type": "recipe",
+    "category": "CC_ANIMALS",
+    "subcategory": "CSC_ANIMALS_EQUINE ARMOR",
+    "skill_used": "tailor",
+    "difficulty": 7,
+    "skills_required": [ "fabrication", 9 ],
+    "time": "310 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 2240 ] ],
+    "components": [ [ [ "alloy_sheet", 28 ] ] ]
   }
 ]

--- a/data/json/recipes/animals/small_quadruped_armor.json
+++ b/data/json/recipes/animals/small_quadruped_armor.json
@@ -135,5 +135,18 @@
     "autolearn": true,
     "using": [ [ "sewing_standard", 10 ] ],
     "components": [ [ [ "duct_tape", 50 ] ], [ [ "bag_plastic", 10 ] ], [ [ "fabric_standard", 10, "LIST" ] ] ]
+  },
+  {
+    "result": "superalloy_armor_small_quadruped",
+    "type": "recipe",
+    "category": "CC_ANIMALS",
+    "subcategory": "CSC_ANIMALS_CANINE ARMOR",
+    "skill_used": "tailor",
+    "difficulty": 7,
+    "skills_required": [ "fabrication", 9 ],
+    "time": "95 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 640 ] ],
+    "components": [ [ [ "alloy_sheet", 8 ] ] ]
   }
 ]

--- a/data/json/uncraft/armor/pets_medium_quadruped.json
+++ b/data/json/uncraft/armor/pets_medium_quadruped.json
@@ -67,6 +67,6 @@
     "difficulty": 1,
     "time": "10 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "alloy_sheet", 10 ] ] ]
+    "components": [ [ [ "alloy_sheet", 14] ] ]
   }
 ]

--- a/data/json/uncraft/armor/pets_small_quadruped.json
+++ b/data/json/uncraft/armor/pets_small_quadruped.json
@@ -67,6 +67,6 @@
     "difficulty": 1,
     "time": "10 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "alloy_sheet", 6 ] ] ]
+    "components": [ [ [ "alloy_sheet", 4 ] ] ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

With #6832 planning to remove superalloy quadruped armor from nanofab template spawns, there would no longer be any way to obtain the armor.

## Describe the solution (The How)

Add a recipee for the armors

## Describe alternatives you've considered

Obsoleting the item when it becomes unobtainable

## Testing

1. Spawned in two dogs and two horses
2. Crafted armors successfully
3.  Applied armor to one dog and one horse
4. Beat all the dogs and horses to death
5. Armored animals were harder to kill
All is functioning as normal

## Additional context

- Removed the "storage" from the armor because it was unusable, only attached bags (seperate thing from armor) can be used to store items. The description of the items was fixed to reflect this change.
- The recipe was vaguely based on human superalloy armors and existing pet armors, the latter of which are pretty unhinged and could use a sanity check.
- I didn't want to use rags because the way the description said "thin mesh" made me think it was woven in a special way or something, that's why it's about 80 thread per plate.
- The weight and "disassemble" values were fixed to reflect the new changes. "Disassemble" in quotation marks because, judging by the short time it takes and the loss of materials, it looks like the original author of these intended for these to be salvage results but accidentally made it disassembly.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.