### PR TITLE
fix: make locked wire gates and bar doors pry-able

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -2305,7 +2305,7 @@
     "color": "cyan",
     "move_cost": 2,
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAT", "CONNECT_TO_WALL", "SUPPORTS_ROOF", "ROAD", "INDOORS", "BURROWABLE" ],
+    "flags": [ "TRANSPARENT", "FLAT", "CONNECT_TO_WALL", "SUPPORTS_ROOF", "ROAD", "INDOORS" ],
     "bash": {
       "str_min": 90,
       "str_max": 250,
@@ -2486,7 +2486,7 @@
       "byproducts": [ { "item": "pipe", "count": 12 }, { "item": "hinge", "count": 2 } ]
     },
     "flags": [ "TRANSPARENT", "NOITEM", "PERMEABLE", "CONNECT_TO_WALL", "LOCKED", "THIN_OBSTACLE", "WELDABLE_BARS" ],
-    "examine_action": "locked_object_pickable",
+    "examine_action": "locked_object",
     "oxytorch": {
       "result": "t_mdoor_frame",
       "duration": "10 seconds",
@@ -2505,6 +2505,15 @@
         { "item": "scrap", "count": [ 3, 12 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
       ]
+    },
+    "pry": {
+      "success_message": "You pry open the door.",
+      "fail_message": "You pry, but cannot pry open the door.",
+      "pry_quality": 4,
+      "noise": 24,
+      "sound": "metal screeching!",
+      "difficulty": 4,
+      "new_ter_type": "t_door_bar_o"
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -61,7 +61,7 @@
     "type": "terrain",
     "id": "t_chaingate_l",
     "name": "locked wire gate",
-    "description": "A gate for a chain link fence.  This one has a locked padlock on the latch system.  With the right tools, you could cut the metal fence or pick the lock.  You could also examine the fence to see if it looks climbable.",
+    "description": "A gate for a chain link fence.  This one has a locked padlock on the latch system.  With the right tools, you could cut the metal fence, pick the lock, or pry the whole thing open.  You could also examine the fence to see if it looks climbable.",
     "symbol": "+",
     "color": "cyan",
     "move_cost": 0,

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -75,7 +75,7 @@
     },
     "flags": [ "TRANSPARENT", "PERMEABLE", "LOCKED", "THIN_OBSTACLE", "BURROWABLE" ],
     "connects_to": "CHAINFENCE",
-    "examine_action": "locked_object_pickable",
+    "examine_action": "locked_object",
     "oxytorch": {
       "result": "t_dirt",
       "duration": "9 seconds",
@@ -96,6 +96,15 @@
       "sound_fail": "clang!",
       "ter_set": "t_dirt",
       "items": [ { "item": "wire", "count": [ 8, 20 ] }, { "item": "scrap", "count": [ 0, 12 ] } ]
+    },
+    "pry": {
+      "success_message": "You pry open the gate.",
+      "fail_message": "You pry, but cannot pry open the gate.",
+      "pry_quality": 1,
+      "noise": 18,
+      "sound": "metal screeching!",
+      "difficulty": 8,
+      "new_ter_type": "t_chaingate_o"
     }
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

Locked wire gates and locked bar doors (the ones for jail cells) are not pry-able.

## Describe the solution (The How)

Add pry

## Describe alternatives you've considered

Add pry but with different values than the one's I've suggested. I only assume that the values I applied were reasonable after comparing them to the values other doors use being pried.

## Testing

Spawned in
Bar doors and wire gates can now be pried, in addition to the other things.

## Additional context

I wanted to add the "byproducts" field to the locked wire gate (as in the lock braking and turning into 3 scrap, like how the boltcutter does), but the "pry" attribute does not accept "byproducts."

While I was in the neighborhood I noticed that open metal garage doors were burrowable. Not only are they almost always placed on concrete (or otherwise hard) floors, but they're already open.

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.