### PR TITLE
fix(mods/MagicalNights): Fix fridge goods spawning in wizard tower furnaces

### DIFF
--- a/data/mods/MagicalNights/worldgen/wizard-towers.json
+++ b/data/mods/MagicalNights/worldgen/wizard-towers.json
@@ -156,7 +156,7 @@
       "d": { "item": "SUS_office_desk", "chance": 25 },
       "D": { "item": "snacks", "chance": 10, "repeat": [ 1, 2 ] },
       "E": { "item": "dresser", "chance": 50, "repeat": [ 1, 5 ] },
-      "f": [ { "item": "SUS_fridge", "chance": 95 }, { "item": "potions_common", "chance": 25, "repeat": [ 1, 3 ] } ],
+      "F": [ { "item": "SUS_fridge", "chance": 95 }, { "item": "potions_common", "chance": 25, "repeat": [ 1, 3 ] } ],
       "i": [ { "item": "SUS_office_filing_cabinet", "chance": 30 }, { "item": "office", "chance": 50, "repeat": [ 1, 4 ] } ],
       "I": { "item": "SUS_dishwasher", "chance": 50 },
       "m": { "item": "magic_tools_and_loot", "chance": 60 },


### PR DESCRIPTION
## Purpose of change (The Why)

Fridge goods should not be spawning in the furnace

## Describe the solution (The How)

Fix the items entry from `"f"` to `"F"`, thus putting them in the fridge instead of the furnace

## Describe alternatives you've considered

None

## Testing

I made sure that `"F"` was the correct letter for Fridges.

## Additional context

Gotta love finding small issues during normal gameplay

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
