### PR TITLE
fix(balance): Make sure at least 1 body part is damaged from helicopter crash scenario

### DIFF
--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -446,34 +446,34 @@ void start_location::add_map_extra( const tripoint_abs_omt &omtstart,
 void start_location::handle_heli_crash( player &u ) const
 {
     bool no_body_parts_damaged = true;
-    while (no_body_parts_damaged){
+    while( no_body_parts_damaged ) {
         for( const bodypart_id &bp : u.get_all_body_parts( true ) ) {
-        if( bp == bodypart_id( "head" ) || bp == bodypart_id( "torso" ) ) {
-            continue;// Skip head + torso for balance reasons.
-        }
-        const int roll = rng( 1, 8 );
-        switch( roll ) {
-            // Damage + Bleed
-            case 1:
-            case 2:
-                u.add_effect( effect_bleed, 6_minutes, bp.id() );
-            /* fallthrough */
-            case 3:
-            case 4:
-            // Just damage
-            case 5: {
-                const int maxHp = u.get_hp_max( bp );
-                // Body part health will range from 33% to 66% with occasional bleed
-                const int dmg = rng( maxHp / 3, maxHp * 2 / 3 );
-                u.apply_damage( nullptr, bp, dmg );
-                no_body_parts_damaged = false;
-                break;
+            if( bp == bodypart_id( "head" ) || bp == bodypart_id( "torso" ) ) {
+                continue;// Skip head + torso for balance reasons.
             }
-            // No damage
-            default:
-                break;
+            const int roll = rng( 1, 8 );
+            switch( roll ) {
+                // Damage + Bleed
+                case 1:
+                case 2:
+                    u.add_effect( effect_bleed, 6_minutes, bp.id() );
+                /* fallthrough */
+                case 3:
+                case 4:
+                // Just damage
+                case 5: {
+                    const int maxHp = u.get_hp_max( bp );
+                    // Body part health will range from 33% to 66% with occasional bleed
+                    const int dmg = rng( maxHp / 3, maxHp * 2 / 3 );
+                    u.apply_damage( nullptr, bp, dmg );
+                    no_body_parts_damaged = false;
+                    break;
+                }
+                // No damage
+                default:
+                    break;
+            }
         }
-    }
     }
 }
 

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -445,7 +445,9 @@ void start_location::add_map_extra( const tripoint_abs_omt &omtstart,
 
 void start_location::handle_heli_crash( player &u ) const
 {
-    for( const bodypart_id &bp : u.get_all_body_parts( true ) ) {
+    bool no_body_parts_damaged = true;
+    while (no_body_parts_damaged){
+        for( const bodypart_id &bp : u.get_all_body_parts( true ) ) {
         if( bp == bodypart_id( "head" ) || bp == bodypart_id( "torso" ) ) {
             continue;// Skip head + torso for balance reasons.
         }
@@ -464,12 +466,14 @@ void start_location::handle_heli_crash( player &u ) const
                 // Body part health will range from 33% to 66% with occasional bleed
                 const int dmg = rng( maxHp / 3, maxHp * 2 / 3 );
                 u.apply_damage( nullptr, bp, dmg );
+                no_body_parts_damaged = false;
                 break;
             }
             // No damage
             default:
                 break;
         }
+    }
     }
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

This scenario gives a good amount of points, and it would be rather anticlimactic if you could just somehow come out of the wreck completely unscathed.

## Describe the solution (The How)

Continue to loop over body parts until at least one hits the damage condition

## Describe alternatives you've considered

None

## Testing

Loaded into scenario ~4-6 times, and made sure I had gotten damaged each time.

## Additional context

Testing took longer than coding the change

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
