### PR TITLE
feat: armored backpacks (and harness)

### DIFF
--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -257,5 +257,12 @@
       "flags": [ "HOLSTER_PISTOL" ]
     },
     "flags": [ "WAIST", "COMPACT", "OVERSIZE" ]
+  },
+  {
+    "id": "survivor_vest_armored",
+    "type": "ARMOR",
+    "name": { "str": "armored survivor harness", "str_pl": "armored survivor harnesses" },
+    "copy-from": "survivor_vest",
+    "material": [ "leather", "kevlar" ]
   }
 ]

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -1058,5 +1058,40 @@
     "warmth": 5,
     "material_thickness": 2,
     "flags": [ "VARSIZE" ]
+  },
+  {
+    "id": "survivor_hiking_backpack_armored",
+    "type": "ARMOR",
+    "name": { "str": "armored survivor hiking backpack" },
+    "copy-from": "survivor_hiking_backpack",
+    "material": [ "leather", "kevlar" ]
+  },
+  {
+    "id": "survivor_duffel_bag_armored",
+    "type": "ARMOR",
+    "name": { "str": "armored survivor duffel bag" },
+    "copy-from": "survivor_duffel_bag",
+    "material": [ "leather", "kevlar" ]
+  },
+  {
+    "id": "survivor_pack_armored",
+    "type": "ARMOR",
+    "name": { "str": "armored survivor backpack" },
+    "copy-from": "survivor_pack",
+    "material": [ "leather", "kevlar" ]
+  },
+  {
+    "id": "survivor_rucksack_armored",
+    "type": "ARMOR",
+    "name": { "str": "armored survivor rucksack" },
+    "copy-from": "survivor_rucksack",
+    "material": [ "leather", "kevlar" ]
+  },
+  {
+    "id": "survivor_runner_pack_armored",
+    "type": "ARMOR",
+    "name": { "str": "armored survivor runner pack" },
+    "copy-from": "survivor_runner_pack",
+    "material": [ "leather", "kevlar" ]
   }
 ]

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -1114,5 +1114,179 @@
     "qualities": [ { "id": "HAMMER_FINE", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
     "using": [ [ "welding_standard", 10 ], [ "steel_standard", 1 ] ],
     "components": [ [ [ "sheath", 1 ] ] ]
+  },
+  {
+    "result": "survivor_vest_armored",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 5,
+    "skills_required": [ "fabrication", 3 ],
+    "time": "1 h 10 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 100 ] ],
+    "components": [
+      [ [ "kevlar_plate", 5 ] ],
+      [ [ "fabric_hides_proper", 6, "LIST" ] ],
+      [ [ "holster", 1 ], [ "sholster", 1 ] ],
+      [
+        [ "tacvest", 1 ],
+        [ "legrig", 1 ],
+        [ "vest", 1 ],
+        [ "tool_belt", 1 ],
+        [ "ragpouch", 3 ],
+        [ "leather_pouch", 2 ],
+        [ "dump_pouch", 1 ],
+        [ "purse", 2 ],
+        [ "fanny", 2 ]
+      ],
+      [ [ "duct_tape", 50 ] ]
+    ]
+  },
+  {
+    "result": "survivor_hiking_backpack_armored",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 7,
+    "skills_required": [ "fabrication", 6 ],
+    "time": "2 h 20 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 300 ] ],
+    "components": [
+      [ [ "kevlar_plate", 30 ] ],
+      [ [ "fabric_hides_proper", 36, "LIST" ] ],
+      [ [ "backpack_hiking", 2 ], [ "backpack_tactical_large", 1 ] ],
+      [
+        [ "tacvest", 1 ],
+        [ "legrig", 1 ],
+        [ "vest", 1 ],
+        [ "tool_belt", 1 ],
+        [ "ragpouch", 3 ],
+        [ "leather_pouch", 2 ],
+        [ "dump_pouch", 1 ],
+        [ "purse", 2 ],
+        [ "fanny", 2 ]
+      ],
+      [ [ "duct_tape", 300 ] ]
+    ]
+  },
+  {
+    "result": "survivor_duffel_bag_armored",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 7,
+    "skills_required": [ "fabrication", 6 ],
+    "time": "1 h 40 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 200 ] ],
+    "components": [
+      [ [ "kevlar_plate", 18 ] ],
+      [ [ "fabric_hides_proper", 20, "LIST" ] ],
+      [ [ "molle_pack", 4 ], [ "duffelbag", 2 ], [ "rucksack", 4 ] ],
+      [
+        [ "tacvest", 1 ],
+        [ "legrig", 1 ],
+        [ "vest", 1 ],
+        [ "tool_belt", 1 ],
+        [ "ragpouch", 3 ],
+        [ "leather_pouch", 2 ],
+        [ "dump_pouch", 1 ],
+        [ "purse", 2 ],
+        [ "fanny", 2 ]
+      ],
+      [ [ "duct_tape", 200 ] ]
+    ]
+  },
+  {
+    "result": "survivor_pack_armored",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 5,
+    "skills_required": [ "fabrication", 4 ],
+    "time": "1 h 20 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 120 ] ],
+    "components": [
+      [ [ "kevlar_plate", 10 ] ],
+      [ [ "fabric_hides_proper", 10, "LIST" ] ],
+      [ [ "runner_bag", 4 ], [ "backpack", 2 ], [ "backpack_leather", 2 ], [ "mbag", 4 ] ],
+      [
+        [ "tacvest", 1 ],
+        [ "legrig", 1 ],
+        [ "vest", 1 ],
+        [ "tool_belt", 1 ],
+        [ "ragpouch", 3 ],
+        [ "leather_pouch", 2 ],
+        [ "dump_pouch", 1 ],
+        [ "purse", 2 ],
+        [ "fanny", 2 ]
+      ],
+      [ [ "duct_tape", 120 ] ]
+    ]
+  },
+  {
+    "result": "survivor_rucksack_armored",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 6,
+    "skills_required": [ "fabrication", 5 ],
+    "time": "1 h 30 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 160 ] ],
+    "components": [
+      [ [ "kevlar_plate", 14 ] ],
+      [ [ "fabric_hides_proper", 16, "LIST" ] ],
+      [ [ "backpack", 4 ], [ "backpack_leather", 4 ], [ "molle_pack", 2 ], [ "duffelbag", 1 ], [ "rucksack", 2 ] ],
+      [
+        [ "tacvest", 1 ],
+        [ "legrig", 1 ],
+        [ "vest", 1 ],
+        [ "tool_belt", 1 ],
+        [ "ragpouch", 3 ],
+        [ "leather_pouch", 2 ],
+        [ "dump_pouch", 1 ],
+        [ "purse", 2 ],
+        [ "fanny", 2 ]
+      ],
+      [ [ "duct_tape", 160 ] ]
+    ]
+  },
+  {
+    "result": "survivor_runner_pack_armored",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 4,
+    "skills_required": [ "fabrication", 3 ],
+    "time": "1 h 10 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 80 ] ],
+    "components": [
+      [ [ "kevlar_plate", 6 ] ],
+      [ [ "fabric_hides_proper", 8, "LIST" ] ],
+      [ [ "runner_bag", 2 ], [ "backpack", 1 ], [ "backpack_leather", 1 ], [ "mbag", 2 ] ],
+      [
+        [ "tacvest", 1 ],
+        [ "legrig", 1 ],
+        [ "vest", 1 ],
+        [ "tool_belt", 1 ],
+        [ "ragpouch", 3 ],
+        [ "leather_pouch", 2 ],
+        [ "dump_pouch", 1 ],
+        [ "purse", 2 ],
+        [ "fanny", 2 ]
+      ],
+      [ [ "duct_tape", 80 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Backpacks are worn on outermost layer and have decent coverage, which results in them getting hit often. Being made of cotton and leather they are easily damaged even by attacks that have no chance to damage the player character.

## Describe the solution (The How)

Add armored variants of survivor backpacks that are made of kevlar and leather. I considered increasing their weights but google told me that soft kevlar (as opposed to hard plates) has a bit lower density than cotton.

## Describe alternatives you've considered

Continue repairing backpacks after every fight.

## Testing

Tested as a mod. Getting backpacks damaged by melee is very rare. Being yeeted by aa brute and landing on pavement damages them sometimes. Being yeeted through a wall damages them most of time. Being shot by rifle calibers damages them most of time.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
