### PR TITLE
feat(UI): show terrain/furniture value as cover in "look around" menu

### DIFF
--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -242,16 +242,31 @@ std::string map_data_common_t::extended_description() const
 
     if( debug_vision() ) {
         ss << "Bash: " << bash.str_min << "-" << bash.str_max << "\n";
-        if( bash.ranged ) {
-            static std::string indent = "    ";
-            ss << "Ranged: " << "\n";
-            ss << indent << "Reduction:" << bash.ranged->reduction.min << "-" << bash.ranged->reduction.max;
-            if( bash.ranged->reduction_laser ) {
-                ss << indent << "Laser res:" << bash.ranged->reduction_laser->min << "-" <<
-                   bash.ranged->reduction_laser->max;
-            }
-            ss << indent << "Block unaimed chance: " << bash.ranged->block_unaimed_chance;
+    }
+
+    if( bash.ranged && bash.ranged->reduction.min > 0 ) {
+        static std::string indent = "    ";
+        ss << "\n" << "Cover:" << "\n";
+        if( bash.ranged->reduction.min == bash.ranged->reduction.max ) {
+            ss << indent << "Damage Reduction: " << bash.ranged->reduction.min << "\n";
+        } else {
+            ss << indent << "Damage Reduction: " << bash.ranged->reduction.min << "-" << bash.ranged->reduction.max << "\n";
         }
+        if( bash.ranged->reduction_laser ) {
+            if( bash.ranged->reduction_laser->min == bash.ranged->reduction_laser->max ) {
+                ss << indent << "Vs. Laser: " << bash.ranged->reduction_laser->min << "\n";
+            } else {
+                ss << indent << "Vs. Laser: " << bash.ranged->reduction_laser->min << "-" <<
+                   bash.ranged->reduction_laser->max << "\n";
+            }
+        }
+        if( debug_vision() && bash.ranged->destroy_threshold > 0 ) {
+            ss << indent << "Destroy Threshold: " << bash.ranged->destroy_threshold << "\n";
+        }
+        if( bash.ranged->block_unaimed_chance > 0_pct ) {
+            ss << indent << "Block Chance: " << bash.ranged->block_unaimed_chance / 1_pct << "%" << "\n";
+        }
+        ss << "\n";
     }
 
     if( !flags.empty() ) {

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -250,7 +250,8 @@ std::string map_data_common_t::extended_description() const
         if( bash.ranged->reduction.min == bash.ranged->reduction.max ) {
             ss << indent << "Damage Reduction: " << bash.ranged->reduction.min << "\n";
         } else {
-            ss << indent << "Damage Reduction: " << bash.ranged->reduction.min << "-" << bash.ranged->reduction.max << "\n";
+            ss << indent << "Damage Reduction: " << bash.ranged->reduction.min << "-" <<
+               bash.ranged->reduction.max << "\n";
         }
         if( bash.ranged->reduction_laser ) {
             if( bash.ranged->reduction_laser->min == bash.ranged->reduction_laser->max ) {


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

So, I found this little gem on examining terrain with `;` while debug mode was on:
<img width="485" height="159" alt="image" src="https://github.com/user-attachments/assets/38742275-ed94-418c-bb67-0c831e432d0b" />

I decided with some cleaning up, knowing how much cover terrain provides might be useful outside of debug.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In descriptions.cpp, tweaked `map_data_common_t::extended_description` so that ranged bash info isn't debug-only, and greatly cleaned up how it displays. Shows the damage reduction as either a single number or a range depending on if it varies, and shows block chance as an actual percentage instead of a `_pm` probability unit. Lastly, it also shows destroy threshold when debug mode is turned on, as for now I left "how high a roll to destroy" as debug info since that was the only other bash-related property left hidden in the UI. Gave it some newlines here and there to not be a giant mess as well.

## Describe alternatives you've considered

1. Un-debug'ing bash info and destroy threshold.
2. Not showing block chance if it's 100%.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Viewed some terrain to see what it looks like.

A wall, showing 100% block chance and varied damage reduction:
<img width="247" height="138" alt="image" src="https://github.com/user-attachments/assets/1f8742a5-2fc3-4cee-abd8-8b84ac4699b5" />

Same wall with debug mode on:
<img width="247" height="170" alt="image" src="https://github.com/user-attachments/assets/a8ff8e88-f3bc-46f6-969e-67d98f6524b1" />

A window, showing laser reduction in its cover info:
<img width="290" height="270" alt="image" src="https://github.com/user-attachments/assets/517fed6b-7f8d-4d86-9cbd-24f07501f421" />

A bench, showing fixed damage reduction and cover chance of 25% (will no longer show cover info after https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6857 is merged):
<img width="216" height="211" alt="image" src="https://github.com/user-attachments/assets/f7256509-f5c1-4423-aa92-2eb346f424cf" />

Locker, showing fixed damage reduction and 100% cover chance:
<img width="218" height="224" alt="image" src="https://github.com/user-attachments/assets/c49411bd-bca0-4a8d-a0da-b62afbf0bd44" />

Ol' Reliable, a sandbag barricade:
<img width="237" height="192" alt="image" src="https://github.com/user-attachments/assets/46359155-765a-4244-9b3b-9a842433175e" />

Open door, showing no cover info since it doesn't provide cover:
<img width="262" height="160" alt="image" src="https://github.com/user-attachments/assets/cca1ad31-33fe-4555-9e58-0da5b5f197b7" />

Canvas wall, showing no cover info because bullets go through with no damage reduction:
<img width="309" height="66" alt="image" src="https://github.com/user-attachments/assets/487b68b5-22fd-455a-83f2-b67a33cef926" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Odd thing tho: `if( bash.ranged->reduction_laser )` is perfectly valid but checking the existence of `bash.ranged->reduction` was erroring on me, so I had to check that min damage reduction was above zero to make sure it doesn't print the cover stats of canvas flaps or open doors that inherit from closed ones.

But then some terrain like floors would show a nonsensical number when examined, so the UI checks both that ranged bash info actually exists (avoid showing nonsense for floors) AND that damage reduction is actually above zero (avoid showing cover info for stuff that won't do anything useful when shot).

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
