### PR TITLE
fix: new turrents have corresponding broken item

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -3274,6 +3274,24 @@
   },
   {
     "type": "GENERIC",
+    "id": "broken_turret_antimateriel",
+    "symbol": ",",
+    "color": "green",
+    "name": { "str": "broken anti-materiel milspec turret" },
+    "weight": "80 kg",
+    "copy-from": "broken_turret"
+  },
+  {
+    "type": "GENERIC",
+    "id": "broken_turret_mark19",
+    "symbol": ",",
+    "color": "green",
+    "name": { "str": "broken grenade launcher milspec turret" },
+    "weight": "120 kg",
+    "copy-from": "broken_turret"
+  },
+  {
+    "type": "GENERIC",
     "id": "wool_pillow",
     "copy-from": "pillow",
     "looks_like": "pillow",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -4710,6 +4710,50 @@
     ]
   },
   {
+    "result": "broken_turret_antimateriel",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "difficulty": 4,
+    "time": "1 h",
+    "using": [ [ "soldering_standard", 10 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "m2browning", 1 ] ],
+      [ [ "small_storage_battery", 1 ] ],
+      [ [ "robot_controls", 1 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "turret_chassis", 1 ] ]
+    ]
+  },
+  {
+    "result": "broken_turret_mark19",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "difficulty": 4,
+    "time": "1 h",
+    "using": [ [ "soldering_standard", 10 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "mark19", 1 ] ],
+      [ [ "small_storage_battery", 1 ] ],
+      [ [ "robot_controls", 1 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "turret_chassis", 1 ] ]
+    ]
+  },
+  {
     "type": "uncraft",
     "result": "mp3",
     "skill_used": "electronics",


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Anti-materiel turret and grenade launcher turret would call for a broken_turret_antimateriel or a broken_turret_mark19, but neither of those items exist, nor is there an option to uncraft them

## Describe the solution (The How)

Add broken turret items and associated uncraft results for the above mentioned turrets.

## Describe alternatives you've considered


## Testing

Spawned in turrets
killed them, broken turrets produced
disassembled them, appropriate componants produced

## Additional context

Why are they so disproportionatly heavy?

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.