### PR TITLE
feat: Allow dash to cross gaps and traps safely

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -287,6 +287,15 @@
     "max_duration": "1 m"
   },
   {
+    "type": "effect_type",
+    "id": "dashing",
+    "name": [ "Dashing" ],
+    "desc": [
+      "Dummy tag for recognizing if a creature is currently using a dash spell effect.  If you see this lingering, that's a bug."
+    ],
+    "permanent": true
+  },
+  {
     "//": "ACTUAL PLAYER EFFECTS START HERE",
     "type": "effect_type",
     "id": "downed",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -241,6 +241,7 @@ static const efftype_id effect_riding( "riding" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_tied( "tied" );
+static const efftype_id dashing_effect("dashing");
 
 static const bionic_id bio_remote( "bio_remote" );
 static const bionic_id bio_probability_travel( "bio_probability_travel" );
@@ -8738,7 +8739,7 @@ bool game::prompt_dangerous_tile( const tripoint &dest_loc ) const
     static const iexamine_function ledge_examine = iexamine_function_from_string( "ledge" );
     std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
 
-    if( harmful_stuff.empty() ) {
+    if( harmful_stuff.empty() || u.has_effect(dashing_effect) ) {
         return true;
     }
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -58,6 +58,7 @@
 #include "vpart_position.h"
 
 static const ammo_effect_str_id ammo_effect_magic( "magic" );
+static const efftype_id dashing_effect("dashing");
 
 namespace spell_detail
 {
@@ -1276,6 +1277,8 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint &targ
     }
     // save the amount of moves the caster has so we can restore them after the dash
     const int cur_moves = caster.moves;
+    // add dash "effect" for detection
+    caster.add_effect(dashing_effect, 1_turns);
     while( walk_point != trajectory.end() ) {
         if( caster_you != nullptr ) {
             if( g->critter_at( here.getlocal( *walk_point ) ) ||
@@ -1294,4 +1297,6 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint &targ
         --walk_point;
     }
     caster.moves = cur_moves;
+    // remove dashing effect since dashing is over
+    caster.remove_effect(dashing_effect);
 }

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -26,6 +26,7 @@
 static const skill_id skill_traps( "traps" );
 
 static const efftype_id effect_lack_sleep( "lack_sleep" );
+static const efftype_id dashing_effect("dashing");
 
 static const trait_id trait_PROF_PD_DET( "PROF_PD_DET" );
 static const trait_id trait_PROF_POLICE( "PROF_POLICE" );
@@ -255,7 +256,7 @@ bool trap::can_see( const tripoint &pos, const Character &p ) const
 void trap::trigger( const tripoint &pos, Creature *creature, item *item ) const
 {
     const bool is_real_creature = creature != nullptr && !creature->is_hallucination();
-    if( is_real_creature || item != nullptr ) {
+    if( ( is_real_creature || item != nullptr ) && !creature->has_effect( dashing_effect ) ) {
         bool triggered = act( pos, creature, item );
         if( triggered && is_real_creature ) {
             if( Character *ch = creature->as_character() ) {


### PR DESCRIPTION
## Purpose of change (The Why)

RoyalFox and others would like a spell effect that can act as a "leap" of sorts and transport you across gaps without any of the teleporting through walls stuff.

Dash already let you do this, but it displayed the prompt about ledges for each open air tile you crossed and had some weird interactions with other traps and them activating if you didn't detect them first.

## Describe the solution (The How)

Dash spells now give you a temporary effect, and this effect is used by trap-related code to not prompt you or activate traps during the dash.

## Describe alternatives you've considered

- Make someone else do it
- Do it with Fake NPC states / Monster Flags or something instead of effects

Effects seemed like the path of least resistance and also seemed a bit more universal than flags.

## Testing

Compiled
- Dash spell crosses gaps between rooftops without prompting for ledges
- Dash spell crosses traps more uniformly now, also without prompting

Due to how I implemented it, you are now able to dash onto open air itself. This is fine, however, because you either fall down the next turn or move onto an adjacent tile that is solid ground. 
This also means you can dash right onto a landmine and not have it go off.

## Additional context

Wile E. Coyote can eat his heart out when he dashes onto open air.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

