### PR TITLE
feat: add clay standing tank from clay pots

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -5584,5 +5584,18 @@
     "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
     "pre_special": "check_empty",
     "post_furniture": "f_recycler"
+  },
+  {
+    "type": "construction",
+    "id": "constr_clay_pots",
+    "group": "place_clay_pots",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "1 m",
+    "components": [ [ [ "clay_watercont", 4 ] ] ],
+    "pre_note": "Can be deconstructed without tools.",
+    "pre_special": "check_empty",
+    "dark_craftable": true,
+    "post_furniture": "f_clay_storage"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1568,5 +1568,10 @@
     "type": "construction_group",
     "id": "install_f_recycler",
     "name": "Install Metal Compactor"
+  },
+  {
+    "type": "construction_group",
+    "id": "place_clay_pots",
+    "name": "Place Clay Pots"
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -1059,6 +1059,30 @@
   },
   {
     "type": "furniture",
+    "id": "f_clay_storage",
+    "looks_like": "f_standing_tank",
+    "name": "clay water pots",
+    "description": "Four large water pots together in a corner, holding up to 150 liters of a single type of liquid.  It is quite fragile but can be constructed and removed without tools.",
+    "symbol": "O",
+    "color": "light_gray",
+    "move_cost_mod": -1,
+    "coverage": 90,
+    "required_str": -1,
+    "flags": [ "BASHABLE", "CONTAINER", "EASY_DECONSTRUCT", "LIQUIDCONT", "NOITEM", "SEALED", "TRANSPARENT" ],
+    "deconstruct": { "items": [ { "item": "clay_watercont", "count": 4 } ] },
+    "examine_action": "keg",
+    "keg_capacity": 600,
+    "bash": {
+      "str_min": 10,
+      "str_max": 20,
+      "sound": "ceramic shattering!",
+      "sound_fail": "whunk!",
+      "items": [ { "item": "ceramic_shard", "count": [ 10, 40 ] } ],
+      "ranged": { "reduction": [ 10, 10 ], "destroy_threshold": 20, "block_unaimed_chance": "75%" }
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_dumpster",
     "name": "dumpster",
     "description": "Stores trash.  Doesn't get picked up anymore.  Note the smell.",


### PR DESCRIPTION
## Purpose of change (The Why)

Standing tanks and wooden kegs take a lot of metal for primitive players, sheet metal and nails for example. Clay pots are far easier to make.

## Describe the solution (The How)

Adds clay water pots, simple deconstructible and constructible from 4 pots. Has 150 liters storage which is equal to the four pots.

## Describe alternatives you've considered

None

## Testing

<img width="2049" height="1203" alt="image" src="https://github.com/user-attachments/assets/d782a303-6807-4744-8069-29b3be3ee27b" />


## Additional context
## Checklist
### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.