### PR TITLE
fix: move damage to top level to fix zombie child clothes

### DIFF
--- a/data/json/monsterdrops/zombie_child.json
+++ b/data/json/monsterdrops/zombie_child.json
@@ -33,12 +33,7 @@
         "distribution": [
           {
             "collection": [
-              {
-                "distribution": [
-                  { "group": "male_underwear", "prob": 90 },
-                  { "item": "union_suit", "prob": 10 }
-                ]
-              },
+              { "distribution": [ { "group": "male_underwear", "prob": 90 }, { "item": "union_suit", "prob": 10 } ] },
               {
                 "distribution": [
                   {
@@ -70,11 +65,7 @@
                       {
                         "distribution": [
                           {
-                            "distribution": [
-                              { "item": "stockings", "prob": 40 },
-                              { "item": "stockings_wool", "prob": 10 },
-                              { "item": "tights", "prob": 50 }
-                            ]
+                            "distribution": [ { "item": "stockings", "prob": 40 }, { "item": "stockings_wool", "prob": 10 }, { "item": "tights", "prob": 50 } ]
                           },
                           { "group": "socks_unisex", "prob": 50 }
                         ]
@@ -84,16 +75,10 @@
                   },
                   {
                     "collection": [
-                      {
-                        "distribution": [ { "item": "dress", "prob": 70 }, { "item": "sundress", "prob": 50 } ]
-                      },
+                      { "distribution": [ { "item": "dress", "prob": 70 }, { "item": "sundress", "prob": 50 } ] },
                       { "group": "dress_shoes", "prob": 30 },
                       {
-                        "distribution": [
-                          { "item": "stockings", "prob": 40 },
-                          { "item": "stockings_wool", "prob": 10 },
-                          { "item": "tights", "prob": 50 }
-                        ]
+                        "distribution": [ { "item": "stockings", "prob": 40 }, { "item": "stockings_wool", "prob": 10 }, { "item": "tights", "prob": 50 } ]
                       }
                     ],
                     "prob": 20

--- a/data/json/monsterdrops/zombie_child.json
+++ b/data/json/monsterdrops/zombie_child.json
@@ -5,7 +5,7 @@
     "//": "default zombie children clothing (always), additional items from child_items (sometimes)",
     "id": "default_zombie_children_death_drops",
     "entries": [
-      { "group": "default_zombie_children_clothes", "custom-flags": [ "UNDERSIZE" ] },
+      { "group": "default_zombie_children_clothes", "damage": [ 1, 4 ], "custom-flags": [ "UNDERSIZE" ] },
       { "group": "child_items", "prob": 65 }
     ]
   },
@@ -15,68 +15,68 @@
     "//": "contains cloth for an average zombie child",
     "id": "default_zombie_children_clothes",
     "entries": [
-      { "group": "coats_unisex", "damage": [ 1, 4 ], "prob": 20 },
-      { "group": "common_gloves", "damage": [ 1, 4 ], "prob": 20 },
-      { "group": "hatstore_hats", "damage": [ 1, 4 ], "prob": 20 },
-      { "group": "scarfs_unisex", "damage": [ 1, 4 ], "prob": 20 },
+      { "group": "coats_unisex", "prob": 20 },
+      { "group": "common_gloves", "prob": 20 },
+      { "group": "hatstore_hats", "prob": 20 },
+      { "group": "scarfs_unisex", "prob": 20 },
       {
         "distribution": [
-          { "item": "backpack", "damage": [ 1, 4 ], "prob": 50 },
-          { "item": "slingpack", "damage": [ 1, 4 ], "prob": 25 },
-          { "item": "travelpack", "damage": [ 1, 4 ], "prob": 20 },
-          { "item": "petpack", "damage": [ 1, 4 ], "prob": 5 }
+          { "item": "backpack", "prob": 50 },
+          { "item": "slingpack", "prob": 25 },
+          { "item": "travelpack", "prob": 20 },
+          { "item": "petpack", "prob": 5 }
         ],
         "prob": 25
       },
-      { "group": "accesories_personal_unisex_kids", "damage": [ 1, 4 ], "prob": 15, "count": 2 },
+      { "group": "accesories_personal_unisex_kids", "prob": 15, "count": 2 },
       {
         "distribution": [
           {
             "collection": [
               {
                 "distribution": [
-                  { "group": "male_underwear", "prob": 90, "damage": [ 1, 4 ] },
-                  { "item": "union_suit", "prob": 10, "damage": [ 1, 4 ] }
+                  { "group": "male_underwear", "prob": 90 },
+                  { "item": "union_suit", "prob": 10 }
                 ]
               },
               {
                 "distribution": [
                   {
                     "collection": [
-                      { "group": "pants_male", "prob": 60, "damage": [ 1, 4 ] },
-                      { "group": "shirts_unisex", "prob": 60, "damage": [ 1, 4 ] },
-                      { "item": "leather_belt", "prob": 30, "damage": [ 1, 4 ] }
+                      { "group": "pants_male", "prob": 60 },
+                      { "group": "shirts_unisex", "prob": 60 },
+                      { "item": "leather_belt", "prob": 30 }
                     ]
                   },
-                  { "item": "suit", "prob": 5, "damage": [ 1, 4 ] },
-                  { "item": "tux", "prob": 5, "damage": [ 1, 4 ] }
+                  { "item": "suit", "prob": 5 },
+                  { "item": "tux", "prob": 5 }
                 ]
               },
-              { "group": "neckties", "prob": 15, "damage": [ 1, 4 ] },
-              { "group": "shoes_unisex", "prob": 30, "damage": [ 1, 4 ] },
-              { "group": "socks_unisex", "damage": [ 1, 4 ], "prob": 50 }
+              { "group": "neckties", "prob": 15 },
+              { "group": "shoes_unisex", "prob": 30 },
+              { "group": "socks_unisex", "prob": 50 }
             ]
           },
           {
             "collection": [
-              { "group": "female_underwear", "prob": 90, "damage": [ 1, 4 ] },
+              { "group": "female_underwear", "prob": 90 },
               {
                 "distribution": [
                   {
                     "collection": [
-                      { "group": "pants_female", "prob": 60, "damage": [ 1, 4 ] },
-                      { "group": "shoes_unisex", "prob": 30, "damage": [ 1, 4 ] },
-                      { "group": "shirts_unisex", "prob": 60, "damage": [ 1, 4 ] },
+                      { "group": "pants_female", "prob": 60 },
+                      { "group": "shoes_unisex", "prob": 30 },
+                      { "group": "shirts_unisex", "prob": 60 },
                       {
                         "distribution": [
                           {
                             "distribution": [
-                              { "item": "stockings", "prob": 40, "damage": [ 1, 4 ] },
-                              { "item": "stockings_wool", "prob": 10, "damage": [ 1, 4 ] },
-                              { "item": "tights", "prob": 50, "damage": [ 1, 4 ] }
+                              { "item": "stockings", "prob": 40 },
+                              { "item": "stockings_wool", "prob": 10 },
+                              { "item": "tights", "prob": 50 }
                             ]
                           },
-                          { "group": "socks_unisex", "prob": 50, "damage": [ 1, 4 ] }
+                          { "group": "socks_unisex", "prob": 50 }
                         ]
                       }
                     ],
@@ -85,14 +85,14 @@
                   {
                     "collection": [
                       {
-                        "distribution": [ { "item": "dress", "prob": 70, "damage": [ 1, 4 ] }, { "item": "sundress", "prob": 50, "damage": [ 1, 4 ] } ]
+                        "distribution": [ { "item": "dress", "prob": 70 }, { "item": "sundress", "prob": 50 } ]
                       },
-                      { "group": "dress_shoes", "prob": 30, "damage": [ 1, 4 ] },
+                      { "group": "dress_shoes", "prob": 30 },
                       {
                         "distribution": [
-                          { "item": "stockings", "prob": 40, "damage": [ 1, 4 ] },
-                          { "item": "stockings_wool", "prob": 10, "damage": [ 1, 4 ] },
-                          { "item": "tights", "prob": 50, "damage": [ 1, 4 ] }
+                          { "item": "stockings", "prob": 40 },
+                          { "item": "stockings_wool", "prob": 10 },
+                          { "item": "tights", "prob": 50 }
                         ]
                       }
                     ],


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

I did a dumb and accidentally borked zombie children spawning with random damage on their clothes.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Moved use of `damage` from `default_zombie_children_clothes` to `default_zombie_children_death_drops`.

## Describe alternatives you've considered

Screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

<img width="1139" height="841" alt="image" src="https://github.com/user-attachments/assets/d790f300-6a22-4b24-8a71-d87517b0207c" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
