### PR TITLE
fix: make crafting inside a vehicle with a butchery station not crash

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5364,7 +5364,7 @@ std::vector<detached_ptr<item>> map::use_charges( const tripoint &origin, const 
 
             // TODO: add a sane birthday arg
             detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
-            tmp->charges = forgepart->vehicle().drain( ftype, quantity );
+            tmp->charges = butcherpart->vehicle().drain( ftype, quantity );
             quantity -= tmp->charges;
             ret.push_back( std::move( tmp ) );
 


### PR DESCRIPTION
## Purpose of change (The Why)

Caught a SIGSEGV while trying to craft something from within a vehicle with a butchery station installed. Poking around with a debugger pointed me to this possible copy-pasted line.

## Describe the solution (The How)

Use correct pointer.

## Describe alternatives you've considered

None, hard crashes always point to a bug.

## Testing

Same crafting recipe in the same world started working flawlessly after applying this.

## Additional context

Skipped astyle/formatting, a this is a trivial one-word diff.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
