### PR TITLE
fix: fix #6770 being reverted by #6787

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1583,7 +1583,10 @@ void Creature::process_effects()
             }
             // Add any effects that others remove to the removal list
             for( const efftype_id &removed_effect : _it.second.get_removes_effects() ) {
-                to_remove.emplace_back( removed_effect, bodypart_str_id::NULL_ID(), false );
+                // Don't try to remove it if it isn't present
+                if( has_effect( removed_effect ) ) {
+                    to_remove.emplace_back( removed_effect, bodypart_str_id::NULL_ID(), false );
+                }
             }
             effect &e = _it.second;
             const int prev_int = e.get_intensity();
@@ -1618,7 +1621,8 @@ void Creature::process_effects()
             }
 
             if( !found ) {
-                debugmsg( "Couldn't find effect to remove %s", r.type.str() );
+                // Effect somehow went missing between previous loop and now
+                debugmsg( "Couldn't find effect assigned to be removed %s", r.type.str() );
             }
         }
 


### PR DESCRIPTION
## Purpose of change (The Why)

#6787 accidentally reverted #6770 entirely.

## Describe the solution (The How)

Re-do the changes from #6770

## Describe alternatives you've considered

- Make Retagin do it to atone

## Testing

Absolutely zero, this code worked before it should work again. (Royalfox is better equipped to test anyway)

## Additional context

Gotta love when git / github accidentally does a fucky and causes accidental reverts like this.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

