### PR TITLE
feat(UI, balance): Change self-aware effects to an option in the settings

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -468,17 +468,6 @@
   },
   {
     "type": "mutation",
-    "id": "SELFAWARE",
-    "name": { "str": "Self-Aware" },
-    "points": 1,
-    "description": "You get to see your exact amount of HP remaining and health, instead of only having a vague idea of whether you're in good condition or not.",
-    "starting_trait": true,
-    "valid": false,
-    "active": true,
-    "category": [ "MEDICAL" ]
-  },
-  {
-    "type": "mutation",
     "id": "MASOCHIST",
     "name": { "str": "Masochist" },
     "points": 1,

--- a/data/json/obsoletion/mutations.json
+++ b/data/json/obsoletion/mutations.json
@@ -238,5 +238,14 @@
     "points": 2,
     "description": "Obsoleted due to becoming default behavior.",
     "valid": false
+  },
+  {
+    "type": "mutation",
+    "id": "SELFAWARE",
+    "name": { "str": "Self-Aware" },
+    "points": 1,
+    "description": "This mutation is now just an option in the settings.",
+    "valid": false,
+    "active": true
   }
 ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4699,7 +4699,7 @@ void Character::print_health() const
         return;
     }
     int current_health = get_healthy();
-    if( get_option<std::string>("HEALTH_STYLE") == "number" ) {
+    if( get_option<std::string>( "HEALTH_STYLE" ) == "number" ) {
         add_msg_if_player( _( "Your current health value is %d." ), current_health );
     }
 
@@ -4887,7 +4887,7 @@ std::pair<std::string, nc_color> Character::get_hunger_description() const
         hunger_color = c_red;
     }
 
-    if( get_option<std::string>("HEALTH_STYLE") == "number" ) {
+    if( get_option<std::string>( "HEALTH_STYLE" ) == "number" ) {
         hunger_string = string_format( "%d kcal", total_kcal );
     }
 
@@ -4975,7 +4975,7 @@ std::pair<std::string, nc_color> Character::get_pain_description() const
         pain_color = c_light_red;
     }
     // get pain string
-    if( ( get_option<std::string>("HEALTH_STYLE") == "number" || has_effect( effect_got_checked ) ) &&
+    if( ( get_option<std::string>( "HEALTH_STYLE" ) == "number" || has_effect( effect_got_checked ) ) &&
         get_perceived_pain() > 0 ) {
         pain_string = string_format( "%s %d", _( "Pain " ), get_perceived_pain() );
     } else if( get_perceived_pain() > 0 ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -329,7 +329,6 @@ static const trait_id trait_ROOTS2( "ROOTS2" );
 static const trait_id trait_ROOTS3( "ROOTS3" );
 static const trait_id trait_SAVANT( "SAVANT" );
 static const trait_id trait_SEESLEEP( "SEESLEEP" );
-static const trait_id trait_SELFAWARE( "SELFAWARE" );
 static const trait_id trait_SHELL( "SHELL" );
 static const trait_id trait_SHELL2( "SHELL2" );
 static const trait_id trait_SHOUT2( "SHOUT2" );
@@ -4700,7 +4699,7 @@ void Character::print_health() const
         return;
     }
     int current_health = get_healthy();
-    if( has_trait( trait_SELFAWARE ) ) {
+    if( get_option<std::string>("HEALTH_STYLE") == "number" ) {
         add_msg_if_player( _( "Your current health value is %d." ), current_health );
     }
 
@@ -4888,7 +4887,7 @@ std::pair<std::string, nc_color> Character::get_hunger_description() const
         hunger_color = c_red;
     }
 
-    if( has_trait( trait_SELFAWARE ) ) {
+    if( get_option<std::string>("HEALTH_STYLE") == "number" ) {
         hunger_string = string_format( "%d kcal", total_kcal );
     }
 
@@ -4976,7 +4975,7 @@ std::pair<std::string, nc_color> Character::get_pain_description() const
         pain_color = c_light_red;
     }
     // get pain string
-    if( ( has_trait( trait_SELFAWARE ) || has_effect( effect_got_checked ) ) &&
+    if( ( get_option<std::string>("HEALTH_STYLE") == "number" || has_effect( effect_got_checked ) ) &&
         get_perceived_pain() > 0 ) {
         pain_string = string_format( "%s %d", _( "Pain " ), get_perceived_pain() );
     } else if( get_perceived_pain() > 0 ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -151,7 +151,6 @@ static const trait_id trait_MASOCHIST( "MASOCHIST" );
 static const trait_id trait_MASOCHIST_MED( "MASOCHIST_MED" );
 static const trait_id trait_MUT_JUNKIE( "MUT_JUNKIE" );
 static const trait_id trait_SAPIOVORE( "SAPIOVORE" );
-static const trait_id trait_SELFAWARE( "SELFAWARE" );
 
 static const trait_flag_str_id trait_flag_PRED1( "PRED1" );
 static const trait_flag_str_id trait_flag_PRED2( "PRED2" );
@@ -3866,12 +3865,10 @@ static bodypart_str_id pick_part_to_heal(
     const bool bleed = bleed_chance > 0.0f;
     const bool bite = bite_chance > 0.0f;
     const bool infect = infect_chance > 0.0f;
-    const bool precise = &healer == &patient ?
-                         patient.has_trait( trait_SELFAWARE ) :
-                         /** @EFFECT_PER slightly increases precision when using first aid on someone else */
+    /** @EFFECT_PER slightly increases precision when using first aid */
+    /** @EFFECT_FIRSTAID increases precision when using first aid */
+    const bool precise = ( healer.get_skill_level( skill_firstaid ) * 4 + healer.per_cur >= 20 );
 
-                         /** @EFFECT_FIRSTAID increases precision when using first aid on someone else */
-                         ( healer.get_skill_level( skill_firstaid ) * 4 + healer.per_cur >= 20 );
     while( true ) {
         bodypart_str_id healed_part = patient.body_window( menu_header, force, precise,
                                       limb_power, head_bonus, torso_bonus,

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -68,7 +68,6 @@ static const trait_id trait_PER_ALPHA( "PER_ALPHA" );
 static const trait_id trait_ROBUST( "ROBUST" );
 static const trait_id trait_ROOTS2( "ROOTS2" );
 static const trait_id trait_ROOTS3( "ROOTS3" );
-static const trait_id trait_SELFAWARE( "SELFAWARE" );
 static const trait_id trait_SLIMESPAWNER( "SLIMESPAWNER" );
 static const trait_id trait_STR_ALPHA( "STR_ALPHA" );
 static const trait_id trait_THRESH_MARLOSS( "THRESH_MARLOSS" );
@@ -541,10 +540,6 @@ void Character::activate_mutation( const trait_id &mut )
     } else if( mut == trait_M_PROVENANCE ) {
         spores(); // double trouble!
         blossoms();
-        tdata.powered = false;
-        return;
-    } else if( mut == trait_SELFAWARE ) {
-        print_health();
         tdata.powered = false;
         return;
     } else if( mut == trait_TREE_COMMUNION ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1550,11 +1550,11 @@ void options_manager::add_options_interface()
 
     add_empty_line();
 
-    add("HEALTH_STYLE", interface, translate_marker("Health Display Style"),
-         translate_marker("Switch health-related display styling such as HP and hunger"), 
-         {{ "number", translate_marker("Numerical")}, {"bar", translate_marker("Bar")}},
-          "bar");
-    
+    add( "HEALTH_STYLE", interface, translate_marker( "Health Display Style" ),
+         translate_marker( "Switch health-related display styling such as HP and hunger" ),
+    {{ "number", translate_marker( "Numerical" )}, {"bar", translate_marker( "Bar" )}},
+    "bar" );
+
     add_empty_line();
 
     add( "WIKI_DOC_URL", interface, translate_marker( "Wiki URL" ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1550,6 +1550,12 @@ void options_manager::add_options_interface()
 
     add_empty_line();
 
+    add("HEALTH_STYLE", interface, translate_marker("Health Display Style"),
+         translate_marker("Switch health-related display styling such as HP and hunger"), 
+         {{ "number", translate_marker("Numerical")}, {"bar", translate_marker("Bar")}},
+          "bar");
+    
+    add_empty_line();
 
     add( "WIKI_DOC_URL", interface, translate_marker( "Wiki URL" ),
          translate_marker( "The URL opened by pressing the open wiki keybind." ),

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -61,7 +61,6 @@
 #include "vpart_position.h"
 #include "weather.h"
 
-static const trait_id trait_SELFAWARE( "SELFAWARE" );
 static const trait_id trait_THRESH_FELINE( "THRESH_FELINE" );
 static const trait_id trait_THRESH_BIRD( "THRESH_BIRD" );
 static const trait_id trait_THRESH_URSINE( "THRESH_URSINE" );
@@ -770,7 +769,7 @@ static int get_int_digits( const int &digits )
 
 static void draw_limb_health( avatar &u, const catacurses::window &w, const bodypart_str_id &bp )
 {
-    const bool is_self_aware = u.has_trait( trait_SELFAWARE );
+    const std::string display_type = get_option<std::string>("HEALTH_STYLE");
     static auto print_symbol_num = []( const catacurses::window & w, int num, const std::string & sym,
     const nc_color & color ) {
         while( num-- > 0 ) {
@@ -790,7 +789,7 @@ static void draw_limb_health( avatar &u, const catacurses::window &w, const body
                         ( u.mutation_value( "mending_modifier" ) >= 1.0f );
         nc_color color = splinted ? c_blue : c_dark_gray;
 
-        if( is_self_aware || u.has_effect( effect_got_checked ) ) {
+        if( display_type == "number" || u.has_effect( effect_got_checked ) ) {
             color_override = color;
         } else {
             const int num = mend_perc / 20;
@@ -806,7 +805,7 @@ static void draw_limb_health( avatar &u, const catacurses::window &w, const body
         hp.second = *color_override;
     }
 
-    if( is_self_aware || u.has_effect( effect_got_checked ) ) {
+    if( display_type == "number" || u.has_effect( effect_got_checked ) ) {
         wprintz( w, hp.second, "%3d  ", hp_cur );
     } else {
         wprintz( w, hp.second, hp.first );

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -769,7 +769,7 @@ static int get_int_digits( const int &digits )
 
 static void draw_limb_health( avatar &u, const catacurses::window &w, const bodypart_str_id &bp )
 {
-    const std::string display_type = get_option<std::string>("HEALTH_STYLE");
+    const std::string display_type = get_option<std::string>( "HEALTH_STYLE" );
     static auto print_symbol_num = []( const catacurses::window & w, int num, const std::string & sym,
     const nc_color & color ) {
         while( num-- > 0 ) {


### PR DESCRIPTION
## Purpose of change (The Why)

This is a useful QoL but does not *really* justify being a trait at chargen. Plus, this was brought up as another desired change around the time of Stylish's changes.

## Describe the solution (The How)

- Add a new option to the settings menu: Health Display Style.
- Changes most checks of Self-Aware to instead check for the setting in the options
- Made the first aid bit just use the first aid and perception.

## Describe alternatives you've considered

- Going the complete Stylish route of making an inverse trait instead

There are pros and cons to both styles of Health Information display, so being able to freely change between it seems good.

## Testing

It compiles, and it correctly displays HP and Hunger in-game.

## Additional context

Now HP math is able to be done a hell of a lot easier

Perhaps we can also change the stamina display to do something similar in the future, and also maybe add more numerical displays in general.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a PR that removes JSON entities.
  - [x] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
