### PR TITLE
feat(balance): increase yield of removing grass to match cutting grass

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -3568,7 +3568,7 @@
     "required_skills": [ [ "survival", 0 ] ],
     "time": "6 m",
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
-    "byproducts": [ { "item": "straw_pile", "count": [ 0, 1 ] } ],
+    "byproducts": [ { "item": "straw_pile" } ],
     "pre_terrain": "t_grass",
     "post_terrain": "t_dirt"
   },
@@ -3580,7 +3580,7 @@
     "required_skills": [ [ "survival", 0 ] ],
     "time": "6 m",
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
-    "byproducts": [ { "item": "straw_pile" } ],
+    "byproducts": [ { "item": "straw_pile", "count": 2 } ],
     "pre_terrain": "t_grass_long",
     "post_terrain": "t_dirt"
   },
@@ -3592,7 +3592,7 @@
     "required_skills": [ [ "survival", 0 ] ],
     "time": "6 m",
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
-    "byproducts": [ { "item": "straw_pile", "count": [ 1, 2 ] } ],
+    "byproducts": [ { "item": "straw_pile", "count": [ 2, 3 ] } ],
     "pre_terrain": "t_grass_tall",
     "post_terrain": "t_dirt"
   },
@@ -3604,7 +3604,7 @@
     "required_skills": [ [ "survival", 0 ] ],
     "time": "6 m",
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
-    "byproducts": [ { "item": "straw_pile", "count": [ 0, 1 ] } ],
+    "byproducts": [ { "item": "straw_pile" } ],
     "pre_terrain": "t_grass_dead",
     "post_terrain": "t_dirt"
   },


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Digging up grass for material can be a pain at times, and is a bit inconsistent in that cutting long grass into regular grass and then digging up the grass yields 1-2 straw, while removing long grass entirely only yielded 1 straw. Likewise cutting tall grass and then digging it up afterward would give 1-3 grass total while digging it up directly only gave 1-2. And of course, a good chunk of that grass will give nothing half the time...

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Made it so that digging up regular and dead grass always yields 1 straw pile, instead of sometimes yielding nothing.
2. Bumped up the yield from digging up long and tall grass accordingly to yield exactly 2 and 2-3 respectively, so that digging them up will yield the same amounts as cutting the grass then digging it up would (1 + 1 for long grass, 1-2 + 1 for tall grass).

## Describe alternatives you've considered

Removing cutting grass for being largely decorative and rebalancing straw yield of grass removal without having to deal with existing grass-cutting yields, or conversely tweaking how much they give to not be 100% for long grass since it's not the main method of harvesting straw but more for aesthetics.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1.Checked affected file for syntax and lint errors.
2. Did the math :<

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
