### PR TITLE
feat(UI): add XP progress reporting to studying magic

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4500,6 +4500,11 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
 
 void activity_handlers::study_spell_do_turn( player_activity *act, player *p )
 {
+    // moves_left decreases by player speed each turn and thus is a pain to work with
+    // But we want a persistent value
+    if (act->values.size() < 4) {
+        act->values.push_back(0);
+    }   
     if( !character_funcs::can_see_fine_details( *p ) ) {
         act->values[2] = -1;
         act->moves_left = 0;
@@ -4512,6 +4517,18 @@ void activity_handlers::study_spell_do_turn( player_activity *act, player *p )
 
         act->values[0] += xp;
         studying.gain_exp( xp );
+
+        // This should trigger infrequently
+        if (act->values[3] % 600 == 599) {
+            // if we are at the first run through, we need to set spot 3 as 0.
+            if (act->values.size() < 5) {
+                act->values.push_back(0);
+            }
+            p->add_msg_if_player(m_good, _("You gained %i experience in %s"), act->values[0] - act->values[4], studying.name());
+            // This way we only display the difference
+            act->values[4] = act->values[0];
+        }
+        
         // Every time we use get_level the level is recalculated, this is suboptimal, so we remember it here.
         const int new_level = studying.get_level();
 
@@ -4525,6 +4542,8 @@ void activity_handlers::study_spell_do_turn( player_activity *act, player *p )
             act->moves_left = 1000000;
         }
     }
+    // increment
+    act->values[3] += 1;
 }
 
 void activity_handlers::study_spell_finish( player_activity *act, player *p )

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4502,9 +4502,9 @@ void activity_handlers::study_spell_do_turn( player_activity *act, player *p )
 {
     // moves_left decreases by player speed each turn and thus is a pain to work with
     // But we want a persistent value
-    if (act->values.size() < 4) {
-        act->values.push_back(0);
-    }   
+    if( act->values.size() < 4 ) {
+        act->values.push_back( 0 );
+    }
     if( !character_funcs::can_see_fine_details( *p ) ) {
         act->values[2] = -1;
         act->moves_left = 0;
@@ -4519,16 +4519,17 @@ void activity_handlers::study_spell_do_turn( player_activity *act, player *p )
         studying.gain_exp( xp );
 
         // This should trigger infrequently
-        if (act->values[3] % 600 == 599) {
+        if( act->values[3] % 600 == 599 ) {
             // if we are at the first run through, we need to set spot 3 as 0.
-            if (act->values.size() < 5) {
-                act->values.push_back(0);
+            if( act->values.size() < 5 ) {
+                act->values.push_back( 0 );
             }
-            p->add_msg_if_player(m_good, _("You gained %i experience in %s"), act->values[0] - act->values[4], studying.name());
+            p->add_msg_if_player( m_good, _( "You gained %i experience in %s" ),
+                                  act->values[0] - act->values[4], studying.name() );
             // This way we only display the difference
             act->values[4] = act->values[0];
         }
-        
+
         // Every time we use get_level the level is recalculated, this is suboptimal, so we remember it here.
         const int new_level = studying.get_level();
 


### PR DESCRIPTION
## Purpose of change (The Why)

It was brought up to me that, when stopping part-way-through a study session, the XP is not properly communicated to the player. Additionally, it looks to the player that all the XP is gained at the very end rather than progressively throughout.

## Describe the solution (The How)

Makes the game report the XP you've gained every 10 minutes

In particular, reports the amount of XP you've gained *since* 10 minutes ago.

## Describe alternatives you've considered

- Report every minute instead

## Testing

It compiles and works for me

## Additional context

I have not actually tested if the push_backs of the values vector are necessary. I figured it would be good to have them there just in case.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

