### PR TITLE
feat(balance): remove `NO_PENETRATE_OBSTACLES` from throwing weapons and other bashing ammo

### DIFF
--- a/data/json/items/ammo/20x66mm.json
+++ b/data/json/items/ammo/20x66mm.json
@@ -10,7 +10,7 @@
     "count": 10,
     "damage": { "damage_type": "bash", "amount": 6 },
     "proportional": { "recoil": 0.4, "loudness": 0.6 },
-    "extend": { "effects": [ "LARGE_BEANBAG", "NOGIB", "NO_PENETRATE_OBSTACLES" ] }
+    "extend": { "effects": [ "LARGE_BEANBAG", "NOGIB" ] }
   },
   {
     "id": "20x66_flechette_reloaded",

--- a/data/json/items/ammo/40x46mm.json
+++ b/data/json/items/ammo/40x46mm.json
@@ -30,7 +30,7 @@
     "damage": { "damage_type": "bash", "amount": 20 },
     "casing": "40x46mm_m212_casing",
     "loudness": 80,
-    "extend": { "effects": [ "LARGE_BEANBAG", "NO_PENETRATE_OBSTACLES" ] }
+    "extend": { "effects": [ "LARGE_BEANBAG" ] }
   },
   {
     "id": "40x46mm_m433",

--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -110,7 +110,7 @@
     "count": 10,
     "damage": { "damage_type": "bash", "amount": 5 },
     "proportional": { "recoil": 0.4, "loudness": 0.6 },
-    "extend": { "effects": [ "BEANBAG", "NOGIB", "NO_PENETRATE_OBSTACLES" ] }
+    "extend": { "effects": [ "BEANBAG", "NOGIB" ] }
   },
   {
     "id": "shot_bird",

--- a/data/json/items/classes/range.json
+++ b/data/json/items/classes/range.json
@@ -77,7 +77,6 @@
     "name": { "str": "base slingshot" },
     "skill": "archery",
     "ammo": "pebble",
-    "ammo_effects": [ "NO_PENETRATE_OBSTACLES" ],
     "extend": { "flags": [ "BELT_CLIP" ] }
   },
   {
@@ -86,7 +85,6 @@
     "type": "GUN",
     "weapon_category": [ "SLINGS" ],
     "name": { "str": "base sling" },
-    "skill": "throw",
-    "ammo_effects": [ "NO_PENETRATE_OBSTACLES" ]
+    "skill": "throw"
   }
 ]

--- a/data/json/items/gun/monster_gun.json
+++ b/data/json/items/gun/monster_gun.json
@@ -54,7 +54,7 @@
     ],
     "skill": "throw",
     "ammo": [ "rock" ],
-    "ammo_effects": [ "NO_PENETRATE_OBSTACLES", "NEVER_MISFIRES" ],
+    "ammo_effects": [ "NEVER_MISFIRES" ],
     "clip_size": 1,
     "ranged_damage": { "damage_type": "bash", "amount": -1 },
     "weight": "540 g",

--- a/data/json/items/ranged/archery.json
+++ b/data/json/items/ranged/archery.json
@@ -82,7 +82,7 @@
     "loudness": 0,
     "count": 10,
     "dont_recover_one_in": 10,
-    "effects": [ "NOGIB", "NO_PENETRATE_OBSTACLES" ]
+    "effects": [ "NOGIB" ]
   },
   {
     "type": "AMMO",
@@ -146,7 +146,7 @@
     "loudness": 0,
     "count": 10,
     "dont_recover_one_in": 35,
-    "effects": [ "NOGIB", "NO_PENETRATE_OBSTACLES" ]
+    "effects": [ "NOGIB" ]
   },
   {
     "type": "AMMO",
@@ -315,7 +315,7 @@
     "loudness": 0,
     "count": 10,
     "dont_recover_one_in": 45,
-    "effects": [ "NOGIB", "NO_PENETRATE_OBSTACLES" ]
+    "effects": [ "NOGIB" ]
   },
   {
     "type": "AMMO",

--- a/data/json/items/ranged/crossbows.json
+++ b/data/json/items/ranged/crossbows.json
@@ -58,7 +58,7 @@
     "loudness": 0,
     "count": 10,
     "dont_recover_one_in": 10,
-    "effects": [ "NOGIB", "NO_PENETRATE_OBSTACLES" ]
+    "effects": [ "NOGIB" ]
   },
   {
     "type": "AMMO",
@@ -140,7 +140,7 @@
     "loudness": 0,
     "count": 10,
     "dont_recover_one_in": 35,
-    "effects": [ "NOGIB", "NO_PENETRATE_OBSTACLES" ]
+    "effects": [ "NOGIB" ]
   },
   {
     "type": "AMMO",
@@ -281,7 +281,7 @@
     "loudness": 0,
     "count": 10,
     "dont_recover_one_in": 45,
-    "effects": [ "NOGIB", "NO_PENETRATE_OBSTACLES" ]
+    "effects": [ "NOGIB" ]
   },
   {
     "type": "AMMO",

--- a/data/mods/Aftershock/items/gun/advanced.json
+++ b/data/mods/Aftershock/items/gun/advanced.json
@@ -22,7 +22,7 @@
     "name": "integral plasma ejector",
     "skill": "rifle",
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "2 rd.", 2 ] ],
-    "ammo_effects": [ "PLASMA", "EXPLOSIVE", "STREAM_BIG", "WIDE", "FLAME" ]
+    "ammo_effects": [ "PLASMA", "EXPLOSIVE", "STREAM_BIG", "WIDE", "FLAME", "NO_PENETRATE_OBSTACLES" ]
   },
   {
     "id": "railgun",

--- a/data/mods/CRT_EXPANSION/items/crt_gun.json
+++ b/data/mods/CRT_EXPANSION/items/crt_gun.json
@@ -278,7 +278,7 @@
     "clip_size": 25,
     "reload": 200,
     "valid_mod_locations": [ [ "accessories", 1 ], [ "grip", 1 ], [ "sights", 1 ] ],
-    "ammo_effects": [ "FRAG" ],
+    "ammo_effects": [ "FRAG", "NO_PENETRATE_OBSTACLES" ],
     "flags": [ "NEVER_JAMS" ]
   },
   {

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -75,7 +75,7 @@
     "durability": 10,
     "loudness": 50,
     "reload": 0,
-    "ammo_effects": [ "PLASMA", "EXPLOSIVE_HUGE", "STREAM_BIG", "INCENDIARY", "WIDE" ],
+    "ammo_effects": [ "PLASMA", "EXPLOSIVE_HUGE", "STREAM_BIG", "INCENDIARY", "WIDE", "NO_PENETRATE_OBSTACLES" ],
     "flags": [ "NEVER_JAMS", "NO_UNLOAD", "TRADER_AVOID", "PYROMANIAC_WEAPON" ]
   },
   {


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Belated followup to `NO_PENETRATE_OBSTACLES` updates.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Decided to walk back the application of `NO_PENETRATE_OBSTACLES` on slings and other weapons/ammo that deal bashing damage, in turn removing it from feral thrown rocks. Main reasons are twofold:
1. Powerful pebble/rock weapons like the slingshot cannon and pneumatic assault rifle could resonably make sense punching holes in cover, so might as well leave it up to the whims of if it has the damage to keep going.
2. Hand-thrown objects can still punch through cover just fine if strong enough, and it's inconsistent that a sling can't punch through cover while a thrown rock can. We could make it so thrown weapons also can't punch through cover, but on the other hand enough strength should allow it plus javelins and the like probably should punch through more easily.

Also updated mods, adding the flag to relevant items.

## Describe alternatives you've considered

Making it so thrown items also get excluded from overpenetration unless they either don't deal bashing damage or deal more than a given amount of bashing damage? Feels overall more complicated, weh.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task doc` so the Lua API documentation is updated.
-->
