### PR TITLE
feat(balance): Remove pit-digging from log walls

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -502,7 +502,7 @@
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "24 m",
     "//2": "Added sawing quality since likely splitting the log in half.",
-    "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "AXE", "level": 2 }, { "id": "SAW_W", "level": 2 } ] ],
+    "qualities": [ [ { "id": "AXE", "level": 2 }, { "id": "SAW_W", "level": 2 } ] ],
     "components": [ [ [ "log", 1 ] ], [ [ "wood_structural_small", 2, "LIST" ] ] ],
     "pre_terrain": "t_wall_log_half",
     "post_terrain": "t_fortification_log"
@@ -1233,9 +1233,7 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "45 m",
-    "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
     "components": [ [ [ "log", 2 ] ], [ [ "wood_structural_small", 3, "LIST" ] ] ],
-    "pre_flags": "PIT_SHALLOW",
     "post_terrain": "t_wall_log_half"
   },
   {
@@ -1244,8 +1242,7 @@
     "copy-from": "constr_wall_log_half",
     "//": "Step 2: Finish the log wall",
     "pre_terrain": "t_wall_log_half",
-    "post_terrain": "t_wall_log",
-    "delete": { "pre_flags": "PIT_SHALLOW" }
+    "post_terrain": "t_wall_log"
   },
   {
     "type": "construction",

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1234,6 +1234,7 @@
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "45 m",
     "components": [ [ [ "log", 2 ] ], [ [ "wood_structural_small", 3, "LIST" ] ] ],
+    "pre_special": "check_empty",
     "post_terrain": "t_wall_log_half"
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

The requirement for a pit made it impossible to construct multi-story log houses in-game.

This is not realistic, as there are many multi-story log houses irl.

Overall, the restriction made no sense and hampered player building for no good reason.

## Describe the solution (The How)

Removes the pit requirement, as well as the digging requirement, from the half-built log walls. Also removes relevant bits from the "fortifications" and the flag deletion from the full log wall.

## Describe alternatives you've considered

- Add some sort of special exception to allow stacking log walls on top of each other but not allow constructing them on other wall types.

## Testing

Simple JSON change, just made sure it lints and makes sense.

## Additional context

<img width="250" height="188" alt="image" src="https://github.com/user-attachments/assets/942da3ae-b927-4a4f-a753-2f6b638fee32" />

Continuing to make player constructions suck less


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
