### PR TITLE
fix(mods/MagicalNights, balance): fix translocate self not getting intelligence scaling

### DIFF
--- a/data/mods/MagicalNights/Spells/classless.json
+++ b/data/mods/MagicalNights/Spells/classless.json
@@ -214,6 +214,7 @@
     "description": "Translocates the user to an attuned gate.",
     "valid_targets": [ "self" ],
     "effect": "translocate",
+    "scale_int": true,
     "difficulty": 15,
     "max_level": 35,
     "base_casting_time": 6000,


### PR DESCRIPTION
## Purpose of change (The Why)

I missed it in my lazy regex'ing in the previous PR.

It has plenty of difficulty already, it doesn't need more.

## Describe the solution (The How)

add scale_int

## Describe alternatives you've considered

- Die

## Testing

None, other than that it lints (and I looked over the other spells in the same file to make sure I wasn't missing any others)

## Additional context

I still stand by my decision from the PR I introduced scaling in.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
