### PR TITLE
style: use oneline style for Lua bindings

### DIFF
--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -242,9 +242,8 @@ void cata::detail::reg_item( sol::state &lua )
 
         luna::set_fx( ut, "get_type", &item::typeId );
         DOC( "Almost for a corpse." );
-        luna::set_fx( ut, "get_mtype", []( const item & it ) {
-            return it.get_mtype() ? it.get_mtype()->id : mtype_id::NULL_ID();
-        } );
+        luna::set_fx( ut, "get_mtype",
+        []( const item & it ) { return it.get_mtype() ? it.get_mtype()->id : mtype_id::NULL_ID(); } );
 
         DOC( "Translated item name with prefixes" );
         luna::set_fx( ut, "tname", &item::tname );
@@ -324,9 +323,7 @@ void cata::detail::reg_item( sol::state &lua )
         luna::set_fx( ut, "is_soft", &item::is_soft );
         luna::set_fx( ut, "is_reloadable", &item::is_reloadable );
         DOC( "DEPRECATED: Items are no longer filthy" );
-        luna::set_fx( ut, "is_filthy", []() {
-            return false;
-        } );
+        luna::set_fx( ut, "is_filthy", []() { return false; } );
         luna::set_fx( ut, "is_active", &item::is_active );
         luna::set_fx( ut, "is_upgrade", &item::is_upgrade );
 
@@ -358,15 +355,9 @@ void cata::detail::reg_item( sol::state &lua )
         luna::set_fx( ut, "is_made_of",
                       sol::resolve < auto( const material_id & ) const -> bool > ( &item::made_of ) );
 
-        luna::set_fx( ut, "get_kcal", []( item & it ) -> int {
-            return it.is_comestible() ? it.get_comestible()->default_nutrition.kcal : 0;
-        } );
-        luna::set_fx( ut, "get_quench", []( item & it ) -> int {
-            return it.is_comestible() ? it.get_comestible()->quench : 0;
-        } );
-        luna::set_fx( ut, "get_comestible_fun", []( item & it ) -> int {
-            return it.get_comestible_fun();
-        } );
+        luna::set_fx( ut, "get_kcal", []( item & it ) -> int { return it.is_comestible() ? it.get_comestible()->default_nutrition.kcal : 0; } );
+        luna::set_fx( ut, "get_quench", []( item & it ) -> int { return it.is_comestible() ? it.get_comestible()->quench : 0; } );
+        luna::set_fx( ut, "get_comestible_fun", []( item & it ) -> int { return it.get_comestible_fun(); } );
         DOC( "Gets the TimeDuration until this item rots" );
         luna::set_fx( ut, "get_rot", &item::get_rot );
 
@@ -534,16 +525,10 @@ void cata::detail::reg_debug_api( sol::state &lua )
     luna::set_fx( lib, "log_warn", &lua_log_warn_impl );
     luna::set_fx( lib, "log_error", &lua_log_error_impl );
     luna::set_fx( lib, "debugmsg", &lua_debugmsg_impl );
-    luna::set_fx( lib, "clear_lua_log", []() {
-        cata::get_lua_log_instance().clear();
-    } );
-    luna::set_fx( lib, "set_log_capacity", []( int v ) {
-        cata::get_lua_log_instance().set_log_capacity( v );
-    } );
+    luna::set_fx( lib, "clear_lua_log", []() { cata::get_lua_log_instance().clear(); } );
+    luna::set_fx( lib, "set_log_capacity", []( int v ) { cata::get_lua_log_instance().set_log_capacity( v ); } );
     luna::set_fx( lib, "reload_lua_code", &cata::reload_lua_code );
-    luna::set_fx( lib, "save_game", []() -> bool {
-        return g->save( false );
-    } );
+    luna::set_fx( lib, "save_game", []() -> bool { return g->save( false ); } );
 
     luna::finalize_lib( lib );
 }
@@ -677,24 +662,16 @@ void cata::detail::reg_time_types( sol::state &lua )
         luna::set_fx( ut, "from_turn", &time_point::from_turn );
 
         // Methods
-        luna::set_fx( ut, "to_turn", []( const time_point & tp ) -> int {
-            return to_turn<int>( tp );
-        } );
+        luna::set_fx( ut, "to_turn", []( const time_point & tp ) -> int { return to_turn<int>( tp ); } );
 
         luna::set_fx( ut, "is_night", &is_night );
         luna::set_fx( ut, "is_day", &is_day );
         luna::set_fx( ut, "is_dusk", &is_dusk );
         luna::set_fx( ut, "is_dawn", &is_dawn );
 
-        luna::set_fx( ut, "second_of_minute", []( const time_point & tp ) -> int {
-            return to_turn<int>( tp ) % 60;
-        } );
-        luna::set_fx( ut, "minute_of_hour", []( const time_point & tp ) -> int {
-            return minute_of_hour<int>( tp );
-        } );
-        luna::set_fx( ut, "hour_of_day", []( const time_point & tp ) -> int {
-            return hour_of_day<int>( tp );
-        } );
+        luna::set_fx( ut, "second_of_minute", []( const time_point & tp ) -> int { return to_turn<int>( tp ) % 60; } );
+        luna::set_fx( ut, "minute_of_hour", []( const time_point & tp ) -> int { return minute_of_hour<int>( tp ); } );
+        luna::set_fx( ut, "hour_of_day", []( const time_point & tp ) -> int { return hour_of_day<int>( tp ); } );
 
         // (De-)Serialization
         reg_serde_functions( ut );
@@ -708,30 +685,19 @@ void cata::detail::reg_time_types( sol::state &lua )
 
         // Equality operator
         // It's defined as inline friend function inside point class, we can't access it and so have to improvise
-        luna::set_fx( ut, sol::meta_function::equal_to, []( const time_point & a, const time_point & b ) {
-            return a == b;
-        } );
+        luna::set_fx( ut, sol::meta_function::equal_to, []( const time_point & a, const time_point & b ) { return a == b; } );
 
         // Less-then operator
         // Same deal as with equality operator
-        luna::set_fx( ut, sol::meta_function::less_than, []( const time_point & a, const time_point & b ) {
-            return a < b;
-        } );
+        luna::set_fx( ut, sol::meta_function::less_than, []( const time_point & a, const time_point & b ) { return a < b; } );
 
         // Arithmetic operators
         luna::set_fx( ut, sol::meta_function::addition,
-        []( const time_point & a, const time_duration & b ) -> time_point {
-            return a + b;
-        }
-                    );
+                      []( const time_point & a, const time_duration & b ) -> time_point { return a + b; } );
         luna::set_fx( ut, sol::meta_function::subtraction,
                       sol::overload(
-        []( const time_point & a, const time_point & b ) -> time_duration {
-            return a - b;
-        },
-        []( const time_point & a, const time_duration & b ) -> time_point {
-            return a - b;
-        }
+                          []( const time_point & a, const time_point & b ) -> time_duration { return a - b; },
+                          []( const time_point & a, const time_duration & b ) -> time_point { return a - b; }
                       ) );
     }
     {
@@ -744,47 +710,21 @@ void cata::detail::reg_time_types( sol::state &lua )
             );
 
         // Constructor methods
-        luna::set_fx( ut, "from_turns", []( int t ) {
-            return time_duration::from_turns( t );
-        } );
-        luna::set_fx( ut, "from_seconds", []( int t ) {
-            return time_duration::from_seconds( t );
-        } );
-        luna::set_fx( ut, "from_minutes", []( int t ) {
-            return time_duration::from_minutes( t );
-        } );
-        luna::set_fx( ut, "from_hours", []( int t ) {
-            return time_duration::from_hours( t );
-        } );
-        luna::set_fx( ut, "from_days", []( int t ) {
-            return time_duration::from_days( t );
-        } );
-        luna::set_fx( ut, "from_weeks", []( int t ) {
-            return time_duration::from_weeks( t );
-        } );
+        luna::set_fx( ut, "from_turns", []( int t ) { return time_duration::from_turns( t ); } );
+        luna::set_fx( ut, "from_seconds", []( int t ) { return time_duration::from_seconds( t ); } );
+        luna::set_fx( ut, "from_minutes", []( int t ) { return time_duration::from_minutes( t ); } );
+        luna::set_fx( ut, "from_hours", []( int t ) { return time_duration::from_hours( t ); } );
+        luna::set_fx( ut, "from_days", []( int t ) { return time_duration::from_days( t ); } );
+        luna::set_fx( ut, "from_weeks", []( int t ) { return time_duration::from_weeks( t ); } );
 
-        luna::set_fx( ut, "make_random", []( const time_duration & lo, const time_duration & hi ) {
-            return rng( lo, hi );
-        } );
+        luna::set_fx( ut, "make_random", []( const time_duration & lo, const time_duration & hi ) { return rng( lo, hi ); } );
 
-        luna::set_fx( ut, "to_turns", []( const time_duration & t ) -> int {
-            return to_turns<int>( t );
-        } );
-        luna::set_fx( ut, "to_seconds", []( const time_duration & t ) -> int {
-            return to_seconds<int>( t );
-        } );
-        luna::set_fx( ut, "to_minutes", []( const time_duration & t ) -> int {
-            return to_minutes<int>( t );
-        } );
-        luna::set_fx( ut, "to_hours", []( const time_duration & t ) -> int {
-            return to_hours<int>( t );
-        } );
-        luna::set_fx( ut, "to_days", []( const time_duration & t ) -> int {
-            return to_days<int>( t );
-        } );
-        luna::set_fx( ut, "to_weeks", []( const time_duration & t ) -> int {
-            return to_weeks<int>( t );
-        } );
+        luna::set_fx( ut, "to_turns", []( const time_duration & t ) -> int { return to_turns<int>( t ); } );
+        luna::set_fx( ut, "to_seconds", []( const time_duration & t ) -> int { return to_seconds<int>( t ); } );
+        luna::set_fx( ut, "to_minutes", []( const time_duration & t ) -> int { return to_minutes<int>( t ); } );
+        luna::set_fx( ut, "to_hours", []( const time_duration & t ) -> int { return to_hours<int>( t ); } );
+        luna::set_fx( ut, "to_days", []( const time_duration & t ) -> int { return to_days<int>( t ); } );
+        luna::set_fx( ut, "to_weeks", []( const time_duration & t ) -> int { return to_weeks<int>( t ); } );
 
         // (De-)Serialization
         reg_serde_functions( ut );
@@ -794,23 +734,13 @@ void cata::detail::reg_time_types( sol::state &lua )
         luna::set_fx( ut, sol::meta_function::to_string,
                       sol::resolve<std::string( const time_duration & )>( to_string ) );
 
-        luna::set_fx( ut, sol::meta_function::addition, []( const time_duration & a,
-        const time_duration & b ) {
-            return a + b;
-        } );
-        luna::set_fx( ut, sol::meta_function::subtraction, []( const time_duration & a,
-        const time_duration & b ) {
-            return a - b;
-        } );
-        luna::set_fx( ut, sol::meta_function::multiplication, []( const time_duration & a, int b ) {
-            return a * b;
-        } );
-        luna::set_fx( ut, sol::meta_function::division, []( const time_duration & a, int b ) {
-            return a / b;
-        } );
-        luna::set_fx( ut, sol::meta_function::unary_minus, []( const time_duration & a ) {
-            return -a;
-        } );
+        luna::set_fx( ut, sol::meta_function::addition,
+        []( const time_duration & a, const time_duration & b ) { return a + b; } );
+        luna::set_fx( ut, sol::meta_function::subtraction,
+        []( const time_duration & a, const time_duration & b ) { return a - b; } );
+        luna::set_fx( ut, sol::meta_function::multiplication, []( const time_duration & a, int b ) { return a * b; } );
+        luna::set_fx( ut, sol::meta_function::division, []( const time_duration & a, int b ) { return a / b; } );
+        luna::set_fx( ut, sol::meta_function::unary_minus, []( const time_duration & a ) { return -a; } );
     }
 }
 
@@ -820,12 +750,8 @@ void cata::detail::reg_testing_library( sol::state &lua )
     luna::userlib lib = luna::begin_lib( lua, "tests_lib" );
 
     // Regression test for https://github.com/ThePhD/sol2/issues/1444
-    luna::set_fx( lib, "my_awesome_lambda_1", []() -> int {
-        return 1;
-    } );
-    luna::set_fx( lib, "my_awesome_lambda_2", []() -> int {
-        return 2;
-    } );
+    luna::set_fx( lib, "my_awesome_lambda_1", []() -> int { return 1; } );
+    luna::set_fx( lib, "my_awesome_lambda_2", []() -> int { return 2; } );
 
     luna::finalize_lib( lib );
 }

--- a/src/catalua_bindings_coords.cpp
+++ b/src/catalua_bindings_coords.cpp
@@ -40,15 +40,11 @@ void cata::detail::reg_point_tripoint( sol::state &lua )
 
         // Equality operator
         // It's defined as inline friend function inside point class, we can't access it and so have to improvise
-        luna::set_fx( ut, sol::meta_function::equal_to, []( const point & a, const point & b ) {
-            return a == b;
-        } );
+        luna::set_fx( ut, sol::meta_function::equal_to, []( const point & a, const point & b ) { return a == b; } );
 
         // Less-then operator
         // Same deal as with equality operator
-        luna::set_fx( ut, sol::meta_function::less_than, []( const point & a, const point & b ) {
-            return a < b;
-        } );
+        luna::set_fx( ut, sol::meta_function::less_than, []( const point & a, const point & b ) { return a < b; } );
 
         // Arithmetic operators
         // point + point
@@ -102,15 +98,11 @@ void cata::detail::reg_point_tripoint( sol::state &lua )
 
         // Equality operator
         // It's defined as inline friend function inside point class, we can't access it and so have to improvise
-        luna::set_fx( ut, sol::meta_function::equal_to, []( const tripoint & a, const tripoint & b ) {
-            return a == b;
-        } );
+        luna::set_fx( ut, sol::meta_function::equal_to, []( const tripoint & a, const tripoint & b ) { return a == b; } );
 
         // Less-then operator
         // Same deal as with equality operator
-        luna::set_fx( ut, sol::meta_function::less_than, []( const tripoint & a, const tripoint & b ) {
-            return a < b;
-        } );
+        luna::set_fx( ut, sol::meta_function::less_than, []( const tripoint & a, const tripoint & b ) { return a < b; } );
 
         // Arithmetic operators
         // tripoint + tripoint (overload 1)

--- a/src/catalua_bindings_creature.cpp
+++ b/src/catalua_bindings_creature.cpp
@@ -250,9 +250,7 @@ void cata::detail::reg_creature( sol::state &lua )
 
         SET_FX_T( has_grab_break_tec, bool() const );
 
-        luna::set_fx( ut, "get_weight_capacity", []( UT_CLASS & cr ) -> std::int64_t {
-            return cr.weight_capacity().value();
-        } );
+        luna::set_fx( ut, "get_weight_capacity", []( UT_CLASS & cr ) -> std::int64_t { return cr.weight_capacity().value(); } );
     }
 #undef UT_CLASS // #define UT_CLASS Creature
 }
@@ -277,10 +275,8 @@ void cata::detail::reg_monster( sol::state &lua )
         SET_MEMB( unique_name );
 
         // Methods
-        luna::set_fx( ut, "get_type", []( const monster & m )
-        {
-            return m.type -> id; //I really don't want to break the uniformity, but...
-        } );
+        // I really don't want to break the uniformity, but...
+        luna::set_fx( ut, "get_type", []( const monster & m ) { return m.type -> id; } );
         SET_FX_T( can_upgrade, bool() const );
         SET_FX_T( hasten_upgrade, void() );
         SET_FX_T( get_upgrade_time, int() const );
@@ -407,10 +403,7 @@ void cata::detail::reg_character( sol::state &lua )
             faction *fac = charac.get_faction();
             return fac == nullptr ? faction_id::NULL_ID() : fac->id;
         } );
-        luna::set_fx( ut, "set_faction_id", []( UT_CLASS & charac, faction_id id )
-        {
-            charac.set_fac_id( id.str() );
-        } );
+        luna::set_fx( ut, "set_faction_id", []( UT_CLASS & charac, faction_id id ) { charac.set_fac_id( id.str() ); } );
 
         SET_FX_T( sight_impaired, bool() const );
 
@@ -698,9 +691,7 @@ void cata::detail::reg_character( sol::state &lua )
         SET_FX_T( all_items, std::vector<item *>( bool need_charges ) const );
 
         DOC( "Removes given `Item` from character's inventory. The `Item` must be in the inventory, neither wielded nor worn." );
-        luna::set_fx( ut, "inv_remove_item", []( Character & ch, item * it ) -> void {
-            ch.inv_remove_item( it );
-        } );
+        luna::set_fx( ut, "inv_remove_item", []( Character & ch, item * it ) -> void { ch.inv_remove_item( it ); } );
 
         SET_FX_T( assign_activity,
                   void( const activity_id &, int, int, int, const std::string & ) );
@@ -787,12 +778,8 @@ void cata::detail::reg_character( sol::state &lua )
         SET_FX_T( has_morale_to_read, bool() const );
         SET_FX_T( has_morale_to_craft, bool() const );
 
-        luna::set_fx( ut, "knows_recipe", []( const UT_CLASS & utObj, const recipe_id & rec ) -> bool {
-            return utObj.knows_recipe( &( rec.obj() ) );
-        } );
-        luna::set_fx( ut, "learn_recipe", []( UT_CLASS & utObj, const recipe_id & rec ) -> void {
-            utObj.learn_recipe( &( rec.obj() ) );
-        } );
+        luna::set_fx( ut, "knows_recipe", []( const UT_CLASS & utObj, const recipe_id & rec ) -> bool { return utObj.knows_recipe( &( rec.obj() ) ); } );
+        luna::set_fx( ut, "learn_recipe", []( UT_CLASS & utObj, const recipe_id & rec ) -> void { utObj.learn_recipe( &( rec.obj() ) ); } );
 
         SET_FX_T( suffer, void() );
 
@@ -913,8 +900,8 @@ void cata::detail::reg_npc( sol::state &lua )
 
         SET_FX_T( smash_ability, int() const );
 
-        luna::set_fx( ut, "complain_about", []( UT_CLASS & npchar, const std::string & issue,
-        const time_duration & dur, const std::string & speech, sol::optional<bool> force ) -> bool {
+        luna::set_fx( ut, "complain_about",
+        []( UT_CLASS & npchar, const std::string & issue, const time_duration & dur, const std::string & speech, sol::optional<bool> force ) -> bool {
             return npchar.complain_about( issue, dur, speech, force ? *force : false );
         } );
 

--- a/src/catalua_bindings_game.cpp
+++ b/src/catalua_bindings_game.cpp
@@ -70,50 +70,28 @@ void cata::detail::reg_game_api( sol::state &lua )
 
     luna::set_fx( lib, "get_creature_at", []( const tripoint & p,
     sol::optional<bool> allow_hallucination ) -> Creature * {
-        if( allow_hallucination.has_value() )
-        {
-            return g->critter_at<Creature>( p, *allow_hallucination );
-        }
-        return g->critter_at<Creature>( p );
+        return g->critter_at<Creature>( p, allow_hallucination.value_or( false ) );
     } );
     luna::set_fx( lib, "get_monster_at", []( const tripoint & p,
     sol::optional<bool> allow_hallucination ) -> monster * {
-        if( allow_hallucination.has_value() )
-        {
-            return g->critter_at<monster>( p, *allow_hallucination );
-        }
-        return g->critter_at<monster>( p );
+        return g->critter_at<monster>( p, allow_hallucination.value_or( false ) );
     } );
     luna::set_fx( lib, "place_monster_at", []( const mtype_id & id, const tripoint & p ) {
         return g->place_critter_at( id, p );
     } );
     luna::set_fx( lib, "get_character_at", []( const tripoint & p,
     sol::optional<bool> allow_hallucination ) -> Character * {
-        if( allow_hallucination.has_value() )
-        {
-            return g->critter_at<Character>( p, *allow_hallucination );
-        }
-        return g->critter_at<Character>( p );
+        return g->critter_at<Character>( p, allow_hallucination.value_or( false ) );
     } );
     luna::set_fx( lib, "get_npc_at", []( const tripoint & p,
     sol::optional<bool> allow_hallucination ) -> npc * {
-        if( allow_hallucination.has_value() )
-        {
-            return g->critter_at<npc>( p, *allow_hallucination );
-        }
-        return g->critter_at<npc>( p );
+        return g->critter_at<npc>( p, allow_hallucination.value_or( false ) );
     } );
 
     luna::set_fx( lib, "choose_adjacent", []( const std::string & message,
     sol::optional<bool> allow_vertical ) -> sol::optional<tripoint> {
-        std::optional<tripoint> stdOpt;
-        if( allow_vertical.has_value() )
-        {
-            stdOpt = choose_adjacent( message, *allow_vertical );
-        } else
-        {
-            stdOpt = choose_adjacent( message );
-        }
+        std::optional<tripoint> stdOpt = choose_adjacent( message, allow_vertical.value_or( false ) );
+
         if( stdOpt.has_value() )
         {
             return sol::optional<tripoint>( *stdOpt );
@@ -122,14 +100,8 @@ void cata::detail::reg_game_api( sol::state &lua )
     } );
     luna::set_fx( lib, "choose_direction", []( const std::string & message,
     sol::optional<bool> allow_vertical ) -> sol::optional<tripoint> {
-        std::optional<tripoint> stdOpt;
-        if( allow_vertical.has_value() )
-        {
-            stdOpt = choose_direction( message, *allow_vertical );
-        } else
-        {
-            stdOpt = choose_direction( message );
-        }
+        std::optional<tripoint> stdOpt = choose_direction( message, allow_vertical.value_or( false ) );
+
         if( stdOpt.has_value() )
         {
             return sol::optional<tripoint>( *stdOpt );

--- a/src/catalua_bindings_game.cpp
+++ b/src/catalua_bindings_game.cpp
@@ -37,20 +37,15 @@ void cata::detail::reg_game_api( sol::state &lua )
     luna::set_fx( lib, "get_map", &get_map );
     luna::set_fx( lib, "get_distribution_grid_tracker", &get_distribution_grid_tracker );
     luna::set_fx( lib, "add_msg", sol::overload(
-                      add_msg_lua,
-    []( sol::variadic_args va ) {
-        add_msg_lua( game_message_type::m_neutral, va );
-    }
+    add_msg_lua, []( sol::variadic_args va ) { add_msg_lua( game_message_type::m_neutral, va ); }
                   ) );
-    luna::set_fx( lib, "place_player_overmap_at", []( const tripoint & p ) -> void {
-        g->place_player_overmap( tripoint_abs_omt( p ) );
-    } );
+    luna::set_fx( lib, "place_player_overmap_at", []( const tripoint & p ) -> void { g->place_player_overmap( tripoint_abs_omt( p ) ); } );
     luna::set_fx( lib, "current_turn", []() -> time_point { return calendar::turn; } );
     luna::set_fx( lib, "turn_zero", []() -> time_point { return calendar::turn_zero; } );
     luna::set_fx( lib, "before_time_starts", []() -> time_point { return calendar::before_time_starts; } );
     luna::set_fx( lib, "rng", sol::resolve<int( int, int )>( &rng ) );
-    luna::set_fx( lib, "add_on_every_x_hook", []( sol::this_state lua_this, time_duration interval,
-    sol::protected_function f ) {
+    luna::set_fx( lib, "add_on_every_x_hook",
+    []( sol::this_state lua_this, time_duration interval, sol::protected_function f ) {
         sol::state_view lua( lua_this );
         std::vector<on_every_x_hooks> &hooks = lua["game"]["cata_internal"]["on_every_x_hooks"];
         for( auto &entry : hooks ) {
@@ -64,32 +59,20 @@ void cata::detail::reg_game_api( sol::state &lua )
         hooks.push_back( on_every_x_hooks{ interval, vec } );
     } );
 
-    luna::set_fx( lib, "create_item", []( const itype_id & itype, int count ) -> std::unique_ptr<item> {
-        return std::make_unique<item>( itype, calendar::turn, count );
-    } );
+    luna::set_fx( lib, "create_item", []( const itype_id & itype, int count ) -> std::unique_ptr<item> { return std::make_unique<item>( itype, calendar::turn, count ); } );
 
-    luna::set_fx( lib, "get_creature_at", []( const tripoint & p,
-    sol::optional<bool> allow_hallucination ) -> Creature * {
-        return g->critter_at<Creature>( p, allow_hallucination.value_or( false ) );
-    } );
-    luna::set_fx( lib, "get_monster_at", []( const tripoint & p,
-    sol::optional<bool> allow_hallucination ) -> monster * {
-        return g->critter_at<monster>( p, allow_hallucination.value_or( false ) );
-    } );
-    luna::set_fx( lib, "place_monster_at", []( const mtype_id & id, const tripoint & p ) {
-        return g->place_critter_at( id, p );
-    } );
-    luna::set_fx( lib, "get_character_at", []( const tripoint & p,
-    sol::optional<bool> allow_hallucination ) -> Character * {
-        return g->critter_at<Character>( p, allow_hallucination.value_or( false ) );
-    } );
-    luna::set_fx( lib, "get_npc_at", []( const tripoint & p,
-    sol::optional<bool> allow_hallucination ) -> npc * {
-        return g->critter_at<npc>( p, allow_hallucination.value_or( false ) );
-    } );
+    luna::set_fx( lib, "get_creature_at",
+                  []( const tripoint & p, sol::optional<bool> allow_hallucination ) -> Creature * { return g->critter_at<Creature>( p, allow_hallucination.value_or( false ) ); } );
+    luna::set_fx( lib, "get_monster_at",
+                  []( const tripoint & p, sol::optional<bool> allow_hallucination ) -> monster * { return g->critter_at<monster>( p, allow_hallucination.value_or( false ) ); } );
+    luna::set_fx( lib, "place_monster_at", []( const mtype_id & id, const tripoint & p ) { return g->place_critter_at( id, p ); } );
+    luna::set_fx( lib, "get_character_at",
+                  []( const tripoint & p, sol::optional<bool> allow_hallucination ) -> Character * { return g->critter_at<Character>( p, allow_hallucination.value_or( false ) ); } );
+    luna::set_fx( lib, "get_npc_at",
+                  []( const tripoint & p, sol::optional<bool> allow_hallucination ) -> npc * { return g->critter_at<npc>( p, allow_hallucination.value_or( false ) ); } );
 
-    luna::set_fx( lib, "choose_adjacent", []( const std::string & message,
-    sol::optional<bool> allow_vertical ) -> sol::optional<tripoint> {
+    luna::set_fx( lib, "choose_adjacent",
+    []( const std::string & message, sol::optional<bool> allow_vertical ) -> sol::optional<tripoint> {
         std::optional<tripoint> stdOpt = choose_adjacent( message, allow_vertical.value_or( false ) );
 
         if( stdOpt.has_value() )
@@ -124,12 +107,8 @@ void cata::detail::reg_game_api( sol::state &lua )
                   ) );
     luna::set_fx( lib, "play_ambient_variant_sound", &sfx::play_ambient_variant_sound );
 
-    luna::set_fx( lib, "add_npc_follower", []( npc & p ) {
-        g->add_npc_follower( p.getID() );
-    } );
-    luna::set_fx( lib, "remove_npc_follower", []( npc & p ) {
-        g->remove_npc_follower( p.getID() );
-    } );
+    luna::set_fx( lib, "add_npc_follower", []( npc & p ) { g->add_npc_follower( p.getID() ); } );
+    luna::set_fx( lib, "remove_npc_follower", []( npc & p ) { g->remove_npc_follower( p.getID() ); } );
 
     luna::finalize_lib( lib );
 }

--- a/src/catalua_bindings_ids.cpp
+++ b/src/catalua_bindings_ids.cpp
@@ -52,34 +52,22 @@ void reg_id( sol::state &lua )
                                         );
         }
 
-        luna::set_fx( ut, "obj", []( const SID & sid ) -> const T* {
-            return &sid.obj();
-        } );
+        luna::set_fx( ut, "obj", []( const SID & sid ) -> const T* { return &sid.obj(); } );
         if constexpr( do_int_id ) {
             luna::set_fx( ut, "int_id", &SID::id );
-            luna::set_fx( ut, "implements_int_id", []() {
-                return true;
-            } );
+            luna::set_fx( ut, "implements_int_id", []() { return true; } );
         } else {
-            luna::set_fx( ut, "implements_int_id", []() {
-                return false;
-            } );
+            luna::set_fx( ut, "implements_int_id", []() { return false; } );
         }
         luna::set_fx( ut, "is_null", &SID::is_null );
         luna::set_fx( ut, "is_valid", &SID::is_valid );
         luna::set_fx( ut, "str", &SID::c_str );
         luna::set_fx( ut, "NULL_ID", &SID::NULL_ID );
-        luna::set_fx( ut, sol::meta_function::to_string, []( const SID & id ) -> std::string {
-            return string_format( "%s[%s]", luna::detail::luna_traits<SID>::name, id.c_str() );
-        } );
+        luna::set_fx( ut, sol::meta_function::to_string, []( const SID & id ) -> std::string { return string_format( "%s[%s]", luna::detail::luna_traits<SID>::name, id.c_str() ); } );
 
         // (De-)Serialization
-        luna::set_fx( ut, "serialize", []( const SID & ut, JsonOut & jsout ) {
-            jsout.write( ut.str() );
-        } );
-        luna::set_fx( ut, "deserialize", []( SID & ut, JsonIn & jsin ) {
-            ut = SID( jsin.get_string() );
-        } );
+        luna::set_fx( ut, "serialize", []( const SID & ut, JsonOut & jsout ) { jsout.write( ut.str() ); } );
+        luna::set_fx( ut, "deserialize", []( SID & ut, JsonIn & jsin ) { ut = SID( jsin.get_string() ); } );
     }
     if constexpr( do_int_id ) {
         // Register int_id class under given name
@@ -87,17 +75,12 @@ void reg_id( sol::state &lua )
                                 IID(),
                                 IID( const IID & ),
                                 IID( const SID & )
-                                > ()
-                                                       );
+                                > () );
 
-        luna::set_fx( ut, "obj", []( const IID & iid ) -> const T* {
-            return &iid.obj();
-        } );
+        luna::set_fx( ut, "obj", []( const IID & iid ) -> const T* { return &iid.obj(); } );
         luna::set_fx( ut, "str_id", &IID::id );
         luna::set_fx( ut, "is_valid", &IID::is_valid );
-        luna::set_fx( ut, sol::meta_function::to_string, []( const IID & id ) -> std::string {
-            return string_format( "%s[%d][%s]", luna::detail::luna_traits<IID>::name, id.to_i(), id.is_valid() ? id.id().c_str() : "<invalid>" );
-        } );
+        luna::set_fx( ut, sol::meta_function::to_string, []( const IID & id ) -> std::string { return string_format( "%s[%d][%s]", luna::detail::luna_traits<IID>::name, id.to_i(), id.is_valid() ? id.id().c_str() : "<invalid>" ); } );
     }
 }
 
@@ -141,9 +124,7 @@ void cata::detail::reg_types( sol::state &lua )
         sol::usertype<faction> ut =
             luna::new_usertype<faction>( lua, luna::no_bases, luna::no_constructor );
 
-        luna::set_fx( ut, "str_id", []( const faction & x ) -> faction_id {
-            return x.id;
-        } );
+        luna::set_fx( ut, "str_id", []( const faction & x ) -> faction_id { return x.id; } );
 
         // Factions are a pain because they _inherit_ from their type, not reference it by id.
         // This causes various weirdness, so let's omit the fields for now.
@@ -159,12 +140,8 @@ void cata::detail::reg_types( sol::state &lua )
         sol::usertype<ter_t> ut =
             luna::new_usertype<ter_t>( lua, luna::no_bases, luna::no_constructor );
 
-        luna::set_fx( ut, "str_id", []( const ter_t & x ) -> ter_str_id {
-            return x.id;
-        } );
-        luna::set_fx( ut, "int_id", []( const ter_t & x ) -> ter_id {
-            return x.id.id();
-        } );
+        luna::set_fx( ut, "str_id", []( const ter_t & x ) -> ter_str_id { return x.id; } );
+        luna::set_fx( ut, "int_id", []( const ter_t & x ) -> ter_id { return x.id.id(); } );
 
         luna::set_fx( ut, "name", &ter_t::name );
         luna::set_fx( ut, "get_flags",
@@ -172,30 +149,14 @@ void cata::detail::reg_types( sol::state &lua )
         luna::set_fx( ut, "has_flag", sol::resolve<bool( const std::string & ) const>
                       ( &ter_t::has_flag ) );
         luna::set_fx( ut, "set_flag", &ter_t::set_flag );
-        luna::set_fx( ut, "get_light_emitted", []( ter_t & t ) -> int {
-            return t.light_emitted;
-        } );
-        luna::set_fx( ut, "set_light_emitted", []( ter_t & t, int val ) {
-            t.light_emitted = val;
-        } );
-        luna::set_fx( ut, "get_movecost", []( ter_t & t ) -> int {
-            return t.movecost;
-        } );
-        luna::set_fx( ut, "set_movecost", []( ter_t & t, int val ) {
-            t.movecost = val;
-        } );
-        luna::set_fx( ut, "get_coverage", []( ter_t & t ) -> int {
-            return t.coverage;
-        } );
-        luna::set_fx( ut, "set_coverage", []( ter_t & t, int val ) {
-            t.coverage = val;
-        } );
-        luna::set_fx( ut, "get_max_volume", []( ter_t & t ) -> units::volume {
-            return t.max_volume;
-        } );
-        luna::set_fx( ut, "set_max_volume", []( ter_t & t, units::volume val ) {
-            t.max_volume = val;
-        } );
+        luna::set_fx( ut, "get_light_emitted", []( ter_t & t ) -> int { return t.light_emitted; } );
+        luna::set_fx( ut, "set_light_emitted", []( ter_t & t, int val ) { t.light_emitted = val; } );
+        luna::set_fx( ut, "get_movecost", []( ter_t & t ) -> int { return t.movecost; } );
+        luna::set_fx( ut, "set_movecost", []( ter_t & t, int val ) { t.movecost = val; } );
+        luna::set_fx( ut, "get_coverage", []( ter_t & t ) -> int { return t.coverage; } );
+        luna::set_fx( ut, "set_coverage", []( ter_t & t, int val ) { t.coverage = val; } );
+        luna::set_fx( ut, "get_max_volume", []( ter_t & t ) -> units::volume { return t.max_volume; } );
+        luna::set_fx( ut, "set_max_volume", []( ter_t & t, units::volume val ) { t.max_volume = val; } );
         luna::set( ut, "open", &ter_t::open );
         luna::set( ut, "close", &ter_t::close );
         luna::set( ut, "trap_id_str", &ter_t::trap_id_str );
@@ -207,12 +168,8 @@ void cata::detail::reg_types( sol::state &lua )
         sol::usertype<furn_t> ut =
             luna::new_usertype<furn_t>( lua, luna::no_bases, luna::no_constructor );
 
-        luna::set_fx( ut, "str_id", []( const furn_t &x ) -> furn_str_id {
-            return x.id;
-        } );
-        luna::set_fx( ut, "int_id", []( const furn_t &x ) -> furn_id {
-            return x.id.id();
-        } );
+        luna::set_fx( ut, "str_id", []( const furn_t &x ) -> furn_str_id { return x.id; } );
+        luna::set_fx( ut, "int_id", []( const furn_t &x ) -> furn_id { return x.id.id(); } );
 
         luna::set_fx( ut, "name", &furn_t::name );
         luna::set_fx( ut, "get_flags",
@@ -220,33 +177,17 @@ void cata::detail::reg_types( sol::state &lua )
         luna::set_fx( ut, "has_flag", sol::resolve<bool( const std::string & ) const>
                       ( &furn_t::has_flag ) );
         luna::set_fx( ut, "set_flag", &furn_t::set_flag );
-        luna::set_fx( ut, "get_light_emitted", []( furn_t &f ) -> int {
-            return f.light_emitted;
-        } );
-        luna::set_fx( ut, "set_light_emitted", []( furn_t &f, int val ) {
-            f.light_emitted = val;
-        } );
+        luna::set_fx( ut, "get_light_emitted", []( furn_t &f ) -> int { return f.light_emitted; } );
+        luna::set_fx( ut, "set_light_emitted", []( furn_t &f, int val ) { f.light_emitted = val; } );
 
-        luna::set_fx( ut, "get_movecost", []( furn_t &f ) -> int {
-            return f.movecost;
-        } );
-        luna::set_fx( ut, "set_movecost", []( furn_t &f, int val ) {
-            f.movecost = val;
-        } );
+        luna::set_fx( ut, "get_movecost", []( furn_t &f ) -> int { return f.movecost; } );
+        luna::set_fx( ut, "set_movecost", []( furn_t &f, int val ) { f.movecost = val; } );
 
-        luna::set_fx( ut, "get_coverage", []( furn_t &f ) -> int {
-            return f.coverage;
-        } );
-        luna::set_fx( ut, "set_coverage", []( furn_t &f, int val ) {
-            f.coverage = val;
-        } );
+        luna::set_fx( ut, "get_coverage", []( furn_t &f ) -> int { return f.coverage; } );
+        luna::set_fx( ut, "set_coverage", []( furn_t &f, int val ) { f.coverage = val; } );
 
-        luna::set_fx( ut, "get_max_volume", []( furn_t &f ) -> units::volume {
-            return f.max_volume;
-        } );
-        luna::set_fx( ut, "set_max_volume", []( furn_t &f, units::volume val ) {
-            f.max_volume = val;
-        } );
+        luna::set_fx( ut, "get_max_volume", []( furn_t &f ) -> units::volume { return f.max_volume; } );
+        luna::set_fx( ut, "set_max_volume", []( furn_t &f, units::volume val ) { f.max_volume = val; } );
 
         luna::set( ut, "open", &furn_t::open );
         luna::set( ut, "close", &furn_t::close );

--- a/src/catalua_bindings_magic.cpp
+++ b/src/catalua_bindings_magic.cpp
@@ -38,9 +38,7 @@ void cata::detail::reg_spell_type( sol::state &lua )
 
         // The string conversion function references this object's str_id.
         luna::set_fx( ut, sol::meta_function::to_string,
-        []( const UT_CLASS & id ) -> std::string {
-            return string_format( "%s[%s]", luna::detail::luna_traits<UT_CLASS>::name, id.id.c_str() );
-        } );
+        []( const UT_CLASS & id ) -> std::string { return string_format( "%s[%s]", luna::detail::luna_traits<UT_CLASS>::name, id.id.c_str() ); } );
 
         SET_MEMB_RO( id );
         DOC( "The name of the primary effect this spell will enact." );
@@ -90,9 +88,7 @@ void cata::detail::reg_spell_type( sol::state &lua )
 
         DOC( "Other spells cast by this spell." );
         luna::set_fx( ut, "additional_spells",
-        []( const UT_CLASS & spid ) -> std::vector<fake_spell> {
-            std::vector<fake_spell> rv = spid.additional_spells; return rv;
-        } );
+        []( const UT_CLASS & spid ) -> std::vector<fake_spell> { std::vector<fake_spell> rv = spid.additional_spells; return rv; } );
 
         DOC( "Returns a (long) list of every spell in the game." );
         SET_FX_T( get_all, const std::vector<spell_type> &() );
@@ -117,16 +113,12 @@ void cata::detail::reg_spell_fake( sol::state &lua )
         );
 
         luna::set_fx( ut, sol::meta_function::to_string,
-        []( const UT_CLASS & id ) -> std::string {
-            return string_format( "%s[%s]", luna::detail::luna_traits<UT_CLASS>::name, id.id.c_str() );
-        } );
+        []( const UT_CLASS & id ) -> std::string { return string_format( "%s[%s]", luna::detail::luna_traits<UT_CLASS>::name, id.id.c_str() ); } );
 
         SET_MEMB_RO( id );
 
         DOC( "Returns the defined maximum level of this SpellSimple instance, if defined. Otherwise, returns 0." );
-        luna::set_fx( ut, "max_level", []( UT_CLASS & sp ) -> int {
-            return sp.max_level.has_value() ? *sp.max_level : 0;
-        } );
+        luna::set_fx( ut, "max_level", []( UT_CLASS & sp ) -> int { return sp.max_level.has_value() ? *sp.max_level : 0; } );
 
         // Perhaps this should be writeable?
         SET_MEMB_RO( level );

--- a/src/catalua_bindings_map.cpp
+++ b/src/catalua_bindings_map.cpp
@@ -96,9 +96,7 @@ void cata::detail::reg_map( sol::state &lua )
 
         luna::set_fx( ut, "get_map_size_in_submaps", &map::getmapsize );
         DOC( "In map squares" );
-        luna::set_fx( ut, "get_map_size", []( const map & m ) -> int {
-            return m.getmapsize() * SEEX;
-        } );
+        luna::set_fx( ut, "get_map_size", []( const map & m ) -> int { return m.getmapsize() * SEEX; } );
 
         DOC( "Creates a new item(s) at a position on the map." );
         luna::set_fx( ut, "create_item_at", []( map & m, const tripoint & p, const itype_id & itype,
@@ -122,15 +120,9 @@ void cata::detail::reg_map( sol::state &lua )
         } );
 
         luna::set_fx( ut, "has_items_at", &map::has_items );
-        luna::set_fx( ut, "get_items_at", []( map & m, const tripoint & p ) -> std::unique_ptr<map_stack> {
-            return std::make_unique<map_stack>( m.i_at( p ) );
-        } );
-        luna::set_fx( ut, "remove_item_at", []( map & m, const tripoint & p, item * it ) -> void {
-            m.i_rem( p, it );
-        } );
-        luna::set_fx( ut, "clear_items_at", []( map & m, const tripoint & p ) -> void {
-            m.i_clear( p );
-        } );
+        luna::set_fx( ut, "get_items_at", []( map & m, const tripoint & p ) -> std::unique_ptr<map_stack> { return std::make_unique<map_stack>( m.i_at( p ) ); } );
+        luna::set_fx( ut, "remove_item_at", []( map & m, const tripoint & p, item * it ) -> void { m.i_rem( p, it ); } );
+        luna::set_fx( ut, "clear_items_at", []( map & m, const tripoint & p ) -> void { m.i_clear( p ); } );
 
 
         luna::set_fx( ut, "get_ter_at", sol::resolve<ter_id( const tripoint & )const>( &map::ter ) );
@@ -138,14 +130,10 @@ void cata::detail::reg_map( sol::state &lua )
                       sol::resolve<bool( const tripoint &, const ter_id & )>( &map::ter_set ) );
 
         luna::set_fx( ut, "get_furn_at", sol::resolve<furn_id( const tripoint & )const>( &map::furn ) );
-        luna::set_fx( ut, "set_furn_at", []( map & m, const tripoint & p, const furn_id & id ) {
-            m.furn_set( p, id );
-        } );
+        luna::set_fx( ut, "set_furn_at", []( map & m, const tripoint & p, const furn_id & id ) { m.furn_set( p, id ); } );
 
-        luna::set_fx( ut, "has_field_at", []( const map & m, const tripoint & p,
-        const field_type_id & fid ) -> bool {
-            return !!m.field_at( p ).find_field( fid );
-        } );
+        luna::set_fx( ut, "has_field_at",
+                      []( const map & m, const tripoint & p, const field_type_id & fid ) -> bool { return !!m.field_at( p ).find_field( fid ); } );
         luna::set_fx( ut, "get_field_int_at", &map::get_field_intensity );
         luna::set_fx( ut, "get_field_age_at", &map::get_field_age );
         luna::set_fx( ut, "mod_field_int_at", &map::mod_field_intensity );
@@ -157,9 +145,7 @@ void cata::detail::reg_map( sol::state &lua )
             return m.add_field( p, fid, intensity, age );
         } );
         luna::set_fx( ut, "remove_field_at", &map::remove_field );
-        luna::set_fx( ut, "get_trap_at", []( map & m, const tripoint & p ) -> trap_id {
-            return m.tr_at( p ).loadid;
-        } );
+        luna::set_fx( ut, "get_trap_at", []( map & m, const tripoint & p ) -> trap_id { return m.tr_at( p ).loadid; } );
         DOC( "Set a trap at a position on the map. It can also replace existing trap, even with `trap_null`." );
         luna::set_fx( ut, "set_trap_at", &map::trap_set );
         DOC( "Disarms a trap using your skills and stats, with consequences depending on success or failure." );
@@ -187,9 +173,7 @@ void cata::detail::reg_map( sol::state &lua )
         sol::usertype<map_stack> ut = luna::new_usertype<map_stack>( lua, luna::bases<item_stack>(),
                                       luna::no_constructor );
 
-        luna::set_fx( ut, "as_item_stack", []( map_stack & ref ) -> item_stack& {
-            return ref;
-        } );
+        luna::set_fx( ut, "as_item_stack", []( map_stack & ref ) -> item_stack& { return ref; } );
     }
 }
 
@@ -217,10 +201,8 @@ void cata::detail::reg_distribution_grid( sol::state &lua )
                 luna::no_constructor
             );
 
-        luna::set_fx( ut, "get_grid_at_abs_ms", []( distribution_grid_tracker & tr, const tripoint & p )
-        -> distribution_grid& {
-            return tr.grid_at( tripoint_abs_ms( p ) );
-        } );
+        luna::set_fx( ut, "get_grid_at_abs_ms",
+                      []( distribution_grid_tracker & tr, const tripoint & p ) -> distribution_grid& { return tr.grid_at( tripoint_abs_ms( p ) ); } );
     }
 
 }

--- a/src/catalua_bindings_mutation.cpp
+++ b/src/catalua_bindings_mutation.cpp
@@ -131,42 +131,24 @@ void cata::detail::mod_mutation_branch( sol::state &lua )
 
         // The string conversion function references this object's str_id.
         luna::set_fx( ut, sol::meta_function::to_string,
-        []( const UT_CLASS & id ) -> std::string {
-            return string_format( "%s[%s]", luna::detail::luna_traits<UT_CLASS>::name, id.id.c_str() );
-        } );
+        []( const UT_CLASS & id ) -> std::string { return string_format( "%s[%s]", luna::detail::luna_traits<UT_CLASS>::name, id.id.c_str() ); } );
 
         // Copy the return values so they can't be modified in-place.
         DOC( "Lists the primary mutation(s) needed to gain this mutation." );
-        luna::set_fx( ut, "prerequisites", []( const UT_CLASS & mut ) -> std::vector<trait_id> {
-            std::vector<trait_id> rv = mut.prereqs; return rv;
-        } );
+        luna::set_fx( ut, "prerequisites", []( const UT_CLASS & mut ) -> std::vector<trait_id> { std::vector<trait_id> rv = mut.prereqs; return rv; } );
         DOC( "Lists the secondary mutation(s) needed to gain this mutation." );
-        luna::set_fx( ut, "other_prerequisites", []( const UT_CLASS & mut ) -> std::vector<trait_id> {
-            std::vector<trait_id> rv = mut.prereqs2; return rv;
-        } );
+        luna::set_fx( ut, "other_prerequisites", []( const UT_CLASS & mut ) -> std::vector<trait_id> { std::vector<trait_id> rv = mut.prereqs2; return rv; } );
         DOC( "Lists the threshold mutation(s) required to gain this mutation." );
-        luna::set_fx( ut, "thresh_requirements", []( const UT_CLASS & mut ) -> std::vector<trait_id> {
-            std::vector<trait_id> rv = mut.threshreq; return rv;
-        } );
+        luna::set_fx( ut, "thresh_requirements", []( const UT_CLASS & mut ) -> std::vector<trait_id> { std::vector<trait_id> rv = mut.threshreq; return rv; } );
         DOC( "Lists the type(s) of this mutation. Mutations of a given type are mutually exclusive." );
-        luna::set_fx( ut, "mutation_types", []( const UT_CLASS & mut ) -> std::set<std::string> {
-            std::set<std::string> rv = mut.types; return rv;
-        } );
+        luna::set_fx( ut, "mutation_types", []( const UT_CLASS & mut ) -> std::set<std::string> { std::set<std::string> rv = mut.types; return rv; } );
         DOC( "Lists conflicting mutations." );
-        luna::set_fx( ut, "conflicts_with", []( const UT_CLASS & mut ) -> std::vector<trait_id> {
-            std::vector<trait_id> rv = mut.cancels; return rv;
-        } );
+        luna::set_fx( ut, "conflicts_with", []( const UT_CLASS & mut ) -> std::vector<trait_id> { std::vector<trait_id> rv = mut.cancels; return rv; } );
         DOC( "Lists mutations that replace (e.g. evolve from) this one." );
-        luna::set_fx( ut, "replaced_by", []( const UT_CLASS & mut ) -> std::vector<trait_id> {
-            std::vector<trait_id> rv = mut.replacements; return rv;
-        } );
-        luna::set_fx( ut, "addition_mutations", []( const UT_CLASS & mut ) -> std::vector<trait_id> {
-            std::vector<trait_id> rv = mut.additions; return rv;
-        } );
+        luna::set_fx( ut, "replaced_by", []( const UT_CLASS & mut ) -> std::vector<trait_id> { std::vector<trait_id> rv = mut.replacements; return rv; } );
+        luna::set_fx( ut, "addition_mutations", []( const UT_CLASS & mut ) -> std::vector<trait_id> { std::vector<trait_id> rv = mut.additions; return rv; } );
         DOC( "Lists the categories this mutation belongs to." );
-        luna::set_fx( ut, "categories", []( const UT_CLASS & mut ) -> std::vector<mutation_category_id> {
-            std::vector<mutation_category_id> rv = mut.category; return rv;
-        } );
+        luna::set_fx( ut, "categories", []( const UT_CLASS & mut ) -> std::vector<mutation_category_id> { std::vector<mutation_category_id> rv = mut.category; return rv; } );
         /* Would bind .flags to .trait_flags(), but json_trait_flag does not
          * seem to have definitions for comparison to itself.
          */

--- a/src/catalua_bindings_recipe.cpp
+++ b/src/catalua_bindings_recipe.cpp
@@ -56,9 +56,7 @@ void cata::detail::reg_recipe( sol::state &lua )
             | views::filter( [&]( const recipe & r ) { return r.has_flag( flag_name ); } )
             | ranges::to<std::vector<recipe>>();
         } );
-        luna::set_fx( ut, "get_all", []() -> std::vector<recipe> {
-            return recipe_dict | views::values | ranges::to<std::vector<recipe>>();
-        } );
+        luna::set_fx( ut, "get_all", []() -> std::vector<recipe> { return recipe_dict | views::values | ranges::to<std::vector<recipe>>(); } );
     }
 #undef UT_CLASS // #define UT_CLASS recipe
 }

--- a/src/catalua_bindings_ui.cpp
+++ b/src/catalua_bindings_ui.cpp
@@ -19,57 +19,33 @@ void cata::detail::reg_ui_elements( sol::state &lua )
                 > ()
             );
         DOC( "Sets title which is on the top line." );
-        luna::set_fx( ut, "title", []( uilist & ui, const std::string & text ) {
-            ui.title = text;
-        } );
+        luna::set_fx( ut, "title", []( uilist & ui, const std::string & text ) { ui.title = text; } );
         DOC( "Sets text which is in upper box." );
-        luna::set_fx( ut, "text", []( uilist & ui, const std::string & input ) {
-            ui.text = input;
-        } );
+        luna::set_fx( ut, "text", []( uilist & ui, const std::string & input ) { ui.text = input; } );
         DOC( "Sets footer text which is in lower box. It overwrites descs of entries unless is empty." );
-        luna::set_fx( ut, "footer", []( uilist & ui, const std::string & text ) {
-            ui.footer_text = text;
-        } );
+        luna::set_fx( ut, "footer", []( uilist & ui, const std::string & text ) { ui.footer_text = text; } );
         DOC( "Puts a lower box. Footer or entry desc appears on it." );
-        luna::set_fx( ut, "desc_enabled", []( uilist & ui, bool value ) {
-            ui.desc_enabled = value;
-        } );
+        luna::set_fx( ut, "desc_enabled", []( uilist & ui, bool value ) { ui.desc_enabled = value; } );
         DOC( "Adds an entry. `string` is its name, and `int` is what it returns. If `int` is `-1`, the number is decided orderly." );
-        luna::set_fx( ut, "add", []( uilist & ui, int retval, const std::string & text ) {
-            ui.addentry( retval, true, MENU_AUTOASSIGN, text );
-        } );
+        luna::set_fx( ut, "add", []( uilist & ui, int retval, const std::string & text ) { ui.addentry( retval, true, MENU_AUTOASSIGN, text ); } );
         DOC( "Adds an entry with desc(second `string`). `desc_enabled(true)` is required for showing desc." );
         luna::set_fx( ut, "add_w_desc", []( uilist & ui, int retval, const std::string & text,
-        const std::string & desc ) {
-            ui.addentry_desc( retval, true, MENU_AUTOASSIGN, text, desc );
-        } );
+        const std::string & desc ) { ui.addentry_desc( retval, true, MENU_AUTOASSIGN, text, desc ); } );
         DOC( "Adds an entry with desc and col(third `string`). col is additional text on the right of the entry name." );
         luna::set_fx( ut, "add_w_col", []( uilist & ui, int retval, const std::string & text,
-        const std::string & desc, const std::string col ) {
-            ui.addentry_col( retval, true, MENU_AUTOASSIGN, text, col, desc );
-        } );
+        const std::string & desc, const std::string col ) { ui.addentry_col( retval, true, MENU_AUTOASSIGN, text, col, desc ); } );
         DOC( "Entries from uilist. Remember, in lua, the first element of vector is `entries[1]`, not `entries[0]`." );
         luna::set( ut, "entries", &uilist::entries );
         DOC( "Changes the color. Default color is `c_magenta`." );
-        luna::set_fx( ut, "border_color", []( uilist & ui, color_id col ) {
-            ui.border_color = get_all_colors().get( col );
-        } );
+        luna::set_fx( ut, "border_color", []( uilist & ui, color_id col ) { ui.border_color = get_all_colors().get( col ); } );
         DOC( "Changes the color. Default color is `c_light_gray`." );
-        luna::set_fx( ut, "text_color", []( uilist & ui, color_id col ) {
-            ui.text_color = get_all_colors().get( col );
-        } );
+        luna::set_fx( ut, "text_color", []( uilist & ui, color_id col ) { ui.text_color = get_all_colors().get( col ); } );
         DOC( "Changes the color. Default color is `c_green`." );
-        luna::set_fx( ut, "title_color", []( uilist & ui, color_id col ) {
-            ui.title_color = get_all_colors().get( col );
-        } );
+        luna::set_fx( ut, "title_color", []( uilist & ui, color_id col ) { ui.title_color = get_all_colors().get( col ); } );
         DOC( "Changes the color. Default color is `h_white`." );
-        luna::set_fx( ut, "hilight_color", []( uilist & ui, color_id col ) {
-            ui.hilight_color = get_all_colors().get( col );
-        } );
+        luna::set_fx( ut, "hilight_color", []( uilist & ui, color_id col ) { ui.hilight_color = get_all_colors().get( col ); } );
         DOC( "Changes the color. Default color is `c_light_green`." );
-        luna::set_fx( ut, "hotkey_color", []( uilist & ui, color_id col ) {
-            ui.hotkey_color = get_all_colors().get( col );
-        } );
+        luna::set_fx( ut, "hotkey_color", []( uilist & ui, color_id col ) { ui.hotkey_color = get_all_colors().get( col ); } );
         DOC( "Returns retval for selected entry, or a negative number on fail/cancel" );
         luna::set_fx( ut, "query", []( uilist & ui ) {
             ui.query();
@@ -93,9 +69,7 @@ void cata::detail::reg_ui_elements( sol::state &lua )
         DOC( "Entry text of column." );
         luna::set( ut, "ctxt",  &uilist_entry::ctxt );
         DOC( "Entry text color. Its default color is `c_red_red`, which makes color of the entry same as what `uilist` decides. So if you want to make color different, choose one except `c_red_red`." );
-        luna::set_fx( ut, "txt_color", []( uilist_entry & ui_entry, color_id col ) {
-            ui_entry.text_color = get_all_colors().get( col );
-        } );
+        luna::set_fx( ut, "txt_color", []( uilist_entry & ui_entry, color_id col ) { ui_entry.text_color = get_all_colors().get( col ); } );
     }
 
     {
@@ -107,20 +81,12 @@ void cata::detail::reg_ui_elements( sol::state &lua )
                 query_popup()
                 > ()
             );
-        luna::set_fx( ut, "message", []( query_popup & popup, sol::variadic_args va ) {
-            popup.message( "%s", cata::detail::fmt_lua_va( va ) );
-        } );
-        luna::set_fx( ut, "message_color", []( query_popup & popup, color_id col ) {
-            popup.default_color( get_all_colors().get( col ) );
-        } );
+        luna::set_fx( ut, "message", []( query_popup & popup, sol::variadic_args va ) { popup.message( "%s", cata::detail::fmt_lua_va( va ) ); } );
+        luna::set_fx( ut, "message_color", []( query_popup & popup, color_id col ) { popup.default_color( get_all_colors().get( col ) ); } );
         DOC( "Set whether to allow any key" );
-        luna::set_fx( ut, "allow_any_key", []( query_popup & popup, bool val ) {
-            popup.allow_anykey( val );
-        } );
+        luna::set_fx( ut, "allow_any_key", []( query_popup & popup, bool val ) { popup.allow_anykey( val ); } );
         DOC( "Returns selected action" );
-        luna::set_fx( ut, "query", []( query_popup & popup ) {
-            return popup.query().action;
-        } );
+        luna::set_fx( ut, "query", []( query_popup & popup ) { return popup.query().action; } );
         DOC( "Returns `YES` or `NO`. If ESC pressed, returns `NO`." );
         luna::set_fx( ut, "query_yn", []( query_popup & popup ) {
             return popup
@@ -152,13 +118,9 @@ void cata::detail::reg_ui_elements( sol::state &lua )
                 > ()
             );
         DOC( "`title` is on the left of input field." );
-        luna::set_fx( ut, "title", []( string_input_popup & sipop, const std::string & text ) {
-            sipop.title( text );
-        } );
+        luna::set_fx( ut, "title", []( string_input_popup & sipop, const std::string & text ) { sipop.title( text ); } );
         DOC( "`desc` is above input field." );
-        luna::set_fx( ut, "desc", []( string_input_popup & sipop, const std::string & text ) {
-            sipop.description( text );
-        } );
+        luna::set_fx( ut, "desc", []( string_input_popup & sipop, const std::string & text ) { sipop.description( text ); } );
         DOC( "Returns your input." );
         luna::set_fx( ut, "query_str", []( string_input_popup & sipop ) {
             sipop.only_digits( false );


### PR DESCRIPTION

## Purpose of change (The Why)

```diff
-        luna::set_fx( ut, "is_filthy", []() {
-            return false;
-        } );
+        luna::set_fx( ut, "is_filthy", []() { return false; } );
```

now that we've got #6573, save that vertical space!

## Describe the solution (The How)

check individual commits

## Describe alternatives you've considered

be verbose and unhappy

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/29da1de3-30c3-4168-b2c8-535e9407038a" />

seems to work normally

## Additional context

i hate astyle so much why are we always burdened with our choices of the past aaaaaaaaaaa

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

