### PR TITLE
feat: `on_character_reset_stats` lua hook

### DIFF
--- a/data/mods/speedydex/main.lua
+++ b/data/mods/speedydex/main.lua
@@ -1,0 +1,41 @@
+gdebug.log_info("SpeedyDex: main")
+local mod = game.mod_runtime[game.current_mod]
+
+---@class SpeedyDexStorage
+---@field additional_moves_per_dex number
+---@field min_required_dex number
+---@field allow_negative_bonus boolean
+local storage = game.mod_storage[game.current_mod]
+
+mod.storage = storage
+
+---CONFIGURATION
+---Default: for every level above 10 dexterity, the player gains 2 moves. Negative bonuses are not allowed.
+storage.min_required_dex = 10 -- The minimum dex required for bonus to kick in
+storage.additional_moves_per_dex = 2 -- The amount of moves gained per dex above the minimum
+storage.allow_negative_bonus = false
+
+---Applies SpeedyDex speed bonus to the player every turn.
+function mod.speedydex()
+  local player = gapi.get_avatar()
+
+  local dex = player:get_dex()
+  local bonus = mod.calc_speedydex_bonus(dex)
+
+  gdebug.log_info("SpeedyDex: dex = " .. dex .. ", bonus = " .. bonus)
+  player:mod_speed_bonus(bonus)
+end
+
+---Calculate speed bonus from dexterity value.
+---@param dex number
+---@return number
+mod.calc_speedydex_bonus = function(dex)
+  ---@diagnostic disable-next-line: unnecessary-if
+  -- do negative bonus if allowed
+  if storage.allow_negative_bonus and dex < storage.min_required_dex then
+    return (storage.min_required_dex - dex) * storage.additional_moves_per_dex
+  else
+    local modified_dex = math.max(dex - storage.min_required_dex, 0)
+    return modified_dex * storage.additional_moves_per_dex
+  end
+end

--- a/data/mods/speedydex/preload.lua
+++ b/data/mods/speedydex/preload.lua
@@ -1,36 +1,6 @@
-gdebug.log_info("SpeedyDex: Lua loaded")
+gdebug.log_info("SpeedyDex: Preload")
 
 ---@class ModSpeedyDex
 local mod = game.mod_runtime[game.current_mod]
 
----CONFIGURATION
----Default: for every level above 10 dexterity, the player gains 2 moves. Negative bonuses are not allowed.
-local SPEEDYDEX_MIN_DEX = 10 -- The minimum dex required for bonus to kick in
-local SPEEDYDEX_DEX_SPEED = 2 -- The amount of moves gained per dex above the minimum
-local allow_negative_bonus = false
-
----Calculate speed bonus from dexterity value.
----@param dex number
----@return number
-local function calc_speedydex_bonus(dex)
-  -- do negative bonus if allowed
-  if allow_negative_bonus and dex < SPEEDYDEX_MIN_DEX then
-    return (SPEEDYDEX_MIN_DEX - dex) * SPEEDYDEX_DEX_SPEED
-  else
-    local modified_dex = math.max(dex - SPEEDYDEX_MIN_DEX, 0)
-    return modified_dex * SPEEDYDEX_DEX_SPEED
-  end
-end
-
----Applies SpeedyDex speed bonus to the player every turn.
-function mod.speedydex()
-  local player = gapi.get_avatar()
-
-  local dex = player:get_dex()
-  local bonus = calc_speedydex_bonus(dex)
-
-  player:mod_speed_bonus(bonus)
-end
-
--- Register to run every game turn.
-gapi.add_on_every_x_hook(TimeDuration.new().from_turns(1), mod.speedydex)
+table.insert(game.hooks.on_character_reset_stats, mod.speedydex)

--- a/docs/en/mod/lua/reference/lua.md
+++ b/docs/en/mod/lua/reference/lua.md
@@ -6650,6 +6650,11 @@ Function `()`
 Called right after game has loaded
 Function `()`
 
+#### on_character_reset_stats
+
+Called when character stat gets reset
+Function `()`
+
 #### on_every_x
 
 Called every in-game period

--- a/docs/en/mod/lua/tutorial/modding.md
+++ b/docs/en/mod/lua/tutorial/modding.md
@@ -134,13 +134,15 @@ details.
 Most of necessary data and game runtime state is available through global `game` table. It has the
 following members:
 
-game.current_mod Id of mod that's being loaded (available only when script is executed)
-game.active_mods List of active world mods, in load order game.mod_runtime.<mod_id> Runtime data for
-mods (each mod gets its own table named after its id) game.mod_storage.<mod_id> Per-mod storage that
-gets automatically saved/loaded on game save/load. game.cata_internal For internal game purposes,
-please don't use this game.hooks.<hook_id> Hooks exposed to Lua scripts, will be called on
-corresponding events game.iuse.<iuse_id> Item use functions that will be recognized by the item
-factory and called on item use
+| Variable                    | Description                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------- |
+| `game.current_mod`          | Id of mod that's being loaded (available only when script is executed)                |
+| `game.active_mods`          | List of active world mods, in load order                                              |
+| `game.mod_runtime.<mod_id>` | Runtime data for mods (each mod gets its own table named after its id)                |
+| `game.mod_storage.<mod_id>` | Per-mod storage that gets automatically saved/loaded on game save/load                |
+| `game.cata_internal`        | For internal game purposes, please don't use this                                     |
+| `game.hooks.<hook_id>`      | Hooks exposed to Lua scripts, will be called on corresponding events                  |
+| `game.iuse.<iuse_id>`       | Item use functions that will be recognized by the item factory and called on item use |
 
 ### Game Bindings
 

--- a/lua_annotations.lua
+++ b/lua_annotations.lua
@@ -1721,6 +1721,7 @@ gdebug = {}
 
 --- Documentation for hooks
 ---@class hooks
+---@field on_character_reset_stats fun() @Called when character stat gets reset
 ---@field on_every_x fun() @Called every in-game period
 ---@field on_game_load fun() @Called right after game has loaded
 ---@field on_game_save fun() @Called when game is about to save

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -649,6 +649,8 @@ void cata::detail::reg_hooks_examples( sol::state &lua )
     luna::set_fx( lib, "on_game_save", []() {} );
     DOC( "Called right after game has loaded" );
     luna::set_fx( lib, "on_game_load", []() {} );
+    DOC( "Called when character stat gets reset" );
+    luna::set_fx( lib, "on_character_reset_stats", []() {} );
     DOC( "Called every in-game period" );
     luna::set_fx( lib, "on_every_x", []() {} );
     DOC( "Called right after mapgen has completed. "

--- a/src/catalua_hooks.cpp
+++ b/src/catalua_hooks.cpp
@@ -1,0 +1,29 @@
+#include "catalua_hooks.h"
+#include "catalua_impl.h"
+#include "catalua_sol.h"
+
+namespace cata
+{
+
+constexpr auto hook_names = std::array
+{
+    "on_game_load",
+    "on_game_save",
+    "on_mapgen_postprocess",
+};
+
+void define_hooks( lua_state &state )
+{
+    sol::state &lua = state.lua;
+    sol::table hooks = lua.create_table();
+
+    // Main game data table
+    sol::table gt = lua.globals()["game"];
+    gt["hooks"] = hooks;
+
+    for( const auto &hook : hook_names ) {
+        hooks[hook] = lua.create_table();
+    }
+}
+
+} // namespace cata

--- a/src/catalua_hooks.cpp
+++ b/src/catalua_hooks.cpp
@@ -9,6 +9,7 @@ constexpr auto hook_names = std::array
 {
     "on_game_load",
     "on_game_save",
+    "on_character_reset_stats",
     "on_mapgen_postprocess",
 };
 

--- a/src/catalua_hooks.h
+++ b/src/catalua_hooks.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string_view>
+
+class lua_state;
+
+namespace cata
+{
+
+/// Run Lua hooks registered with given name.
+/// an empty table needs to be initialized in `init_global_state_tables` first.
+void run_hooks( std::string_view hooks_table );
+
+/// Define all hooks that are used in the game.
+void define_hooks( lua_state &state );
+
+} // namespace cata

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -3,6 +3,7 @@
 #include "avatar.h"
 #include "bionics.h"
 #include "calendar.h"
+#include "catalua_hooks.h"
 #include "character_effects.h"
 #include "character_functions.h"
 #include "character_stat.h"
@@ -813,6 +814,8 @@ void Character::reset_stats()
 
     recalc_sight_limits();
     recalc_speed_bonus();
+
+    cata::run_hooks( "on_character_reset_stats" );
 }
 
 void Character::environmental_revert_effect()

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -707,9 +707,9 @@ void Character::reset_stats()
     }
 
     // Dodge-related effects
-    mod_dodge_bonus( mabuff_dodge_bonus() -
-                     ( encumb( body_part_leg_l ) + encumb( body_part_leg_r ) ) / 20.0f - encumb(
-                         body_part_torso ) / 10.0f );
+    mod_dodge_bonus( mabuff_dodge_bonus()
+                     - ( ( encumb( body_part_leg_l ) + encumb( body_part_leg_r ) ) / 20.0f )
+                     - ( encumb( body_part_torso ) / 10.0f ) );
     // Whiskers don't work so well if they're covered
     if( has_trait( trait_WHISKERS ) && !wearing_something_on( bodypart_id( "mouth" ) ) ) {
         mod_dodge_bonus( 1.5 );
@@ -799,18 +799,10 @@ void Character::reset_stats()
     int_cur = int_max + get_int_bonus();
 
     // Floor for our stats.  No stat changes should occur after this!
-    if( dex_cur < 0 ) {
-        dex_cur = 0;
-    }
-    if( str_cur < 0 ) {
-        str_cur = 0;
-    }
-    if( per_cur < 0 ) {
-        per_cur = 0;
-    }
-    if( int_cur < 0 ) {
-        int_cur = 0;
-    }
+    dex_cur = std::max( dex_cur, 0 );
+    str_cur = std::max( str_cur, 0 );
+    per_cur = std::max( per_cur, 0 );
+    int_cur = std::max( int_cur, 0 );
 
     recalc_sight_limits();
     recalc_speed_bonus();

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -649,6 +649,7 @@ void character_edit_menu( Character &c )
                 int value;
                 if( query_int( value, _( "Set the stat to?  Currently: %d" ), *bp_ptr ) && value >= 0 ) {
                     *bp_ptr = value;
+                    p.reset_bonuses();
                     p.reset_stats();
                 }
             }


### PR DESCRIPTION

## Purpose of change (The Why)

https://github.com/user-attachments/assets/09c6476a-2a1a-4352-a3dc-e043b193bcc4

fixes #6912

## Describe the solution (The How)

adds a new hook, `on_character_reset_stats`, which gets triggered on `character::reset_stats`

## Additional context

cc @olanti-p 

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

