### PR TITLE
fix(mods/speedydex): make speedup actually work again

### DIFF
--- a/data/mods/speedydex/preload.lua
+++ b/data/mods/speedydex/preload.lua
@@ -3,4 +3,4 @@ gdebug.log_info("SpeedyDex: Preload")
 ---@class ModSpeedyDex
 local mod = game.mod_runtime[game.current_mod]
 
-table.insert(game.hooks.on_character_reset_stats, mod.speedydex)
+table.insert(game.hooks.on_character_reset_stats, function(...) return mod.speedydex(...) end)


### PR DESCRIPTION
## Purpose of change (The Why)

#6914 not actually working due to last minute changes

## Describe the solution (The How)

`preload.lua` runs _before_ `main.lua`. unless wrapped with closure, mod.speedydex is `nil`

## Describe alternatives you've considered

screm

## Testing

1. add speedydex to world mods.
2. debug increase dex to 30
3. see that speed is increased
4. debug decrease dex to 10
5. see that speed is decreased

## Additional context


## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

