### PR TITLE
fix(balance): Make copper wire no-longer free to buy

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -192,7 +192,7 @@
     "id": "cable",
     "category": "scrap_electronics",
     "price": "20 USD",
-    "price_postapoc": "1 USD",
+    "price_postapoc": "4 USD",
     "name": { "str": "copper wire" },
     "symbol": "=",
     "color": "dark_gray",


### PR DESCRIPTION
## Purpose of change (The Why)

You could buy copper wire for free because its price was too small ($1 per 200, which means half a cent per wire, and the game presumably does not like fractions of a cent)

## Describe the solution (The How)

Set the price of copper wires to $4 per 200

## Describe alternatives you've considered

- Set it to the minimum, $2 (1 cent per wire)
- Set it to the price pre-apocalypse, $20 (10 cents per wire)

## Testing

Maths checks out to give whole cents

## Additional context

The only copper that should be free is from Ea Nasir, but we're not in Mesopotamia.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
