### PR TITLE
fix: fix log walls being unable to be finished

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1240,8 +1240,12 @@
   {
     "type": "construction",
     "id": "constr_wall_log",
-    "copy-from": "constr_wall_log_half",
+    "group": "build_log_wall",
     "//": "Step 2: Finish the log wall",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "45 m",
+    "components": [ [ [ "log", 2 ] ], [ [ "wood_structural_small", 3, "LIST" ] ] ],
     "pre_terrain": "t_wall_log_half",
     "post_terrain": "t_wall_log"
   },


### PR DESCRIPTION
## Purpose of change (The Why)

Log walls could not be finished because copy-from made them inherit a requirement for nothing to be there from the half-log-wall.

## Describe the solution (The How)

Just stop using copy-from

## Describe alternatives you've considered

- fix the copy-from

## Testing

it works on my save

## Additional context

Continuing to slowly make construction more viable for players

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
