### PR TITLE
feat: easy parametric hooks™

### DIFF
--- a/data/mods/smart_house_remotes/main.lua
+++ b/data/mods/smart_house_remotes/main.lua
@@ -46,7 +46,11 @@ end
 mod.set_remote_base = function(item, p_omt) item:set_var_tri(mod.var_base, p_omt) end
 
 -- Look for spawned remotes and bind them to given omt
-mod.on_mapgen_postprocess_hook = function(map, p_omt, when)
+---@param params OnMapgenPostprocessParams
+mod.on_mapgen_postprocess_hook = function(params)
+  local map = params.map
+  local p_omt = params.omt
+
   local mapsize = map:get_map_size()
   local item_id = mod.item_id
   for y = 0, mapsize - 1 do

--- a/data/mods/speedydex/main.lua
+++ b/data/mods/speedydex/main.lua
@@ -23,7 +23,7 @@ mod.speedydex = function(params)
   local dex = character:get_dex()
   local bonus = mod.calc_speedydex_bonus(dex)
 
---   gdebug.log_info(character:get_name() .. "{dex: " .. dex .. " bonus: " .. bonus .. "}")
+  --   gdebug.log_info(character:get_name() .. "{dex: " .. dex .. " bonus: " .. bonus .. "}")
   character:mod_speed_bonus(bonus)
 end
 

--- a/data/mods/speedydex/main.lua
+++ b/data/mods/speedydex/main.lua
@@ -16,14 +16,15 @@ storage.additional_moves_per_dex = 2 -- The amount of moves gained per dex above
 storage.allow_negative_bonus = false
 
 ---Applies SpeedyDex speed bonus to the player every turn.
-function mod.speedydex()
-  local player = gapi.get_avatar()
+---@param params { character: Character }
+mod.speedydex = function(params)
+  local character = params.character
 
-  local dex = player:get_dex()
+  local dex = character:get_dex()
   local bonus = mod.calc_speedydex_bonus(dex)
 
-  gdebug.log_info("SpeedyDex: dex = " .. dex .. ", bonus = " .. bonus)
-  player:mod_speed_bonus(bonus)
+--   gdebug.log_info(character:get_name() .. "{dex: " .. dex .. " bonus: " .. bonus .. "}")
+  character:mod_speed_bonus(bonus)
 end
 
 ---Calculate speed bonus from dexterity value.

--- a/data/mods/speedydex/main.lua
+++ b/data/mods/speedydex/main.lua
@@ -16,7 +16,7 @@ storage.additional_moves_per_dex = 2 -- The amount of moves gained per dex above
 storage.allow_negative_bonus = false
 
 ---Applies SpeedyDex speed bonus to the player every turn.
----@param params { character: Character }
+---@param params OnCharacterResetStatsParams
 mod.speedydex = function(params)
   local character = params.character
 

--- a/data/mods/speedydex/modinfo.json
+++ b/data/mods/speedydex/modinfo.json
@@ -3,7 +3,7 @@
     "type": "MOD_INFO",
     "id": "speedydex",
     "name": "SpeedyDex",
-    "authors": [ "KorGgenT", "Kota" ],
+    "authors": [ "KorGgenT", "Kota", "scarf005" ],
     "description": "Higher dex increases your speed.",
     "category": "rebalance",
     "lua_api_version": 2,

--- a/data/raw/generate_types.lua
+++ b/data/raw/generate_types.lua
@@ -306,6 +306,16 @@ doc_gen_func.impl = function()
 ---@field current_mod_path string
 ---@field cata_internal table
 game = {}
+
+---@class OnCharacterResetStatsParams
+---@field character Character
+on_character_reset_stats = {}
+
+---@class OnMapgenPostprocessParams
+---@field map Map
+---@field omt Tripoint
+---@field when TimePoint
+on_mapgen_postprocess = {}
 ]]
 
   ---@diagnostic disable-next-line: undefined-global

--- a/lua_annotations.lua
+++ b/lua_annotations.lua
@@ -12,6 +12,16 @@
 ---@field current_mod_path string
 ---@field cata_internal table
 game = {}
+
+---@class OnCharacterResetStatsParams
+---@field character Character
+on_character_reset_stats = {}
+
+---@class OnMapgenPostprocessParams
+---@field map Map
+---@field omt Tripoint
+---@field when TimePoint
+on_mapgen_postprocess = {}
 --================---- Classes ----================
 
 ---@class ActivityTypeId

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -263,35 +263,26 @@ void run_mod_main_script( lua_state &state, const mod_id &mod )
     run_lua_script( state.lua, script_path );
 }
 
-template<typename... Args>
-static void run_hooks_impl( lua_state &state, std::string_view hooks_table, Args &&...args )
+void run_hooks( std::string_view hook_name )
 {
-    sol::state &lua = state.lua;
-    sol::table hooks = lua.globals()["game"]["hooks"][hooks_table];
-    for( auto &ref : hooks ) {
-        int idx = -1;
-        try {
-            idx = ref.first.as<int>();
-            sol::protected_function func = ref.second;
-            sol::protected_function_result res = func( std::forward<Args>( args )... );
-            check_func_result( res );
-        } catch( std::runtime_error &e ) {
-            debugmsg( "Failed to run hook %s[%d]: %s", hooks_table, idx, e.what() );
-            break;
-        }
-    }
+    lua_state &state = *DynamicDataLoader::get_instance().lua;
+    run_hooks( state, hook_name, []( sol::table & ) {} );
 }
-
-void run_hooks( std::string_view hooks_table )
+void run_hooks( lua_state &state, std::string_view hook_name )
 {
-    run_hooks_impl( *DynamicDataLoader::get_instance().lua, hooks_table );
+    run_hooks( state, hook_name, []( sol::table & ) {} );
 }
-
-void run_hooks( std::string_view hooks_table,
+void run_hooks( std::string_view hook_name,
                 std::function < auto( sol::table &params ) -> void > init )
 {
-    sol::state &lua = DynamicDataLoader::get_instance().lua->lua;
-    sol::table hooks = lua.globals()["game"]["hooks"][hooks_table];
+    lua_state &state = *DynamicDataLoader::get_instance().lua;
+    run_hooks( state, hook_name, init );
+}
+void run_hooks( lua_state &state, std::string_view hook_name,
+                std::function < auto( sol::table &params ) -> void > init )
+{
+    sol::state &lua = state.lua;
+    sol::table hooks = lua.globals()["game"]["hooks"][hook_name];
 
     auto params = lua.create_table();
     init( params );
@@ -301,10 +292,10 @@ void run_hooks( std::string_view hooks_table,
         try {
             idx = ref.first.as<int>();
             sol::protected_function func = ref.second;
-            sol::protected_function_result res = func(params );
+            sol::protected_function_result res = func( params );
             check_func_result( res );
         } catch( std::runtime_error &e ) {
-            debugmsg( "Failed to run hook %s[%d]: %s", hooks_table, idx, e.what() );
+            debugmsg( "Failed to run hook %s[%d]: %s", hook_name, idx, e.what() );
             break;
         }
     }
@@ -377,18 +368,22 @@ void lua_state_deleter::operator()( lua_state *state ) const
 
 void run_on_game_save_hooks( lua_state &state )
 {
-    run_hooks_impl( state, "on_game_save" );
+    run_hooks( state, "on_game_save" );
 }
 
 void run_on_game_load_hooks( lua_state &state )
 {
-    run_hooks_impl( state, "on_game_load" );
+    run_hooks( state, "on_game_load" );
 }
 
 void run_on_mapgen_postprocess_hooks( lua_state &state, map &m, const tripoint &p,
                                       const time_point &when )
 {
-    run_hooks_impl( state, "on_mapgen_postprocess", m, p, when );
+    run_hooks( state, "on_mapgen_postprocess", [&]( sol::table & params ) {
+        params["map"] = &m;
+        params["omt"] = p;
+        params["when"] = when;
+    } );
 }
 
 } // namespace cata

--- a/src/catalua_hooks.h
+++ b/src/catalua_hooks.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <functional>
 #include <string_view>
+
+#include "catalua_sol.h"
 
 class lua_state;
 
@@ -10,6 +13,13 @@ namespace cata
 /// Run Lua hooks registered with given name.
 /// an empty table needs to be initialized in `init_global_state_tables` first.
 void run_hooks( std::string_view hooks_table );
+
+/// Run Lua hooks registered with given name.
+/// an empty table needs to be initialized in `init_global_state_tables` first.
+///
+/// To pass parameters to the hook, use `init` function and set values to table.
+void run_hooks( std::string_view hooks_table,
+                std::function < auto( sol::table &params ) -> void > init );
 
 /// Define all hooks that are used in the game.
 void define_hooks( lua_state &state );

--- a/src/catalua_hooks.h
+++ b/src/catalua_hooks.h
@@ -11,15 +11,17 @@ namespace cata
 {
 
 /// Run Lua hooks registered with given name.
-/// an empty table needs to be initialized in `init_global_state_tables` first.
-void run_hooks( std::string_view hooks_table );
-
-/// Run Lua hooks registered with given name.
-/// an empty table needs to be initialized in `init_global_state_tables` first.
+/// Register hooks with an empty table in `init_global_state_tables` first.
 ///
-/// To pass parameters to the hook, use `init` function and set values to table.
-void run_hooks( std::string_view hooks_table,
+/// @param state Lua state to run hooks in. Defaults to the global state.
+/// @param hooks_table Name of the hooks table to run. e.g "on_game_load".
+/// @param init Function to initialize parameter table for the hook.
+void run_hooks( lua_state &state, std::string_view hook_name,
                 std::function < auto( sol::table &params ) -> void > init );
+void run_hooks( std::string_view hook_name,
+                std::function < auto( sol::table &params ) -> void > init );
+void run_hooks( lua_state &state, std::string_view hook_name );
+void run_hooks( std::string_view hook_name );
 
 /// Define all hooks that are used in the game.
 void define_hooks( lua_state &state );

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -807,7 +807,7 @@ void Character::reset_stats()
     recalc_sight_limits();
     recalc_speed_bonus();
 
-    cata::run_hooks( "on_character_reset_stats" );
+    cata::run_hooks( "on_character_reset_stats", [this]( auto & params ) { params["character"] = this; } );
 }
 
 void Character::environmental_revert_effect()


### PR DESCRIPTION
## Purpose of change (The Why)

https://github.com/user-attachments/assets/bb9c7076-2ad8-4763-84dd-92b2db6aed2e

> "you have a sandevistan?!"
> "a rudimentary implant."

1. `on_game_save_hooks` didn't pass which character was calling hooks, so NPCs with high dex didn't get speed bonus.
2. variadic templates take a long to compile, whereas passing param-setter fn approach is less compilation-time heavy due to being non-generic.
3. named parameters are a good way to type and document parameters.

## Describe the solution (The How)

please check individual commits.

## Describe alternatives you've considered

## Testing

1. enable speedydex
2. spawn a NPC
3. give them dex 1000
4. confirm that NPC is way faster than you

## Additional context

this may or may not affect performance in a negative way.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
