### PR TITLE
feat: bind `item::{,de}activate`

### DIFF
--- a/docs/en/mod/lua/reference/lua.md
+++ b/docs/en/mod/lua/reference/lua.md
@@ -2641,6 +2641,14 @@ Function `( Item ) -> bool`
 
 Function `( Item ) -> bool`
 
+#### activate
+
+Function `( Item )`
+
+#### deactivate
+
+Function `( Item )`
+
 #### is_melee
 
 Is this item an effective melee weapon for the given damage type?

--- a/lua_annotations.lua
+++ b/lua_annotations.lua
@@ -674,6 +674,7 @@ function FurnRaw.new() end
 
 ---@class Item
 ---@field charges integer
+---@field activate fun(arg1: Item)
 ---@field add_item_with_id fun(arg1: Item, arg2: ItypeId, arg3: integer) @Adds an item(s) to contents
 ---@field add_technique fun(arg1: Item, arg2: MartialArtsTechniqueId) @Adds the technique. It isn't treated original, but additional.
 ---@field ammo_capacity fun(arg1: Item, arg2: boolean): integer @Gets the maximum capacity of a magazine
@@ -690,6 +691,7 @@ function FurnRaw.new() end
 ---@field convert fun(arg1: Item, arg2: ItypeId) @Converts the item as given `ItypeId`.
 ---@field covers fun(arg1: Item, arg2: BodyPartTypeIntId): boolean @Checks if the item covers a bodypart
 ---@field current_magazine fun(arg1: Item): Item @Gets the current magazine
+---@field deactivate fun(arg1: Item)
 ---@field display_name fun(arg1: Item, arg2: integer): string @Display name with all bells and whistles like ammo and prefixes
 ---@field energy_remaining fun(arg1: Item): Energy
 ---@field erase_var fun(arg1: Item, arg2: string) @Erase variable

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -327,6 +327,9 @@ void cata::detail::reg_item( sol::state &lua )
         luna::set_fx( ut, "is_active", &item::is_active );
         luna::set_fx( ut, "is_upgrade", &item::is_upgrade );
 
+        luna::set_fx( ut, "activate", &item::activate );
+        luna::set_fx( ut, "deactivate", &item::deactivate );
+
         DOC( "Is this item an effective melee weapon for the given damage type?" );
         luna::set_fx( ut, "is_melee", sol::resolve<bool( damage_type ) const>
                       ( &item::is_melee ) );


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #6868

## Testing

<img width="1410" height="1570" alt="Cataclysm: Bright Nights - 658ea00b7ed_01" src="https://github.com/user-attachments/assets/da97a85f-fe1b-4afd-a606-710ceb7fe8f6" />

1. become debug invincible
2. spawn and spawn grenades
3. run following lua script:

```lua
local grenade_id = ItypeId.new("grenade")
local grenade_act_id = ItypeId.new("grenade_act")
local u = gapi.get_avatar()
local items = u:all_items(false)
for _, v in pairs(items) do
    v:convert(grenade_id)
    if v:get_type() == grenade_id then
        gdebug.log_info( v:get_type(), grenade_act_id)    
        v:convert(grenade_act_id)
        v:activate()
    end
end
```

3. congratulations! you have now become a grenade person

## Additional context

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/c8c9ee6c-7565-4e35-95a4-ab1de59f85e0" />

not to be confused with kevin _granade_

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This PR modifies BN's lua API.
  - [x] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
