### PR TITLE
ci: fix clang-tidy build

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -47,8 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CMAKE: 1
-      CLANG: /usr/bin/clang++-19
-      COMPILER: /usr/bin/clang++-19
+      CLANG: /usr/bin/clang++-20
+      COMPILER: /usr/bin/clang++-20
       TILES: 1
       SOUND: 1
       BUILD_PATH: "build"
@@ -70,7 +70,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh
           sudo ./llvm.sh $VERSION all
-          for bin in clang clang++ clang-format clang-tidy run-clang-tidy; do
+          for bin in clang clang++ clang-format clang-tidy run-clang-tidy llvm-config; do
             sudo update-alternatives --install /usr/bin/$bin $bin /usr/bin/$bin-$VERSION 200
           done
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -28,22 +28,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  skip-duplicates:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          cancel_others: "true"
-          paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/**", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]'
   build:
-    needs: skip-duplicates
-    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
-
     runs-on: ubuntu-latest
     env:
       CMAKE: 1


### PR DESCRIPTION
fixes recently broken clang-tidy pipeline. tested on https://github.com/scarf005/Cataclysm-BN/actions/runs/16849645093/job/47733952037