### PR TITLE
feat: port nested categories

### DIFF
--- a/data/json/recipes/recipes.json
+++ b/data/json/recipes/recipes.json
@@ -3,7 +3,7 @@
     "type": "recipe_category",
     "id": "CC_*",
     "//": "This is just a dummy category. No recipes should be added in here.",
-    "recipe_subcategories": [ "CSC_*_FAVORITE", "CSC_*_RECENT", "CSC_*_HIDDEN" ]
+    "recipe_subcategories": [ "CSC_*_FAVORITE", "CSC_*_RECENT", "CSC_*_HIDDEN", "CSC_*_NESTED" ]
   },
   {
     "type": "recipe_category",

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <map>
 #include <memory>
 #include <type_traits>
 
@@ -206,6 +207,12 @@ class list_circularizer
         T &cur() const {
             // list could be null, but it would be a design time mistake and really, the callers fault.
             return ( *_list )[_index];
+        }
+
+        void set_index( const size_t new_index ) {
+            if( new_index < _list->size() ) {
+                _index = new_index;
+            }
         }
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -390,6 +390,7 @@ void DynamicDataLoader::initialize()
     add( "recipe_category", &load_recipe_category );
     add( "recipe",  &recipe_dictionary::load_recipe );
     add( "uncraft", &recipe_dictionary::load_uncraft );
+    add( "nested_category", &recipe_dictionary::load_nested_category );
     add( "recipe_group",  &recipe_group::load );
 
     add( "tool_quality", &quality::load_static );

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -104,6 +104,8 @@ class recipe
         /// @returns The name (@ref item::nname) of the resulting item (@ref result).
         std::string result_name() const;
 
+        std::string nested_name;
+
         std::map<itype_id, int> byproducts;
 
         skill_id skill_used;
@@ -112,6 +114,7 @@ class recipe
         std::map<skill_id, int> autolearn_requirements; // Skill levels required to autolearn
         std::map<skill_id, int> learn_by_disassembly; // Skill levels required to learn by disassembly
         std::map<itype_id, int> booksets; // Books containing this recipe, and the skill level required
+        std::set<recipe_id> nested_category_data; // Parameters for nested categories
         std::set<flag_id> flags_to_delete; // Flags to delete from the resultant item.
 
         // Create a string list to describe the skill requirements for this recipe
@@ -160,6 +163,8 @@ class recipe
 
         /** Returns a non-empty string describing an inconsistency (if any) in the recipe. */
         std::string get_consistency_error() const;
+
+        bool is_nested() const;
 
         bool hot_result() const;
 

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -158,6 +158,22 @@ std::vector<const recipe *> recipe_subset::recent() const
 
     return res;
 }
+
+
+std::vector<const recipe *> recipe_subset::nested() const
+{
+    std::vector<const recipe *> res;
+
+    std::copy_if( recipes.begin(), recipes.end(), std::back_inserter( res ), [&]( const recipe * r ) {
+        if( !*r || r->obsolete ) {
+            return false;
+        }
+        return uistate.nested_recipes.find( r->ident() ) != uistate.nested_recipes.end();
+    } );
+
+    return res;
+}
+
 std::vector<const recipe *> recipe_subset::search( const std::string &txt,
         const search_type key ) const
 {
@@ -256,6 +272,8 @@ bool recipe_subset::empty_category( const std::string &cat, const std::string &s
         return uistate.recent_recipes.empty();
     } else if( subcat == "CSC_*_HIDDEN" ) {
         return uistate.hidden_recipes.empty();
+    } else if( subcat == "CSC_*_NESTED" ) {
+        return uistate.nested_recipes.empty();
     }
 
     auto iter = category.find( cat );
@@ -311,6 +329,11 @@ void recipe_dictionary::load_recipe( const JsonObject &jo, const std::string &sr
 void recipe_dictionary::load_uncraft( const JsonObject &jo, const std::string &src )
 {
     load( jo, src, recipe_dict.uncraft );
+}
+
+void recipe_dictionary::load_nested_category( const JsonObject &jo, const std::string &src )
+{
+    load( jo, src, recipe_dict.recipes );
 }
 
 recipe &recipe_dictionary::load( const JsonObject &jo, const std::string &src,

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -42,6 +42,7 @@ class recipe_dictionary
         static const recipe &get_uncraft( const itype_id &id );
 
         static void load_recipe( const JsonObject &jo, const std::string &src );
+        static void load_nested_category( const JsonObject &jo, const std::string &src );
         static void load_uncraft( const JsonObject &jo, const std::string &src );
 
         static void finalize();
@@ -143,6 +144,9 @@ class recipe_subset
 
         /** Find hidden recipes */
         std::vector<const recipe *> hidden() const;
+
+        /** Find current nested recipes */
+        std::vector<const recipe *> nested() const;
 
         /** Find recipes matching query (left anchored partial matches are supported) */
         std::vector<const recipe *> search( const std::string &txt,

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -137,6 +137,7 @@ class uistatedata
 
         std::set<recipe_id> hidden_recipes;
         std::set<recipe_id> favorite_recipes;
+        std::set<recipe_id> nested_recipes; // NOLINT(cata-serialize)
         std::vector<recipe_id> recent_recipes;
 
         std::set<construction_group_str_id> favorite_construct_recipes;


### PR DESCRIPTION
## Purpose of change (The Why)
Player QOL. The crafting menu can be annoying to navigate and find recipes quickly. This helps to group them more finely than just armor/foods/etc.
## Describe the solution (The How)
ports change https://github.com/CleverRaven/Cataclysm-DDA/pull/59924/ to begin allowing nested crafting categories. 

This means we can now define a nested_category, which will display in the recipe selection screen, and once selected will transfer you to the `NESTED` tab with a selection of everything from that nested category.
## Describe alternatives you've considered
porting DDA change https://github.com/CleverRaven/Cataclysm-DDA/pull/60761. This seems to be out of my skill level, as it has a bunch of prerequisite PR's that I don't know how to properly sift through and apply. (I have attempted though, to no success)

Additionally, to improve the quality of life, we could port https://github.com/CleverRaven/Cataclysm-DDA/pull/60378, https://github.com/CleverRaven/Cataclysm-DDA/pull/60683. Note that a large portion of the code changes made in these PRs are ripped out for 60701, so if we could just jump ahead and implement that, it would save a lot of time & effort.
## Testing
Created a nested_category "sandwiches" and moved the sandwich recipes under this new category. Loaded in and attempted to craft a recipe from the nested sandwiches category successfully.
## Additional context
Before merging, we need to fix the issue that nested categories display a lot of useless, irrelevant information about the item that was previously displayed. I think this may have been tackled in the original PR, and I just don't have it implemented properly?

It does seem weird to have to move these recipes out of the main list, but I think will make more sense once we get a majority of relevant items converted into nested categories.

Example nested category: (intended to be put into a new file, nested.json or a similar name for organization)
```json
[
  {
    "id": "nested_example",
    "//": "this is an example of how a nested category should be defined",
    "type": "nested_category",
    "category": "CC_FOOD",
    "subcategory": "CSC_FOOD_OTHER",
    "nested_name": "example sandwiches",
    "description": "Recipes related to constructing example sandwiches.",
    "skill_used": "fabrication",
    "nested_category_data": [
      "sandwich_t",
      "sandwich_pb",
      "sandwich_pbj",
      "sandwich_pbh",
      "sandwich_pbm",
      "sandwich_deluxe",
      "sandwich_deluxe_nocheese",
      "fish_sandwich",
      "sandwich_veggy"
    ],
    "difficulty": 0,
    "autolearn": true
  }
]
```
Additionally, each of these items needs to be moved from subcategory CSC_FOOD_VEGGI to CSC_*_NESTED.
```diff
 {
    "type": "recipe",
    "result": "sandwich_pb",
    - "category": "CC_FOOD",
    - "subcategory": "CSC_FOOD_VEGGI",
    + "category": "CC_*",
    + "subcategory": "CSC_*_NESTED",
    "skill_used": "cooking",
    "time": "1 m",
    "autolearn": true,
    "components": [ [ [ "bread_sandwich", 2, "LIST" ] ], [ [ "peanutbutter", 1 ], [ "peanutbutter_imitation", 1 ] ] ]
},
  ```

<details>
  <summary>📸 Screenshots</summary>
<img width="1290" height="384" alt="image" src="https://github.com/user-attachments/assets/f336e927-04cb-43fb-a855-7a391a81d6a8" />
<img width="1290" height="384" alt="image" src="https://github.com/user-attachments/assets/5161ef7b-5019-40c7-8013-6cd3bd6f2db4" />
</details>

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [X] This PR ports commits from DDA or other cataclysm forks.
  - [X] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [X] I have linked the URL of original PR(s) in the description.
- [X] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
<!--
please remove sections irrelevant to this PR.

- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
