### PR TITLE
feat: more guns compatible with Krav Maga

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -611,7 +611,18 @@
       "tec_krav_maga_break",
       "tec_krav_maga_counter"
     ],
-    "weapon_category": [ "PISTOLS", "REVOLVERS", "RIFLES", "SHOTGUNS", "SUBMACHINE_GUNS", "MACHINE_GUNS", "GRENADE_LAUNCHERS", "KNIVES", "BATONS", "TONFAS" ]
+    "weapon_category": [
+      "PISTOLS",
+      "REVOLVERS",
+      "RIFLES",
+      "SHOTGUNS",
+      "SUBMACHINE_GUNS",
+      "MACHINE_GUNS",
+      "GRENADE_LAUNCHERS",
+      "KNIVES",
+      "BATONS",
+      "TONFAS"
+    ]
   },
   {
     "type": "martial_art",

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -611,7 +611,7 @@
       "tec_krav_maga_break",
       "tec_krav_maga_counter"
     ],
-    "weapon_category": [ "PISTOLS", "REVOLVERS", "RIFLES", "SHOTGUNS", "KNIVES", "BATONS", "TONFAS" ]
+    "weapon_category": [ "PISTOLS", "REVOLVERS", "RIFLES", "SHOTGUNS", "SUBMACHINE_GUNS", "MACHINE_GUNS", "GRENADE_LAUNCHERS", "KNIVES", "BATONS", "TONFAS" ]
   },
   {
     "type": "martial_art",


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

More rifle adjacent/shaped guns should be usable with Krav Maga. They all buttstroke just the same.

## Describe the solution (The How)

Make the following categories applicable to Krav Maga
- SMGs - They are pretty much rifles, but smaller
- Machine guns - They are pretty much rifles, but bigger
- Grenade launchers -  They are (excluding the mark 19) rifle shaped and held the same way a rifle is

## Describe alternatives you've considered

Giving players the option to disable the "(weapon) is not a valid (martial art) weapon!" message.

## Testing

Spawned in
Beat zombies with affected weapons, krav maga style.

## Additional context

Rocket launchers, gatling guns, etc are not included in this because they are neither shaped nor held like a rifle.

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
