### PR TITLE
fix: dark, light, and psi damage not loading

### DIFF
--- a/docs/en/mod/json/reference/creatures/monsters.md
+++ b/docs/en/mod/json/reference/creatures/monsters.md
@@ -257,11 +257,13 @@ Monster dodge skill. See GAME_BALANCE.txt for an explanation of dodge mechanics.
 
 (array of objects, optional)
 
-List of damage instances added to die roll on monster melee attack. - `damage_type` valid entries
-are : "true", "biological", "bash", "cut", "acid", "stab", "heat", "cold" and "electric". - `amount`
-amount of damage. - `armor_penetration` how much of the armor the damage instance ignores. -
-`armor_multiplier` is a multiplier on `armor_penetration`. - `damage_multiplier` is a multiplier on
-`amount`.
+| Property            | Description                                                                                                                                                                 |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `damage_type`       | Type of damage. Valid entries: `"true"`, `"bash"`, `"cut"`, `"stab"`, `"bullet"`, `"biological"`, `"acid"`, `"heat"`, `"cold"`, `"dark"`, `"light"`, `"psi"`, `"electric"`. |
+| `amount`            | Amount of damage dealt.                                                                                                                                                     |
+| `armor_penetration` | Amount of armor ignored by this damage instance.                                                                                                                            |
+| `armor_multiplier`  | Multiplier applied to `armor_penetration`.                                                                                                                                  |
+| `damage_multiplier` | Multiplier applied to `amount`.                                                                                                                                             |
 
 ```json
 "melee_damage": [ { "damage_type": "electric", "amount": 4.0, "armor_penetration": 1, "armor_multiplier": 1.2, "damage_multiplier": 1.4 } ],

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -532,9 +532,9 @@ std::map<damage_type, float> load_damage_map( const JsonObject &jo )
     load_if_present( "acid", DT_ACID, non_phys ? *non_phys : init_val );
     load_if_present( "heat", DT_HEAT, non_phys ? *non_phys : init_val );
     load_if_present( "cold", DT_COLD, non_phys ? *non_phys : init_val );
-    load_if_present( "cold", DT_DARK, non_phys ? *non_phys : init_val );
-    load_if_present( "cold", DT_LIGHT, non_phys ? *non_phys : init_val );
-    load_if_present( "cold", DT_PSI, non_phys ? *non_phys : init_val );
+    load_if_present( "dark", DT_DARK, non_phys ? *non_phys : init_val );
+    load_if_present( "light", DT_LIGHT, non_phys ? *non_phys : init_val );
+    load_if_present( "psi", DT_PSI, non_phys ? *non_phys : init_val );
     load_if_present( "electric", DT_ELECTRIC, non_phys ? *non_phys : init_val );
 
     // DT_TRUE should never be resisted


### PR DESCRIPTION

## Purpose of change (The Why)

typo in #6569 unnoticed for months prevented `dark`, `light` and `psi` damages from loading because they were all mapped to `cold`

## Describe the solution (The How)

rename stuff.

## Describe alternatives you've considered

## Testing

should work?

## Additional context


## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

