### PR TITLE
refactor: use `table.insert`

### DIFF
--- a/data/mods/ebook_lua/preload.lua
+++ b/data/mods/ebook_lua/preload.lua
@@ -29,6 +29,6 @@ mod.turntimer_hook = function(turn, func)
   storage.hook_assuarance[the_when:to_turns()] = "Requiem"
 end
 
-game.hooks.on_game_load[#game.hooks.on_game_load + 1] = function(...) return mod.assure_timer_hook(...) end
+table.insert(game.hooks.on_game_load, function(...) return mod.assure_timer_hook(...) end)
 
 game.iuse_functions["LUA_EBOOK"] = function(...) return mod.ebook_ui(...) end

--- a/data/mods/saveload_lua_test/preload.lua
+++ b/data/mods/saveload_lua_test/preload.lua
@@ -2,6 +2,5 @@ gdebug.log_info("SLT: preload")
 
 local mod = game.mod_runtime[game.current_mod]
 
-game.hooks.on_game_load[#game.hooks.on_game_load + 1] = function(...) return mod.on_game_load_hook(...) end
-
-game.hooks.on_game_save[#game.hooks.on_game_save + 1] = function(...) return mod.on_game_save_hook(...) end
+table.insert(game.hooks.on_game_load, function(...) return mod.on_game_load_hook(...) end)
+table.insert(game.hooks.on_game_save, function(...) return mod.on_game_save_hook(...) end)

--- a/data/mods/smart_house_remotes/main.lua
+++ b/data/mods/smart_house_remotes/main.lua
@@ -122,7 +122,7 @@ mod.get_neighbours_at = function(opts, block, p)
   local v = opts[k]
   if v ~= nil and v.idx == block.idx then
     opts[k] = nil
-    block.points[#block.points + 1] = p
+    table.insert(block.points, p)
     if v.can_open then block.can_open_num = block.can_open_num + 1 end
     if v.can_close then block.can_close_num = block.can_close_num + 1 end
     mod.get_neighbours(opts, block, p)
@@ -218,7 +218,7 @@ mod.build_target_list = function(map, pos_omt)
     block.can_close = block.can_close_num > 0
 
     -- Add block to list
-    ret[#ret + 1] = block
+    table.insert(ret, block)
   end
 
   return ret
@@ -347,17 +347,17 @@ mod.iuse_function = function(who, item, pos)
   local transforms = mod.get_transform_list()
   for block_idx, block in pairs(targets) do
     if block.can_open then
-      sel_list[#sel_list + 1] = {
+      table.insert(sel_list, {
         block = block,
         do_open = true,
         text = transforms[block.idx].name_open .. " #" .. tostring(block_idx),
-      }
+      })
     elseif block.can_close then
-      sel_list[#sel_list + 1] = {
+      table.insert(sel_list, {
         block = block,
         do_open = false,
         text = transforms[block.idx].name_close .. " #" .. tostring(block_idx),
-      }
+      })
     end
   end
 

--- a/data/mods/smart_house_remotes/preload.lua
+++ b/data/mods/smart_house_remotes/preload.lua
@@ -6,8 +6,7 @@ gdebug.log_info("SHR: preload.")
 local mod = game.mod_runtime[game.current_mod]
 
 -- Register our map post-process hook
-game.hooks.on_mapgen_postprocess[#game.hooks.on_mapgen_postprocess + 1] =
-  function(...) return mod.on_mapgen_postprocess_hook(...) end
+table.insert(game.hooks.on_mapgen_postprocess, function(...) return mod.on_mapgen_postprocess_hook(...) end)
 
 -- Register our item use function
 game.iuse_functions["SMART_HOUSE_REMOTE"] = function(...) return mod.iuse_function(...) end

--- a/data/mods/teleportation_mod/main.lua
+++ b/data/mods/teleportation_mod/main.lua
@@ -144,7 +144,7 @@ end
 mod.add_anchor_to_list = function(pos)
   --print("adding to list")
   --print(pos)
-  mod.anchor_list[#mod.anchor_list + 1] = pos
+  table.insert(mod.anchor_list, pos)
   --print(#mod.anchor_list, pos)
   mod.save_anchor_omt()
 end

--- a/data/mods/teleportation_mod/preload.lua
+++ b/data/mods/teleportation_mod/preload.lua
@@ -12,6 +12,6 @@ game.iuse_functions["teleporter_anchor_use"] = function(...) return mod.iuse_fun
 
 game.iuse_functions["teleporter_station_use"] = function(...) return mod.iuse_function_station(...) end
 
-game.hooks.on_game_load[#game.hooks.on_game_load + 1] = function(...) return mod.on_game_load_hook(...) end
+table.insert(game.hooks.on_game_load, function(...) return mod.on_game_load_hook(...) end)
 
-game.hooks.on_game_save[#game.hooks.on_game_save + 1] = function(...) return mod.on_game_save_hook(...) end
+table.insert(game.hooks.on_game_save, function(...) return mod.on_game_save_hook(...) end)

--- a/data/raw/generate_docs.lua
+++ b/data/raw/generate_docs.lua
@@ -10,7 +10,7 @@ local sorted_by = function(t, f)
   if not f then f = function(a, b) return (a.k < b.k) end end
   local sorted = {}
   for k, v in pairs(t) do
-    sorted[#sorted + 1] = { k = k, v = v }
+    table.insert(sorted, { k = k, v = v })
   end
   table.sort(sorted, f)
   return sorted
@@ -22,7 +22,7 @@ local remove_hidden_args = function(arg_list)
     if arg == "<this_state>" then
       -- sol::this_state is only visible to C++ side
     else
-      ret[#ret + 1] = arg
+      table.insert(ret, arg)
     end
   end
   return ret

--- a/docs/en/mod/lua/tutorial/modding.md
+++ b/docs/en/mod/lua/tutorial/modding.md
@@ -177,19 +177,21 @@ new hooks by appending to the hooks table like so:
 
 ```lua
 -- In preload.lua
-local mod = game.mod_runtime[ game.current_mod ]
-game.hooks.on_game_save[ #game.hooks.on_game_save + 1 ] = function( ... )
+local mod = game.mod_runtime[game.current_mod]
+
+table.insert(game.hooks.on_game_save, function(...)
   -- This is essentially a forward declaration.
   -- We declare that the hook exists, it should be called on game_save event,
   -- but we will forward all possible arguments (even if there is none) to,
   -- and return value from, the function that we'll declare later on.
-  return mod.my_awesome_hook( ... )
-end
+  return mod.my_awesome_hook(...)
+end)
 
 -- In main.lua
-local mod = game.mod_runtime[ game.current_mod ]
+local mod = game.mod_runtime[game.current_mod]
+
 mod.my_awesome_hook = function()
-  -- Do actual work here
+  -- Do actual work herede
 end
 ```
 


### PR DESCRIPTION

## Purpose of change (The Why)

[`table.insert`](https://www.lua.org/pil/19.2.html) is the recommended and simpler way to insert element to the end of lua table.

## Describe the solution (The How)

use it

## Describe alternatives you've considered

none

## Testing

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/a9f2dcc3-9087-48f4-8320-3bd6c47eba0e" />

played with some lua mods and they all work

## Additional context


## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

