### PR TITLE
fix(mods/JP_Weather_Variants)!: rename weather region for accessibility

### DIFF
--- a/data/mods/JP_Weather_Variants/weather_regional_map_settings.json
+++ b/data/mods/JP_Weather_Variants/weather_regional_map_settings.json
@@ -1,8 +1,8 @@
 [
   {
     "type": "region_settings",
-    "//": "don't know how safe keeping this as 'default' is, so name is changed",
-    "id": "default_copy_jp_weather",
+    "//": "players don't understand they need to change regions, so we are just overwriting the default region",
+    "id": "default",
     "default_oter": "field",
     "default_groundcover": [ [ "t_region_groundcover", 1 ] ],
     "region_terrain_and_furniture": {


### PR DESCRIPTION
## Purpose of change (The Why)

I've gotten multiple reports that the mod is unintuitive to use, as a result of the region being different than default. This can only be changed at the start of a world, so this is a potentially breaking change and additionally meant anyone wanting to apply this mod to an old save was impossible (atleast, without routine maintenance)

## Describe the solution (The How)

Rename the region "default_copy_jp_weather" to "default"

## Describe alternatives you've considered
## Testing
Created a new world, loaded in and the expected weathers appeared unlike before.
## Additional context
I actually don't know if anyone has used the mod. In my testing today, I couldn't get the region in world settings to change even with the mod installed. I seem to remember doing this before and it working as expected, so unless we have somehow broken that feature since I may have been mistaken.
## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
