### PR TITLE
feat(UI): Change `transform` item action's name in the menus to be more accurate

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -172,7 +172,7 @@
   {
     "type": "item_action",
     "id": "transform",
-    "name": { "str": "Turn on" }
+    "name": { "str": "Transform" }
   },
   {
     "type": "item_action",


### PR DESCRIPTION
## Purpose of change (The Why)

Because, as finger firelighters revealed, it otherwise says "turn on" no matter what, which may not be accurate.

Also, I can't do any fancy stuff here (unlike if it was actually in C++) afaik

## Describe the solution (The How)

Just make it "Transform" instead

## Describe alternatives you've considered

- Implement the ability for the item's iuses to be able to override their names in there with a field.

## Testing

String change, I used my eyes.

## Additional context

I don't quite understand why these are in JSON to begin with if they're the names of entire categories and thus you can't give individual items different ones.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
