### PR TITLE
fix: prevent unordered parts error when spawning vehicles

### DIFF
--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1089,7 +1089,7 @@ void vehicle_prototype::finalize()
                 continue;
             }
 
-            if( blueprint.install_part( pt.pos, pt.part ) < 0 ) {
+            if( blueprint.install_part( pt.pos, pt.part, true ) < 0 ) {
                 debugmsg( "init_vehicles: '%s' part '%s'(%d) can't be installed to %d,%d",
                           blueprint.name, pt.part.c_str(),
                           blueprint.part_count(), pt.pos.x, pt.pos.y );


### PR DESCRIPTION

## Purpose of change (The Why)

<img width="772" height="252" alt="image" src="https://github.com/user-attachments/assets/e2f57440-41d4-4098-8d3d-46d7e1c47e83" />

as reported by @shmakota, vehicle parts order

## Describe the solution (The How)

when spawning vehicles, force install parts instead of checking whether they can be installed (i.e there's an neighboring attachment)

## Describe alternatives you've considered

spawned vehicles are complete by definition and shouldn't check for ordering. while it shows an (kind of) unfriendly error message when attempting to spawn a split-in-half vehicle, manually writing vehicle JSON should be discouraged in first place in favor of much intuitive and validated debug JSON vehicle export feature.

## Testing


1. messed up vehicle part order. to reproduce, open deno REPL by typing `deno` then paste following command:

```ts
import { shuffle } from "jsr:@std/random"

const heli = JSON.parse(await Deno.readTextFile("data/json/vehicles/helicopters.json"))
const parts = heli.find(obj => obj.id === "2seater2").parts
const shuffled = shuffle(parts)
console.log(JSON.stringify(shuffled))
```

it will give you shuffled list of parts.

2. start the game with last flight scenario - helicopter pilot profession.

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/3cbc93b8-bf4e-4768-ac65-feb5961b413c" />

3. was able to play normally, with helicopter spawned without bugs.
4. debug spawning heli this way also works without bugs

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

