### PR TITLE
fix: typo writ of trade

### DIFF
--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -3,7 +3,7 @@
     "id": "trade_writ_chemist",
     "type": "GENERIC",
     "name": { "str": "writ of trade (chemist)", "str_pl": "writs of trade (chemist)" },
-    "description": "A few sheets of paper from the chemist living out in the wilderness listing some of the chemical they're capable of making.",
+    "description": "A few sheets of paper from the chemist living out in the wilderness listing some of the chemicals they're capable of making.",
     "weight": "1 g",
     "volume": "5 ml",
     "price": 3000,


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

The chemist made a typo when writing out that writ of trade.
The plural form of "chemical" is "chemicals;"
given the context, multiple chemicals are implied.

## Describe the solution (The How)

s

## Describe alternatives you've considered

(s)

## Testing

spawned in
"chemicals" observed

## Additional context

I've only ever met the chemist once.
I tried to mug her but she just laughed at me.

## ChexMix

### Mandarine Laboratory

- [X] I disregarded the template because this is such a minor change