### PR TITLE
feat(balance, mods/MagicalNights): Make skeleton keys recharge

### DIFF
--- a/data/mods/MagicalNights/items/enchanted/enchanted_misc.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted_misc.json
@@ -58,6 +58,7 @@
     "material": [ "gold" ],
     "symbol": "[",
     "color": "yellow",
+    "relic_data": { "recharge_scheme": [ { "type": "time", "req": "none", "interval": "24 h", "rate": 1 } ] },
     "initial_charges": 5,
     "max_charges": 5,
     "charges_per_use": 1,


### PR DESCRIPTION
## Purpose of change (The Why)

Just getting 5 unlocks period is really lame.

## Describe the solution (The How)

Make them recharge once every 24 hours

## Describe alternatives you've considered

- Longer recharge time
- Fuel them with crystalized mana or the like

## Testing

Loaded in, picked a gun safe with the key, waited 6 hours a few times, got the charge back.

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
