### PR TITLE
fix: Chitinous Plates no longer restrict headgear

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1981,7 +1981,6 @@
       [ "foot_l", 10 ],
       [ "foot_r", 10 ]
     ],
-    "restricts_gear": [ "head" ],
     "armor": [ { "parts": "ALL", "physical": 12 } ],
     "passive_mods": { "dex_mod": -1 }
   },
@@ -2043,7 +2042,6 @@
     "prereqs": [ "CHITIN_FUR2", "CHITIN3" ],
     "threshreq": [ "THRESH_SPIDER" ],
     "category": [ "SPIDER" ],
-    "restricts_gear": [ "head" ],
     "armor": [ { "parts": "ALL", "physical": 10, "bash": 15 } ],
     "passive_mods": { "dex_mod": -1 }
   },


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Chitinous Plate and Furred Plate restrict headgear.
This doesn't make much sense that having thicker skin would preclude the use of helmets, especially when no other skin mutations have any equipment restrictions.

## Describe the solution (The How)

remove the head gear restriction

## Describe alternatives you've considered

Remember the reason why the restriction was put in place to begin with
(I can't find it if any such reason does exist)

## Testing

Spawned in
mutated Furred Plate
Put on a helmet
nothing weird happened

## Additional context

Spider-Man, Spider-Man
Does whatever a spider can!
Put on a hat? No, he can't!
Skin is too thick, helmet no fit!
Look out!
Here comes the Spider-Man!

## Checklist


### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
