### PR TITLE
fix: copy error for being hit on skate

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8933,42 +8933,31 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
     bool in_skater_vehicle = in_vehicle && veh_part.part_with_feature( "SEAT_REQUIRES_BALANCE", false );
 
     if( ( worn_with_flag( flag_REQUIRES_BALANCE ) || in_skater_vehicle ) && !is_on_ground() ) {
-        if( worn_with_flag( flag_ROLLER_ONE ) && !in_skater_vehicle ) {
-            if( worn_with_flag( flag_REQUIRES_BALANCE ) && !has_effect( effect_downed ) ) {
-                int rolls = 4;
-                if( worn_with_flag( flag_ROLLER_ONE ) ) {
-                    rolls += 2;
-                }
-                if( has_trait( trait_PROF_SKATER ) ) {
-                    rolls--;
-                }
-                if( has_trait( trait_DEFT ) ) {
-                    rolls--;
-                }
+            int rolls = 4;
+            if( worn_with_flag( flag_ROLLER_ONE ) && !in_skater_vehicle ) {
+                rolls += 2;
+            }
+            if( has_trait( trait_PROF_SKATER ) ) {
+                rolls--;
+            }
+            if( has_trait( trait_DEFT ) ) {
+                rolls--;
+            }
 
-                if( stability_roll() < dice( rolls, 10 ) ) {
-                    if( !is_player() ) {
-                        if( u_see ) {
-                            add_msg( _( "%1$s loses their balance while being hit!" ), name );
-                        }
-                    } else {
-                        add_msg( m_bad, _( "You lose your balance while being hit!" ) );
+            if( stability_roll() < dice( rolls, 10 ) ) {
+                if( !is_player() ) {
+                    if( u_see ) {
+                        add_msg( _( "%1$s loses their balance while being hit!" ), name );
                     }
-                    if( in_skater_vehicle ) {
-                        g->fling_creature( this, rng_float( 0_degrees, 360_degrees ), 10 );
-                    }
-                    // This kind of downing is not subject to immunity.
-                    add_effect( effect_downed, 2_turns, bodypart_str_id::NULL_ID(), 0, true );
+                } else {
+                    add_msg( m_bad, _( "You lose your balance while being hit!" ) );
                 }
-            } else {
-                add_msg( m_bad, _( "You lose your balance while being hit!" ) );
+                if( in_skater_vehicle ) {
+                    g->fling_creature( this, rng_float( 0_degrees, 360_degrees ), 10 );
+                }
+                // This kind of downing is not subject to immunity.
+                add_effect( effect_downed, 2_turns, bodypart_str_id::NULL_ID(), 0, true );
             }
-            if( in_skater_vehicle ) {
-                g->fling_creature( this, rng_float( 0_degrees, 360_degrees ), 10 );
-            }
-            // This kind of downing is not subject to immunity.
-            add_effect( effect_downed, 2_turns, bodypart_str_id::NULL_ID(), 0, true );
-        }
     }
     enchantment_cache->cast_hit_me( *this, source );
 }


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
Fix #5849 as intended.
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
What's fixed?

You are hit while riding skater or something:

Before:
You are NOT wearing `ROLLER_ONE` flag shoes, you NEVER get downed by being hit.
But you ARE, you get probability to be downed by being hit.
It is the only way for being downed while on wheels. This is quite strange bug.



After:
Wearing `REQUIRES_BALANCE` flag shoes becomes a little bit more **risky**.
If being hit on skate, it compares your stability(melee+STR+PER/3+DEX/4) with 4D10 (`skater` profession and `deft` trait reduces this -1 each).
If stability is lower than, you lose your balance.


<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Never wearing skates

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
<img width="667" height="408" alt="스크린샷 2025-08-13 134953" src="https://github.com/user-attachments/assets/64e3dd23-76da-408f-8709-b3320d92092a" />


<img width="852" height="508" alt="스크린샷 2025-08-13 135001" src="https://github.com/user-attachments/assets/4cf51fab-9b56-41ca-9968-5ec4bd78179b" />

OUCH

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
