### PR TITLE
feat: bind more item functions

### DIFF
--- a/docs/en/mod/lua/reference/lua.md
+++ b/docs/en/mod/lua/reference/lua.md
@@ -573,6 +573,14 @@ Function `( Character ) -> bool`
 
 Function `( Character ) -> bool`
 
+#### uncanny_dodge
+
+Function `( Character ) -> bool`
+
+#### get_melee_stamina_cost
+
+Function `( Character, Item ) -> int`
+
 #### cough
 
 Function `( Character, bool, int )`
@@ -2890,6 +2898,14 @@ Function `( Item, string, double )`
 #### set_var_tri
 
 Function `( Item, string, Tripoint )`
+
+#### attack_cost
+
+Function `( Item ) -> int`
+
+#### stamina_cost
+
+Function `( Item ) -> int`
 
 ## ItemStack
 

--- a/lua_annotations.lua
+++ b/lua_annotations.lua
@@ -172,6 +172,7 @@ function BodyPartTypeIntId.new() end
 ---@field get_kcal_percent fun(arg1: Character): number
 ---@field get_lowest_hp fun(arg1: Character): integer
 ---@field get_max_power_level fun(arg1: Character): Energy
+---@field get_melee_stamina_cost fun(arg1: Character, arg2: Item): integer
 ---@field get_morale fun(arg1: Character, arg2: MoraleTypeDataId): integer
 ---@field get_morale_level fun(arg1: Character): integer
 ---@field get_movement_mode fun(arg1: Character): CharacterMoveMode
@@ -348,6 +349,7 @@ function BodyPartTypeIntId.new() end
 ---@field sight_impaired fun(arg1: Character): boolean
 ---@field spores fun(arg1: Character)
 ---@field suffer fun(arg1: Character)
+---@field uncanny_dodge fun(arg1: Character): boolean
 ---@field unset_mutation fun(arg1: Character, arg2: MutationBranchId)
 ---@field unwield fun(arg1: Character): boolean
 ---@field volume_capacity fun(arg1: Character): Volume
@@ -685,6 +687,7 @@ function FurnRaw.new() end
 ---@field ammo_required fun(arg1: Item): integer
 ---@field ammo_set fun(arg1: Item, arg2: ItypeId, arg3: integer)
 ---@field ammo_unset fun(arg1: Item)
+---@field attack_cost fun(arg1: Item): integer
 ---@field can_contain fun(arg1: Item, arg2: Item): boolean @Checks if this item can contain another
 ---@field clear_vars fun(arg1: Item) @Erase all variables
 ---@field conductive fun(arg1: Item): boolean
@@ -786,6 +789,7 @@ function FurnRaw.new() end
 ---@field set_var_num fun(arg1: Item, arg2: string, arg3: number)
 ---@field set_var_str fun(arg1: Item, arg2: string, arg3: string)
 ---@field set_var_tri fun(arg1: Item, arg2: string, arg3: Tripoint)
+---@field stamina_cost fun(arg1: Item): integer
 ---@field tname fun(arg1: Item, arg2: integer, arg3: boolean, arg4: integer): string @Translated item name with prefixes
 ---@field total_capacity fun(arg1: Item): Volume @Gets maximum volume this item can hold (liquids, ammo, etc)
 ---@field unset_flag fun(arg1: Item, arg2: JsonFlagId)

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -237,6 +237,7 @@ void cata::detail::reg_damage_instance( sol::state &lua )
 
 void cata::detail::reg_item( sol::state &lua )
 {
+#define UT_CLASS item
     {
         sol::usertype<item> ut = luna::new_usertype<item>( lua, luna::no_bases, luna::no_constructor );
 
@@ -468,7 +469,11 @@ void cata::detail::reg_item( sol::state &lua )
                       sol::resolve<void( const std::string &, double )>( &item::set_var ) );
         luna::set_fx( ut, "set_var_tri",
                       sol::resolve<void( const std::string &, const tripoint & )>( &item::set_var ) );
+
+        SET_FX( attack_cost );
+        SET_FX( stamina_cost );
     }
+#undef UT_CLASS // #define UT_CLASS item
 }
 
 

--- a/src/catalua_bindings_creature.cpp
+++ b/src/catalua_bindings_creature.cpp
@@ -449,6 +449,10 @@ void cata::detail::reg_character( sol::state &lua )
 
         SET_FX_T( is_stealthy, bool() const );
 
+        SET_FX( uncanny_dodge );
+
+        SET_FX( get_melee_stamina_cost );
+
         SET_FX_T( cough, void( bool harmful, int loudness ) );
 
         SET_FX_T( bionic_armor_bonus, float( const bodypart_id &, damage_type ) const );


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #6952

## Testing

```lua
local you = gapi.get_avatar()
print("are you uncanny dodging? " .. (you:uncanny_dodge() and "yes" or "no"))

local items = you:all_items(false)
for _, item in pairs(items) do
  print(
    item:tname(1, false, 0) 
    .. "{ attack cost: " .. item:attack_cost() 
    .. ", stamina cost: " .. item:stamina_cost()
    .. ", melee stamina cost: " .. you:get_melee_stamina_cost(item)
    .. " }"
    )
end
```

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/2e5c1437-8134-4388-aac1-312c7415f27f" />

## Additional context

<img width="320" height="158" alt="image" src="https://github.com/user-attachments/assets/b99ea259-ac17-40da-b99e-67a82c62fecc" />

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

