### PR TITLE
fix: stop unloading disposable dab pens

### DIFF
--- a/data/json/items/tool/smoking.json
+++ b/data/json/items/tool/smoking.json
@@ -192,7 +192,6 @@
     "price": "25 USD",
     "price_postapoc": "1 USD",
     "material": "plastic",
-    "ammo": "battery",
     "max_charges": 30,
     "initial_charges": 30,
     "charges_per_use": 1,


### PR DESCRIPTION

## Purpose of change (The Why)

Disposable dab pens have 30 charges of battery that can be unloaded as free floating battery energy.

## Describe the solution (The How)

Remove battery as their ammunition

## Describe alternatives you've considered

give it that NO_UNLOAD flag

## Testing

Spawned in
I can still hit the disposable dab pen, a charge is consumed
I can no longer unload battery charges

## Additional context

none given

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.