### PR TITLE
docs: modernize C++ style guide

### DIFF
--- a/docs/en/dev/explanation/code_style.md
+++ b/docs/en/dev/explanation/code_style.md
@@ -96,12 +96,12 @@ These are less generic guidelines and more pain points we've stumbled across ove
 - Avoid adding new member methods to classes unless required.
   ```diff
   // this function does not access non-public data members or member methods in the class, and thus can be made a free function
-  - units::volume Character::volume_carried() const
+  - std::string Character::profession_description() const
   - {
-  -     return inv.volume();
+  -     return prof->description( male );
   - }
-  + auto volume_carried( const Character &c ) -> units::volume
+  + auto profession_description( const Character &c ) -> std::string
   + {
-  +     return c.inv.volume();
+  +     return c.prof->description( c.male );
   + }
   ```

--- a/docs/en/dev/explanation/code_style.md
+++ b/docs/en/dev/explanation/code_style.md
@@ -78,15 +78,15 @@ These are less generic guidelines and more pain points we've stumbled across ove
       return is_bar_ok( bar ) ? 42 : 404;
   }
   ```
-    - Use for `decltype` style generic functions
-    ```diff
-    template<typename A, typename B>
-    - decltype(std::declval<A&>() * std::declval<B&>()) multiply(A a, B b)
-    + auto multiply( A a, B b ) -> decltype( a * b )
-    {
-        return a*b;
-    }
-    ```
+  - Use for `decltype` style generic functions
+  ```diff
+  template<typename A, typename B>
+  - decltype(std::declval<A&>() * std::declval<B&>()) multiply(A a, B b)
+  + auto multiply( A a, B b ) -> decltype( a * b )
+  {
+      return a*b;
+  }
+  ```
   - Aliasing for long iterator declarations
   ```diff
     std::map<int, std::map<std::string, some_long_typename>> some_map;

--- a/docs/en/dev/explanation/code_style.md
+++ b/docs/en/dev/explanation/code_style.md
@@ -68,7 +68,7 @@ These are less generic guidelines and more pain points we've stumbled across ove
       use a `std::bitset` instead.
   - `float` is to be avoided, but has valid uses.
 - Use [`auto` keyword](https://learn.microsoft.com/en-us/cpp/cpp/auto-cpp?view=msvc-170) where it makes sense to do so, for example:
-  - [trailing return types](https://en.wikipedia.org/wiki/Trailing_return_type) in function declarations.
+  - Prefer [trailing return types](https://en.wikipedia.org/wiki/Trailing_return_type) in function declarations. Long return types obscure function name and makes reading class methods a painful experience.
   ```cpp
   class Bar;
   auto foo( int a ) -> int
@@ -78,6 +78,15 @@ These are less generic guidelines and more pain points we've stumbled across ove
       return is_bar_ok( bar ) ? 42 : 404;
   }
   ```
+    - Use for `decltype` style generic functions
+    ```diff
+    template<typename A, typename B>
+    - decltype(std::declval<A&>() * std::declval<B&>()) multiply(A a, B b)
+    + auto multiply( A a, B b ) -> decltype( a * b )
+    {
+        return a*b;
+    }
+    ```
   - Aliasing for long iterator declarations
   ```diff
     std::map<int, std::map<std::string, some_long_typename>> some_map;
@@ -91,7 +100,6 @@ These are less generic guidelines and more pain points we've stumbled across ove
   ```
   - Doesn't otherwise sacrifice readability for expedience. Options for inlay type hinting are available in popular code editor such as [vscode](https://github.com/clangd/vscode-clangd).
 
-- Prefer [trailing return types](https://en.wikipedia.org/wiki/Trailing_return_type). Long return types obscure function name and makes reading class methods a painful experience. You need to use trailing return type for `decltype` generic programming anyways, so no reason to not use them as default.
 - Avoid `using namespace` for standard namespaces.
 - Avoid adding new member methods to classes unless required.
   ```diff


### PR DESCRIPTION
## Purpose of change (The Why)

Our existing C++ style guide hasn't changed since C++14. now that we have [better tooling (clangd)](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6690) and language [(C++23)](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6500), some of these rules are outdated and needs to be updated.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
