### PR TITLE
docs: simplify cmake build with preset

### DIFF
--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -134,39 +134,27 @@ ccmake ..
 cmake-gui ..
 ```
 
-A CMake build with almost all options with build optimizations (ccache, ninja, mold) + tracy
-profiler may look like:
+There's multiple predefined [build presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) available, which simplifies build process to just two commands:
 
 ```sh
-mkdir build
-cmake \
-  -B build \
-  -G Ninja \
-  -DCATA_CCACHE=ON \
-  -DCMAKE_C_COMPILER=clang \
-  -DCMAKE_CXX_COMPILER=clang++ \
-  -DCMAKE_INSTALL_PREFIX=$HOME/.local/share \
-  -DJSON_FORMAT=ON \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-  -DCURSES=OFF \
-  -DTILES=ON \
-  -DSOUND=ON \
-  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-  -DCATA_CLANG_TIDY_PLUGIN=OFF \
-  -DLUA=ON \
-  -DBACKTRACE=ON \
-  -DLINKER=mold \
-  -DUSE_XDG_DIR=ON \
-  -DUSE_HOME_DIR=OFF \
-  -DUSE_PREFIX_DATA_DIR=OFF \
-  -DUSE_TRACY=ON \
-  -DTRACY_VERSION=master \
-  -DTRACY_ON_DEMAND=ON \
-  -DTRACY_ONLY_IPV4=ON
-cmake --build build
+cmake --preset linux-full
+cmake --build build --preset linux-full --target cataclysm-bn-tiles
 ```
 
-This will place the executables into `build/src/`.
+This will build with almost all options with optimizations (ccache, ninja, mold) and tracy profiler built-in. You can find the executable in `./build/src/`.
+
+> [!NOTE]
+> You can build multiple targets at once with:
+>
+> ```sh
+> cmake --build build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles
+> ```
+>
+> Or limit maximum number of threads with `--parallel` option:
+>
+> ```sh
+> cmake --build build --preset linux-full --target cataclysm-bn-tiles --parallel 4
+> ```
 
 ## Build for Visual Studio / MSBuild
 


### PR DESCRIPTION

## Purpose of change (The Why)

pasting 20 lines long command does not spark joy

## Describe the solution (The How)

update the guide to use presets which shortens build process to two command (for linux)

## Additional context

![Marie-Kondo-Spark-Joy-meme](https://github.com/user-attachments/assets/5c08de74-1640-4cf4-bcd7-a025f0d2cbcc)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

