### PR TITLE
feat: add `drop_count` for ammo

### DIFF
--- a/data/json/items/ammo/signal_flare.json
+++ b/data/json/items/ammo/signal_flare.json
@@ -22,5 +22,12 @@
     "loudness": 55,
     "drop": "handflare_lit",
     "effects": [ "NEVER_MISFIRES", "NO_EMBED", "NO_PENETRATE_OBSTACLES" ]
+  },
+  {
+    "id": "signal_flare_test",
+    "type": "AMMO",
+    "name": { "str": "signal flare half-testing" },
+    "copy-from": "signal_flare",
+    "drop_count": 150
   }
 ]

--- a/docs/en/mod/json/reference/items/item_creation.md
+++ b/docs/en/mod/json/reference/items/item_creation.md
@@ -101,7 +101,10 @@
 "stack_size" : 50,          // (Optional) How many rounds are in the above-defined volume. If omitted, is the same as 'count'
 "show_stats" : true,        // (Optional) Force stat display for combat ammo. (for projectiles lacking both damage and prop_damage)
 "dont_recover_one_in": 1    // (Optional) 1 in x chance of not recovering the ammo (100 means you have a 99% chance of getting it back)
-"drop": "nail"              // (Optional) Defines an object that drops at the projectile location at a 100% chance.
+"drop": "nail",             // (Optional) Defines an object that drops at the projectile location at a 100% chance.
+"drop_active": false        // (Optional) Whether the object starts active. Default is true.
+"drop_count": 1,            // (Optional) Number of items to drop. For tools, this sets their charges. 
+                            // If omitted, the drop amount defaults to the 'count' defined in its itype.
 "effects" : ["COOKOFF", "SHOT"]
 ```
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1742,6 +1742,7 @@ void islot_ammo::load( const JsonObject &jo )
     mandatory( jo, was_loaded, "ammo_type", type );
     optional( jo, was_loaded, "casing", casing, std::nullopt );
     optional( jo, was_loaded, "drop", drop, itype_id::NULL_ID() );
+    optional( jo, was_loaded, "drop_count", drop_count, -1 );
     optional( jo, was_loaded, "drop_active", drop_active, true );
     optional( jo, was_loaded, "dont_recover_one_in", dont_recover_one_in, 1 );
     // Damage instance assign reader handles pierce and prop_damage

--- a/src/itype.h
+++ b/src/itype.h
@@ -700,7 +700,7 @@ struct islot_ammo : common_ranged_data {
      * Control chance for and state of any items dropped at ranged target
      *@{*/
     itype_id drop = itype_id::NULL_ID();
-
+    int drop_count = -1;
     bool drop_active = true;
     /*@}*/
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1874,7 +1874,7 @@ static projectile make_gun_projectile( const item &gun )
         }
 
         if( ammo.drop ) {
-            detached_ptr<item> drop = item::spawn( ammo.drop, calendar::turn, 1 );
+            detached_ptr<item> drop = item::spawn( ammo.drop, calendar::turn, ammo.drop_count );
             if( ammo.drop_active ) {
                 drop->activate();
             }


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
#6928 related.
When you fire a flaregun, the ammo is too dim and gone too quickly.
The reason I found is about #5116, which changed item spawning as 1 charge.
But simply reverting this would make infinite altering 1/-1 and useless disputation among us.
Therefore, I suggest the alternative answer.

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Spawning amount by `drop` defaults to the `count` defined in its itype.
But, you can set the amount by writing `drop_count` in ammo JSON.
After this PR merged, putting `"drop": "nail"` in ammo JSON would give you 100 nails as written.
If you want get 1 nail after fire it, put `"drop_count": 1` !
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Endless 1 and -1 altering, Useless disputation, etc

## Testing
Revived flaregun
<img width="1002" height="756" alt="스크린샷 2025-08-14 163808" src="https://github.com/user-attachments/assets/07c4b6b7-5efa-4636-bf76-90374b91e573" />

And its half version for test
<img width="508" height="189" alt="스크린샷 2025-08-14 164321" src="https://github.com/user-attachments/assets/ee8c6a93-be35-4756-91fe-3fa149085e9b" />
<img width="618" height="237" alt="스크린샷 2025-08-14 164257" src="https://github.com/user-attachments/assets/6ef72e3e-4890-4ac7-a137-71163c525edc" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
