### PR TITLE
fix: salvaging no longer multiples results by stack size, ask before salvaging stuff you can disassemble

### DIFF
--- a/src/salvage.cpp
+++ b/src/salvage.cpp
@@ -153,6 +153,12 @@ static q_result prompt_warnings( const Character &who, const item &target,
             return result;
         }
     }
+    if( recipe_dictionary::get_uncraft( target.typeId() ) ) {
+        auto result = yn_ignore_query( _( "This item could be disassembled instead, salvage anyway?" ) );
+        if( result != q_result::yes ) {
+            return result;
+        }
+    }
     return q_result::yes;
 }
 
@@ -228,6 +234,10 @@ void complete_salvage( Character &who, item &cut, tripoint_abs_ms pos )
         int amount = std::floor( salvagable_percent * salvaged.second );
         if( amount > 0 ) {
             item &result = *item::spawn_temporary( salvaged.first, calendar::turn );
+            // This sanity-checks items that have a default stack amount, e.g. silver/gold
+            if( result.charges > 1 ) {
+                result.charges = 1;
+             }
             // Time based on number of components.
             add_msg( m_good, vgettext( "Salvaged %1$i %2$s.", "Salvaged %1$i %2$s.", amount ),
                      amount, result.display_name( amount ) );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This fixes an oversight where cutting up items whose salvage result (copper, silver, gold etc) spawns in stacks by default, which would multiply the expected results by the default stack amount:
<img width="1605" height="485" alt="image" src="https://github.com/user-attachments/assets/c1d0932f-b0f1-4b88-a2c1-dc6633899f73" />

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In salvage.cpp, `complete_salvage` give a basic if statement that sets the charges of the item about to be spawned to 1 if it has a default charges amount any higher. Basically just stole my solution from how I fixed the same problem in `map::handle_decayed_corpse` previously.
2. Also in salvage.cpp, `prompt_warnings` now prompts you if the item in question could be disassembled instead.

## Describe alternatives you've considered

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned in a silver bracelet and sawed it apart.
3. Confirmed it asked me if I wanted to beforehand due to being uncraftable first.
4. It said I got 9 silver out of it, and I indeed got that amount instead of 900 silver.
5. Cut up a steel drum which can't be uncrafted, it doesn't prompt me.

<img width="605" height="79" alt="image" src="https://github.com/user-attachments/assets/4fa79cfc-f606-4cf1-bbbb-7c254bcfe407" />
<img width="487" height="91" alt="image" src="https://github.com/user-attachments/assets/c0f03395-1cfc-4718-bf01-4ac16264e079" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![d6deb305012789d84d3761dfcc6ebc9d](https://github.com/user-attachments/assets/dda0b9b6-7b4d-46ad-af55-3b716ae440ef)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
