### PR TITLE
feat: jetski, motorized kayak & river boat spawns

### DIFF
--- a/data/json/mapgen/lake.json
+++ b/data/json/mapgen/lake.json
@@ -33,6 +33,16 @@
   {
     "type": "mapgen",
     "method": "json",
+    "om_terrain": [ "river_center" ],
+    "//": "not lake stuff, but seemed like this would be the best spot for this definition",
+    "object": {
+      "fill_ter": "t_water_moving_dp",
+      "place_vehicles": [ { "vehicle": "river_boats", "x": [ 11, 12 ], "y": [ 11, 12 ], "rotation": [ 0, 90, 180, 270 ], "chance": 2 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "om_terrain": [ "lake_water_cube" ],
     "object": { "fill_ter": "t_water_cube" }
   },

--- a/data/json/overmap/overmap_terrain/overmap_terrain_river.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_river.json
@@ -19,8 +19,7 @@
   {
     "type": "overmap_terrain",
     "id": "river_center",
-    "copy-from": "generic_river",
-    "mapgen": [ { "method": "builtin", "name": "river_center" } ]
+    "copy-from": "generic_river"
   },
   {
     "type": "overmap_terrain",

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -89,8 +89,10 @@
       [ "canoe", 100 ],
       [ "kayak", 50 ],
       [ "kayak_racing", 25 ],
+      [ "kayak_motorized", 25 ],
       [ "wood_rowboat_double", 25 ],
       [ "inflatable_boat", 25 ],
+      [ "jetski", 25 ],
       [ "raft", 25 ],
       [ "boat_motor_single", 200 ],
       [ "boat_motor_smuggler", 50 ],
@@ -101,6 +103,26 @@
       [ "pirate_ship", 25 ],
       [ "DUKW", 75 ],
       [ "hovercraft_motor_single", 25 ]
+    ]
+  },
+  {
+    "type": "vehicle_group",
+    "id": "river_boats",
+    "//": "Various boats that might have been abandoned or lost in rivers.  ~50% rafts or kayaks, 40% boats or hovercraft, and 10% police/military/smuggler.",
+    "vehicles": [
+      ["canoe", 195],
+      ["kayak", 100],
+      ["kayak_racing", 50],
+      ["kayak_motorized", 25],
+      ["wood_rowboat_double", 60],
+      ["inflatable_boat", 115],
+      ["jetski", 30],
+      ["raft", 190],
+      ["boat_motor_single", 115],
+      ["boat_motor_smuggler", 60],
+      ["boat_motor_police", 30],
+      ["CG_patrol_boat", 20],
+      ["hovercraft_motor_single", 125]
     ]
   },
   {
@@ -120,7 +142,7 @@
     "type": "vehicle_group",
     "id": "boats_narrow",
     "//": "1 tile wide boats for storage sheds",
-    "vehicles": [ [ "canoe", 2000 ], [ "kayak", 1500 ], [ "kayak_racing", 500 ] ]
+    "vehicles": [ [ "canoe", 2000 ], [ "kayak", 1500 ], [ "kayak_racing", 500 ], [ "kayak_motorized", 250 ], [ "jetski", 250 ] ]
   },
   {
     "type": "vehicle_group",

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -110,19 +110,19 @@
     "id": "river_boats",
     "//": "Various boats that might have been abandoned or lost in rivers.  ~50% rafts or kayaks, 40% boats or hovercraft, and 10% police/military/smuggler.",
     "vehicles": [
-      ["canoe", 195],
-      ["kayak", 100],
-      ["kayak_racing", 50],
-      ["kayak_motorized", 25],
-      ["wood_rowboat_double", 60],
-      ["inflatable_boat", 115],
-      ["jetski", 30],
-      ["raft", 190],
-      ["boat_motor_single", 115],
-      ["boat_motor_smuggler", 60],
-      ["boat_motor_police", 30],
-      ["CG_patrol_boat", 20],
-      ["hovercraft_motor_single", 125]
+      [ "canoe", 195 ],
+      [ "kayak", 100 ],
+      [ "kayak_racing", 50 ],
+      [ "kayak_motorized", 25 ],
+      [ "wood_rowboat_double", 60 ],
+      [ "inflatable_boat", 115 ],
+      [ "jetski", 30 ],
+      [ "raft", 190 ],
+      [ "boat_motor_single", 115 ],
+      [ "boat_motor_smuggler", 60 ],
+      [ "boat_motor_police", 30 ],
+      [ "CG_patrol_boat", 20 ],
+      [ "hovercraft_motor_single", 125 ]
     ]
   },
   {

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -76,7 +76,9 @@
       [ "canoe", 2000 ],
       [ "kayak", 1500 ],
       [ "kayak_racing", 500 ],
+      [ "kayak_motorized", 500 ],
       [ "DUKW", 250 ],
+      [ "jetski", 500 ],
       [ "raft", 2000 ],
       [ "wood_rowboat_double", 1500 ]
     ]
@@ -86,8 +88,8 @@
     "id": "lake_boats",
     "//": "Various boats that might have been abandoned out on the open water.  ~25% small craft, 25% larger commercial boats, 25% police/military, and 25% novelty/replica craft.",
     "vehicles": [
-      [ "canoe", 100 ],
-      [ "kayak", 50 ],
+      [ "canoe", 75 ],
+      [ "kayak", 25 ],
       [ "kayak_racing", 25 ],
       [ "kayak_motorized", 25 ],
       [ "wood_rowboat_double", 25 ],

--- a/data/json/vehicles/boats.json
+++ b/data/json/vehicles/boats.json
@@ -88,10 +88,21 @@
     "type": "vehicle",
     "name": "motorized kayak",
     "blueprint": [ [ "<O>" ] ],
-    "parts": [ 
+    "parts": [
       { "x": 0, "y": 0, "parts": [ "xlframe_horizontal", "seat", "hand_paddles", "carbonfiber_boat_hull" ] },
       { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "carbonfiber_boat_hull" ] },
-      { "x": -1, "y": 0, "parts": [ "xlframe_horizontal", "carbonfiber_boat_hull", "battery_motorbike", "engine_1cyl", "alternator_motorbike", { "part": "tank_small", "fuel": "gasoline" } ] }
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [
+          "xlframe_horizontal",
+          "carbonfiber_boat_hull",
+          "battery_motorbike",
+          "engine_1cyl",
+          "alternator_motorbike",
+          { "part": "tank_small", "fuel": "gasoline" }
+        ]
+      }
     ]
   },
   {
@@ -99,9 +110,20 @@
     "type": "vehicle",
     "name": "jetski",
     "blueprint": [ [ "<O#" ] ],
-    "parts": [ 
+    "parts": [
       { "x": 0, "y": 0, "parts": [ "xlframe_horizontal", "controls", "seat", "plastic_boat_hull" ] },
-      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "plastic_boat_hull", "battery_motorbike", "engine_1cyl_large", "alternator_motorbike", { "part": "tank_small", "fuel": "gasoline" } ] },
+      {
+        "x": 1,
+        "y": 0,
+        "parts": [
+          "xlframe_horizontal",
+          "plastic_boat_hull",
+          "battery_motorbike",
+          "engine_1cyl_large",
+          "alternator_motorbike",
+          { "part": "tank_small", "fuel": "gasoline" }
+        ]
+      },
       { "x": -1, "y": 0, "parts": [ "xlframe_horizontal", "plastic_boat_hull", "cargo_space" ] }
     ],
     "items": [ { "x": -1, "y": 0, "chance": 50, "items": [ "flotation_vest" ] } ]

--- a/data/json/vehicles/boats.json
+++ b/data/json/vehicles/boats.json
@@ -84,6 +84,29 @@
     ]
   },
   {
+    "id": "kayak_motorized",
+    "type": "vehicle",
+    "name": "motorized kayak",
+    "blueprint": [ [ "<O>" ] ],
+    "parts": [ 
+      { "x": 0, "y": 0, "parts": [ "xlframe_horizontal", "seat", "hand_paddles", "carbonfiber_boat_hull" ] },
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "carbonfiber_boat_hull" ] },
+      { "x": -1, "y": 0, "parts": [ "xlframe_horizontal", "carbonfiber_boat_hull", "battery_motorbike", "engine_1cyl", "alternator_motorbike", { "part": "tank_small", "fuel": "gasoline" } ] }
+    ]
+  },
+  {
+    "id": "jetski",
+    "type": "vehicle",
+    "name": "jetski",
+    "blueprint": [ [ "<O#" ] ],
+    "parts": [ 
+      { "x": 0, "y": 0, "parts": [ "xlframe_horizontal", "controls", "seat", "plastic_boat_hull" ] },
+      { "x": 1, "y": 0, "parts": [ "xlframe_horizontal", "plastic_boat_hull", "battery_motorbike", "engine_1cyl_large", "alternator_motorbike", { "part": "tank_small", "fuel": "gasoline" } ] },
+      { "x": -1, "y": 0, "parts": [ "xlframe_horizontal", "plastic_boat_hull", "cargo_space" ] }
+    ],
+    "items": [ { "x": -1, "y": 0, "chance": 50, "items": [ "flotation_vest" ] } ]
+  },
+  {
     "type": "vehicle",
     "id": "sea_scooter",
     "name": "sea scooter",


### PR DESCRIPTION
## Purpose of change (The Why)
Boats should spawn in rivers too!
## Describe the solution (The How)
Adds river_boats vehicle group which is used for boats that spawn in rivers. This generally excludes the larger watercraft.
Additionally, adds a motorized kayak and jetski vehicle.
## Describe alternatives you've considered
## Testing
Spawned both vehicles, ensured they work and look how I'd expect. Explored the rivers a bit and found some naturally occurring boats.
## Additional context
The weight of the spawns has been increased from 1 to 2, as there are many less river tiles on the map than lake tiles, so there should still be a fewer amount of boats spawning here overall.
## Checklist
### Mandatory
- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
