### PR TITLE
feat: allow fire a `FIRE_TWOHAND` gun while driving a unicycle

### DIFF
--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -187,6 +187,15 @@
     "type": "vehicle_part"
   },
   {
+    "copy-from": "saddle_abstract",
+    "id": "saddle_control",
+    "name": { "str": "controllable saddle" },
+    "symbol": "#",
+    "type": "vehicle_part",
+    "looks_like": "saddle_pedal",
+    "extend": { "flags": [ "CONTROLS", "CTRL_WO_HANDS" ] }
+  },
+  {
     "copy-from": "folding_seat_abstract",
     "id": "folding_seat",
     "symbol": "#",

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -55,6 +55,12 @@
     "info": "With a seat or saddle, you drive from here.  You can 'e'xamine the tile to access the controls, or use the vehicle control key (default '^')."
   },
   {
+    "id": "CTRL_WO_HANDS",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ],
+    "info": "You can fire a gun needed two hands while drive here."
+  },
+  {
     "id": "COVERED",
     "type": "json_flag",
     "context": [ "vehicle_part" ],

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -58,7 +58,8 @@
     "id": "CTRL_WO_HANDS",
     "type": "json_flag",
     "context": [ "vehicle_part" ],
-    "info": "You can fire a gun needed two hands while drive here."
+    "info": "You can fire a gun needed two hands while drive here.",
+    "requires_flag": "STEERABLE"
   },
   {
     "id": "COVERED",

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -1610,6 +1610,7 @@ Those flags are added by the game code to specific items (that specific welder, 
 - `CRAFTRIG` Acts as a dehydrator, vacuum sealer and reloading press for crafting purposes.
   Potentially to include additional tools in the future.
 - `CTRL_ELECTRONIC` Controls electrical and electronic systems of the vehicle.
+- `CTRL_WO_HANDS` Allows you fire the gun need two hands while driving. Can only be installed on a part with `STEERABLE` flag.
 - `CURTAIN` Can be installed over a part flagged with `WINDOW`, and functions the same as blinds
   found on windows in buildings.
 - `DIFFICULTY_REMOVE`

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3917,7 +3917,7 @@ bool ranged::gunmode_checks_common( avatar &you, const map &m, std::vector<std::
                 }
             }
             else { // not in air/water, its ctrl is handsfree, wheels aren't here or not steerable
-                messages.push_back( string_format( _( "You can't fire your %s while driving; this vehicle's setup doesn't support it." ),
+                messages.push_back( string_format( _( "You can't fire your %s while driving; you can't steer this vehicle at here." ),
                                             gmode->tname() ) );
                 result = false;
             }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3894,12 +3894,12 @@ bool ranged::gunmode_checks_common( avatar &you, const map &m, std::vector<std::
             const auto vp_control = vp->part_with_feature( "CONTROLS", true );
             const bool ctrl_handsfree = vp_control && vp_control->has_feature( "CTRL_WO_HANDS" );
             const auto vp_wheel = vp->part_with_feature( "WHEEL", true );
-            const bool wheel_stb = vp_wheel && vp_wheel->has_feature( "STABLE" );
+            const bool wheel_stb = vp_wheel && vp_wheel->has_feature( "STEERABLE" );
             const bool using_arms = vp->vehicle().has_part( "MUSCLE_ARMS", true );
             // well, probably someone want to be a mounted air/waterborne archer so...
             const bool in_air_or_water = vp && ( vp->vehicle().is_flying_in_air() || vp->vehicle().is_watercraft() );
 
-        if( ctrl_handsfree ) { // check this vehicle is stable and able to be controlled without hands.
+        if( ctrl_handsfree ) { // check this vehicle is steerable and able to be controlled without hands.
             if( wheel_stb || in_air_or_water ) {
                 if( using_arms ){
                     messages.push_back( string_format( _( "You can't fire your %s while driving; this vehicle is hand-powered." ),
@@ -3915,7 +3915,7 @@ bool ranged::gunmode_checks_common( avatar &you, const map &m, std::vector<std::
                     result = true;
                 }
             }
-            else { // not in air/water, its ctrl is handsfree, wheels aren't here or not stable
+            else { // not in air/water, its ctrl is handsfree, wheels aren't here or not steerable
                 messages.push_back( string_format( _( "You can't fire your %s while driving; this vehicle's setup doesn't support it." ),
                                             gmode->tname() ) );
                 result = false;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3893,14 +3893,15 @@ bool ranged::gunmode_checks_common( avatar &you, const map &m, std::vector<std::
 
             const auto vp_control = vp->part_with_feature( "CONTROLS", true );
             const bool ctrl_handsfree = vp_control && vp_control->has_feature( "CTRL_WO_HANDS" );
+            const auto vp_steerable = vp->part_with_feature( "STEERABLE", true );
             const auto vp_wheel = vp->part_with_feature( "WHEEL", true );
-            const bool wheel_stb = vp_wheel && vp_wheel->has_feature( "STEERABLE" );
+            const bool strbl_whl = vp_steerable && vp_wheel; // is there a steerable stuff and a wheel?
             const bool using_arms = vp->vehicle().has_part( "MUSCLE_ARMS", true );
             // well, probably someone want to be a mounted air/waterborne archer so...
             const bool in_air_or_water = vp && ( vp->vehicle().is_flying_in_air() || vp->vehicle().is_watercraft() );
 
         if( ctrl_handsfree ) { // check this vehicle is steerable and able to be controlled without hands.
-            if( wheel_stb || in_air_or_water ) {
+            if( strbl_whl || in_air_or_water ) {
                 if( using_arms ){
                     messages.push_back( string_format( _( "You can't fire your %s while driving; this vehicle is hand-powered." ),
                                             gmode->tname() ) );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
A skillful acrobat can shoot a bow and arrow on an unicycle, but our super mutant cyborg can't.
If this thing is available, we can have more tactics with a staff sling or composite longbow.
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Add `CTRL_WO_HANDS` flag for vehicle parts, and put some code for it.
I intended to be able to fire the guns while driving at the circumstance below.
- You sit on that controller and above the steerable wheel / or ride in water or air.
- You don't ride arm-powered vehicle.
- Your driving skill is same or over 3.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Shooting a bow works well.
https://github.com/user-attachments/assets/857ebdc1-a32d-4d19-b19f-46eb9618b711

And this is when my driving skill is 0.
<img width="681" height="216" alt="스크린샷 2025-08-16 172037" src="https://github.com/user-attachments/assets/9d7a4d13-8c34-4dcb-ad27-24fe2cdbc307" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Crying

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
