### PR TITLE
fix: don't dunk players underwater through boats, don't allow surfacing from under a boat, take monsters out of the water when they board boats, disallow aquatic monsters from landsharking onto boats

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -362,8 +362,8 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     bool toDeepWater = m.has_flag( TFLAG_DEEP_WATER, dest_loc );
     bool fromSwimmable = m.has_flag( flag_SWIMMABLE, you.pos() );
     bool fromDeepWater = m.has_flag( TFLAG_DEEP_WATER, you.pos() );
-    bool fromBoat = veh0 != nullptr && veh0->is_in_water();
-    bool toBoat = veh1 != nullptr && veh1->is_in_water();
+    bool fromBoat = veh0 != nullptr;
+    bool toBoat = veh1 != nullptr;
     if( is_riding ) {
         if( !you.check_mount_will_move( dest_loc ) ) {
             if( you.is_auto_moving() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10425,14 +10425,15 @@ void game::vertical_move( int movez, bool force, bool peeking )
             }
             // ...and we're trying to move up
             else if( movez == 1 ) {
-            const std::optional<vpart_reference> vp = get_map().veh_at( u.pos() + tripoint( 0, 0, movez ) ).part_with_feature( VPFLAG_BOARDABLE,
-            true );
+                const std::optional<vpart_reference> vp = get_map().veh_at( u.pos() + tripoint( 0, 0,
+                        movez ) ).part_with_feature( VPFLAG_BOARDABLE,
+                                                     true );
                 if( vp ) {
                     add_msg( m_info, _( "You can't board a boat from underneath it!" ) );
                     return;
                     // ...and there's more water above us, but no boats blocking the way.
                 } else if( target_ter->has_flag( TFLAG_WATER_CUBE ) ||
-                    target_ter->has_flag( TFLAG_DEEP_WATER ) ) {
+                           target_ter->has_flag( TFLAG_DEEP_WATER ) ) {
                     // Then go ahead and move up.
                     add_msg( _( "You swim up." ) );
                 } else {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10425,8 +10425,13 @@ void game::vertical_move( int movez, bool force, bool peeking )
             }
             // ...and we're trying to move up
             else if( movez == 1 ) {
-                // ...and there's more water above us us.
-                if( target_ter->has_flag( TFLAG_WATER_CUBE ) ||
+            const std::optional<vpart_reference> vp = get_map().veh_at( u.pos() + tripoint( 0, 0, movez ) ).part_with_feature( VPFLAG_BOARDABLE,
+            true );
+                if( vp ) {
+                    add_msg( m_info, _( "You can't board a boat from underneath it!" ) );
+                    return;
+                    // ...and there's more water above us, but no boats blocking the way.
+                } else if( target_ter->has_flag( TFLAG_WATER_CUBE ) ||
                     target_ter->has_flag( TFLAG_DEEP_WATER ) ) {
                     // Then go ahead and move up.
                     add_msg( _( "You swim up." ) );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2716,7 +2716,7 @@ bool map::is_divable( const tripoint &p ) const
     const std::optional<vpart_reference> vp = veh_at( p ).part_with_feature( VPFLAG_BOARDABLE,
             true );
     if( !vp ) {
-    return has_flag( "SWIMMABLE", p ) && has_flag( TFLAG_DEEP_WATER, p );
+        return has_flag( "SWIMMABLE", p ) && has_flag( TFLAG_DEEP_WATER, p );
     }
     return false;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2713,7 +2713,12 @@ bool map::is_water_shallow_current( const tripoint &p ) const
 
 bool map::is_divable( const tripoint &p ) const
 {
+    const std::optional<vpart_reference> vp = veh_at( p ).part_with_feature( VPFLAG_BOARDABLE,
+            true );
+    if( !vp ) {
     return has_flag( "SWIMMABLE", p ) && has_flag( TFLAG_DEEP_WATER, p );
+    }
+    return false;
 }
 
 bool map::is_outside( const tripoint &p ) const

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -142,7 +142,7 @@ bool monster::will_move_to( const tripoint &p ) const
         return false;
     }
 
-    if( has_flag( MF_AQUATIC ) && !g->m.has_flag( "SWIMMABLE", p ) ) {
+    if( has_flag( MF_AQUATIC ) && ( !g->m.has_flag( "SWIMMABLE", p ) || g->m.veh_at( p ).part_with_feature( "BOARDABLE", true ) ) ) {
         return false;
     }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -142,7 +142,8 @@ bool monster::will_move_to( const tripoint &p ) const
         return false;
     }
 
-    if( has_flag( MF_AQUATIC ) && ( !g->m.has_flag( "SWIMMABLE", p ) || g->m.veh_at( p ).part_with_feature( "BOARDABLE", true ) ) ) {
+    if( has_flag( MF_AQUATIC ) && ( !g->m.has_flag( "SWIMMABLE", p ) ||
+                                    g->m.veh_at( p ).part_with_feature( "BOARDABLE", true ) ) ) {
         return false;
     }
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

A litany of fixes for annoying QoL issues boats had.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In avatar_action.cpp, removed some checks for if a vehicle is on water from `avatar_action::move` because for whatever reason `is_on_water` would not wake the fuck up when you first load the game, and since right now a vehicle can't exist on water unless it's a boat anyway, there's zero reason to have this check. This fixes the issue where loading a save while on a boat would frequently dunk you underwater as soon as you make a move.
2. In game.cpp, set `game::vertical_move` so that swimming up doesn't let you phase through the floor of a boat on the surface, instead stopping you to hint that there's a vehicle overhead.
3. In map.cpp, `map::is_divable` changed to check for the presence of a boardable vehicle tile. This fixes an issue where monsters who make their way onto a boat would be invisible until they get close to you, because even though they'd boarded your boat legitimately (far as I could tell through testing, obstacles like quarterpanels successfully prevented being boarded), they still counted as underwater at the same time and were thus hidden.
4. In monmove.cpp, set `monster::will_move_to` so that `AQUATIC` don't count boardable vehicle tiles as valid places to swim to, preventing them from landsharking up onto your boat, unless the offending tiles are broken.

## Describe alternatives you've considered

Giving jawed terrors the ability to smash obstacles, or maybe code a special attack for them to specifically roll bite damage to hit the boat with like:
<img width="414" height="233" alt="shork" src="https://github.com/user-attachments/assets/ecf9f94f-fb4d-48fe-98e3-d443c2f2babe" />

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Loaded a save where I was on a boat, even after multiple attempts moving immediately after loading the save no longer dunks me underwater.
3. Dipped into the lake underneath the boat and tried to surface, it now warns me about the boat over my head and prevents me from nocliping straight through the floor.
4. Spawned a zombie in the water, tested that they still can't break into the boat when it's closed off by quarterpanels and such, and opening a door for them now has them actually become visible and state that they emerged from the water.
5. Spawned a jawed terror, it can no longer flop onto my boat and bite my legs off.

<img width="1070" height="664" alt="image" src="https://github.com/user-attachments/assets/c8dacb10-9a79-43a7-a603-54da58a9e22f" />
<img width="347" height="83" alt="image" src="https://github.com/user-attachments/assets/36600d53-f07e-49f3-a8b7-286dd958ead6" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
