### PR TITLE
feat(balance): stormbringer tweaks

### DIFF
--- a/data/json/monsters/zed_electric.json
+++ b/data/json/monsters/zed_electric.json
@@ -205,15 +205,15 @@
       "SEES",
       "HEARS",
       "SMELLS",
-      "STUMBLES",
       "WARM",
       "BASHES",
-      "GROUP_BASH",
       "POISON",
+      "PATH_AVOID_DANGER_2",
+      "PRIORITIZE_TARGETS",
+      "NO_FUNG_DMG",
       "ELECTRIC",
       "NO_BREATHE",
-      "REVIVES",
-      "ELECTRIC_FIELD"
+      "REVIVES"
     ]
   },
   {
@@ -227,7 +227,7 @@
     "volume": "62500 ml",
     "weight": "81500 g",
     "hp": 10,
-    "speed": 70,
+    "speed": 80,
     "material": [ "powder" ],
     "symbol": "V",
     "color": "i_cyan",
@@ -241,6 +241,6 @@
     "emit_fields": [ { "emit_id": "emit_shock_cloud", "delay": "1 s" } ],
     "special_attacks": [ [ "DISAPPEAR", 60 ] ],
     "death_function": [ "MELT" ],
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "NOHEAD", "NO_BREATHE", "ELECTRIC", "STUMBLES" ]
+    "flags": [ "SEES", "HEARS", "GOODHEARING", "NOHEAD", "NO_BREATHE", "ELECTRIC", "ELECTRIC_FIELD" ]
   }
 ]


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->
The current evaluation of the Stormbringer monster indicates it is relatively weak.
This is primarily due to the STUMBLES flag on its Shock Vortex, which causes the vortex to approach players too slowly, making it easy to avoid.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
### Shock Vortex:
* Increased the movement speed from 40 to 80.
* Removed the STUMBLES flag.
* Added the ELECTRIC_FIELD flag, allowing it to ignite flammable liquids, similar to the Incandescent Husk.

### Stormbringer (The monster itself):
* Updated its flags to be more consistent with the Zombie Master. This makes the Stormbringer a more significant threat and aligns its behavior with other high-tier zombie variants.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
Tested the changes in-game to confirm that the Shock Vortex now moves at the intended speed and ignites flammable liquids as expected. The Stormbringer's new behavior also functions correctly.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
