### PR TITLE
fix: Take away power armor from mil_armor

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -1959,8 +1959,6 @@
       { "group": "clothing_tactical_torso", "prob": 75 },
       { "group": "clothing_tactical_leg", "prob": 50 },
       { "group": "military_ballistic_armor", "prob": 200 },
-      { "group": "pwr_armor", "prob": 10 },
-      { "group": "pwr_armor_acc", "prob": 10 },
       { "group": "mil_armor_electronics", "prob": 20 },
       [ "chestguard_hard", 20 ],
       [ "armguard_hard", 20 ],


### PR DESCRIPTION
## Purpose of change (The Why)

A good game requires balance. mil_armor spawns in storage units, the mall, on mx_science and mx_military, and inside "military" which itself spawns in a ton of places including all dinosaur nests.

Power armor here lets you farm low risk low reward areas for a random low odds power armor drop. 930 odds, 10 for power armor and 10 for accessories, so more than 1% chance per roll.

## Describe the solution (The How)

Take it away.

## Describe alternatives you've considered

None what so ever.

## Testing

Un-needed here beyond automated tests.

## Additional context

We call THIS a difficulty tweak. https://youtu.be/hauD72P1d2k?t=85

## Checklist
### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.