### PR TITLE
feat: add more professions, rebalancing and tweaks to others

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6109,15 +6109,20 @@
   {
     "type": "profession",
     "id": "prof_feral_mutant",
-    "copy-from": "prof_feral_mutant",
+    "copy-from": "prof_feral_unemployed",
     "name": "Feral Mutant",
-    "description": "Your dreamed of becoming a super-human mutant through genetic alteration.  So what if you're a freak of nature now?  ",
-    "traits": [ "PROF_FERAL", "PATCHSKIN1", "SABER_TEETH", "HOOVES", "LARGE", "THRESH_CHIMERA" ],
-    "//": "Contains a Powerwolf reference.  +2 points due to skills but balanced out by mixed bag of Chimera mutations.",
+    "//": "Contains a Powerwolf reference.  +2 points over volunteer mutant due to skills but balanced out by mixed bag of Chimera mutations.",
+    "description": "You dreamed of becoming a super-human mutant through genetic alteration.  Who cares if you're a freak of nature now?  All you need is flesh and blood.",
+    "traits": [ "PROF_FERAL", "PATCHSKIN1", "SABER_TEETH", "HORNS_CURLED", "LARGE", "THRESH_CHIMERA" ],
     "points": 3,
-    "skills": [ { "level": 2, "name": "cooking" }, { "level": 2, "name": "electronics" } ],
+    "skills": [
+      { "level": 2, "name": "cooking" },
+      { "level": 2, "name": "electronics" },
+      { "level": 2, "name": "melee" },
+      { "level": 2, "name": "unarmed" }
+    ],
     "items": {
-      "both": [ "dress_shirt", "pants", "socks", "boots", "knit_scarf", "coat_lab", "glasses_safety", "wristwatch" ],
+      "both": [ "dress_shirt", "pants", "socks", "boots", "coat_lab", "glasses_safety", "wristwatch" ],
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
     }

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -160,6 +160,12 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "mags_mini_14",
+    "entries": [ { "item": "ruger20", "ammo-item": "223", "charges": 20 }, { "item": "ruger20", "ammo-item": "223", "charges": 20 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "mags_waste_ranger",
     "entries": [ { "item": "blrmag", "ammo-item": "3006", "charges": 4 }, { "item": "blrmag", "ammo-item": "3006", "charges": 4 } ]
   },
@@ -201,6 +207,12 @@
     "subtype": "collection",
     "id": "quiver_crossbow_hunter",
     "entries": [ { "item": "bolt_metal", "charges": 9 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "quiver_feral_socialite",
+    "entries": [ { "item": "bolt_cf", "charges": 10 } ]
   },
   {
     "type": "item_group",
@@ -1330,35 +1342,34 @@
     "name": "Special Operator",
     "description": "You were the best of the best, the military's finest.  That's why you're still alive, even after all your comrades fell to the undead.  As far as you can tell, military command abandoned you in this hellhole when you missed the emergency evac.",
     "points": 5,
-    "traits": [ "PROF_MILITARY", "PROF_SWIMMER" ],
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "smg" },
+      { "level": 3, "name": "survival" },
       { "level": 2, "name": "cutting" },
       { "level": 2, "name": "melee" },
       { "level": 2, "name": "dodge" },
-      { "level": 1, "name": "firstaid" },
-      { "level": 1, "name": "swimming" },
-      { "level": 1, "name": "survival" }
+      { "level": 1, "name": "firstaid" }
     ],
     "items": {
       "both": {
         "items": [
-          "wetsuit",
           "pants_army",
-          "wetsuit_hood",
-          "tac_helmet",
-          "glasses_bal",
-          "wetsuit_gloves",
+          "tshirt",
+          "jacket_army",
+          "gloves_liner",
           "gloves_tactical",
+          "beret",
+          "glasses_bal",
           "socks",
           "boots_combat",
-          "two_way_radio",
-          "dive_bag",
-          "diving_watch"
+          "webbing_belt",
+          "wristwatch",
+          "molle_pack"
         ],
         "entries": [
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          { "group": "charged_two_way_radio" },
           { "item": "kukri", "container-item": "sheath" },
           { "item": "chestrig", "contents-group": "army_mags_mp5" },
           {
@@ -1372,6 +1383,100 @@
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boxer_shorts" ]
     }
+  },
+  {
+    "type": "profession",
+    "id": "specops_frogman",
+    "name": "Spec Ops Combat Diver",
+    "description": "You were the best of the best, the military's finest.  Trained in underwater sabotage and boarding operations, you've survived where others became shark bait.  As far as you can tell, military command has left you high and dry.",
+    "points": 5,
+    "traits": [ "PROF_MILITARY", "PROF_SWIMMER" ],
+    "skills": [
+      { "level": 3, "name": "gun" },
+      { "level": 3, "name": "smg" },
+      { "level": 3, "name": "swimming" },
+      { "level": 2, "name": "cutting" },
+      { "level": 2, "name": "melee" },
+      { "level": 2, "name": "dodge" },
+      { "level": 1, "name": "firstaid" },
+      { "level": 1, "name": "survival" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "wetsuit",
+          "pants_army",
+          "wetsuit_hood",
+          "tac_helmet",
+          "wetsuit_gloves",
+          "socks",
+          "swim_fins",
+          "dive_bag",
+          "diving_watch",
+          "goggles_swim",
+          "swim_fins",
+          "rebreather"
+        ],
+        "entries": [
+          { "group": "charged_two_way_radio" },
+          { "item": "diveknife", "container-item": "sheath" },
+          { "item": "chestrig", "contents-group": "army_mags_mp5" },
+          {
+            "item": "hk_mp5",
+            "ammo-item": "9mm",
+            "charges": 30,
+            "contents-item": [ "shoulder_strap", "suppressor", "holo_sight", "waterproof_gunmod" ]
+          }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "sports_bra", "boy_shorts" ]
+    }
+  },
+  {
+    "type": "profession",
+    "id": "military_saboteur",
+    "name": "Military Saboteur",
+    "description": "You were transferred to the lab's security department in an advisory position.  In actuality, in the event things went wrong your orders were to locate and disable some sort of portal experiment, and issued a backpack nuke.  Unfortunately, you discovered too late that this facility doesn't contain the equipment you were looking for.",
+    "points": 4,
+    "traits": [ "PROF_MILITARY" ],
+    "skills": [
+      { "level": 4, "name": "computer" },
+      { "level": 3, "name": "gun" },
+      { "level": 2, "name": "pistol" },
+      { "level": 2, "name": "speech" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "pants_army",
+          "tshirt",
+          "jacket_army",
+          "gloves_liner",
+          "gloves_tactical",
+          "beret",
+          "socks",
+          "boots_combat",
+          "webbing_belt",
+          "wristwatch",
+          "rucksack",
+          "mininuke",
+          "smart_phone",
+          "id_military"
+        ],
+        "entries": [
+          { "group": "charged_two_way_radio" },
+          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "light_battery_cell", "charges": 100, "container-item": "electrohack" },
+          { "item": "m9", "ammo-item": "9mm", "charges": 15, "container-item": "holster" },
+          { "item": "legpouch_large", "contents-group": "mags_m9_security" }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "boy_shorts", "sports_bra" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
   },
   {
     "type": "profession",
@@ -1413,6 +1518,131 @@
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boy_shorts" ]
     }
+  },
+  {
+    "type": "profession",
+    "id": "lifter_mech_pilot",
+    "name": "Industrial Mech Pilot",
+    "description": "You were recently certified to pilot an industrial and combat engineering model of the Mechanical Exoskeleton Suits the military had been developing.  It's not armed, but it might still be useful despite the heavy use its power cell has been through.",
+    "points": 6,
+    "pets": [ { "name": "mon_mech_lifter", "amount": 1 } ],
+    "skills": [ { "level": 3, "name": "mechanics" }, { "level": 3, "name": "electronics" }, { "level": 2, "name": "computer" } ],
+    "items": {
+      "both": {
+        "items": [
+          "technician_pants_gray",
+          "technician_shirt_gray",
+          "gloves_work",
+          "socks",
+          "boots_steel",
+          "hat_hard",
+          "glasses_safety",
+          "wristwatch",
+          "smart_phone"
+        ],
+        "entries": [
+          { "item": "tool_belt", "contents-item": [ "voltmeter", "wrench", "screwdriver_set" ] },
+          { "item": "huge_atomic_battery_cell", "charges": [ 10000, 25000 ], "custom-flags": [ "auto_wield" ] }
+        ]
+      },
+      "male": [ "boxer_briefs" ],
+      "female": [ "bra", "panties" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "id": "combat_mech_pilot",
+    "name": "Combat Mech Pilot",
+    "description": "You were field-testing the latest in military firepower, with Mechanical Exoskeleton Suits planned to fill the niche left after power armor development shifted to lighter models.  Your mech's built to lay down heavy fire support, but the power cell the technicians provided has been mostly depleted from earlier tests.",
+    "points": 8,
+    "traits": [ "PROF_MILITARY" ],
+    "pets": [ { "name": "mon_mech_combat", "amount": 1 } ],
+    "skills": [
+      { "level": 2, "name": "mechanics" },
+      { "level": 2, "name": "electronics" },
+      { "level": 2, "name": "computer" },
+      { "level": 2, "name": "gun" },
+      { "level": 1, "name": "rifle" },
+      { "level": 1, "name": "dodge" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "pants_army",
+          "tshirt",
+          "jacket_army",
+          "gloves_liner",
+          "gloves_tactical",
+          "socks",
+          "boots_combat",
+          "helmet_liner",
+          "helmet_army",
+          "glasses_bal",
+          "webbing_belt",
+          "wristwatch",
+          "canteen",
+          "molle_pack",
+          "multitool"
+        ],
+        "entries": [
+          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "m17", "ammo-item": "9mm", "container-item": "holster", "charges": 17 },
+          { "item": "legpouch_large", "contents-group": "army_mags_m17" },
+          { "item": "huge_atomic_battery_cell", "charges": [ 10000, 25000 ] }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "boy_shorts", "sports_bra" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "id": "recon_mech_pilot",
+    "name": "Recon Mech Pilot",
+    "description": "You were field-testing the latest in military firepower, with Mechanical Exoskeleton Suits planned to fill the niche left after power armor development shifted to lighter models.  Your mech's built for scouting and sniping, but the power cell the technicians provided has been mostly depleted from earlier tests.",
+    "points": 8,
+    "traits": [ "PROF_MILITARY" ],
+    "pets": [ { "name": "mon_mech_recon", "amount": 1 } ],
+    "skills": [
+      { "level": 2, "name": "mechanics" },
+      { "level": 2, "name": "electronics" },
+      { "level": 2, "name": "computer" },
+      { "level": 2, "name": "gun" },
+      { "level": 1, "name": "rifle" },
+      { "level": 1, "name": "dodge" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "pants_army",
+          "tshirt",
+          "jacket_army",
+          "gloves_liner",
+          "gloves_tactical",
+          "socks",
+          "boots_combat",
+          "helmet_liner",
+          "helmet_army",
+          "glasses_bal",
+          "webbing_belt",
+          "wristwatch",
+          "canteen",
+          "molle_pack",
+          "multitool"
+        ],
+        "entries": [
+          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "m17", "ammo-item": "9mm", "container-item": "holster", "charges": 17 },
+          { "item": "legpouch_large", "contents-group": "army_mags_m17" },
+          { "item": "huge_atomic_battery_cell", "charges": [ 10000, 25000 ] }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "boy_shorts", "sports_bra" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
   },
   {
     "type": "profession",
@@ -1778,6 +2008,17 @@
   },
   {
     "type": "profession",
+    "id": "medic_pilot",
+    "copy-from": "medic",
+    "name": "Medevac Pilot",
+    "description": "As a first responder piloting a medical chopper, you had a birds-eye view of how bad things were getting.  Just when you thought you'd seen the worst of it, patients that were DOA started clawing their way out of their body bags, and dispatch gave a panicked message about the hospitals being overrun before the radio went silent.",
+    "points": 5,
+    "skills": [ { "level": 4, "name": "firstaid" }, { "level": 4, "name": "driving" } ],
+    "vehicle": "Medevac2",
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
     "id": "gyro_pilot",
     "name": "Gyrocopter Pilot",
     "description": "You always loved tinkering with flying machines as a hobby.  With your gyrocopter and what little flight gear you could scrounge up while the world was ending, the sky's the limit.",
@@ -1798,6 +2039,25 @@
           "wristwatch",
           "smart_phone"
         ],
+        "entries": [ { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] } ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "boy_shorts" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "id": "bird_pilot",
+    "name": "Avian Heli Pilot",
+    "description": "When the world ended, you thought your piloting experience would keep you safe.  Then the feathers starting growing out.  You must've poked your nose (wait, beak!?) where it didn't belong during one of your stops to refuel.  At least now you have a backup plan if your ride fails you.",
+    "vehicle": "SmallFlier3",
+    "points": 5,
+    "traits": [ "FEATHERS", "WINGS_BIRD", "BEAK", "THRESH_BIRD" ],
+    "skills": [ { "level": 4, "name": "driving" }, { "level": 1, "name": "speech" }, { "level": 3, "name": "mechanics" } ],
+    "items": {
+      "both": {
+        "items": [ "pants_cargo", "socks", "tank_top", "smart_phone", "boots", "wristwatch", "fancy_sunglasses" ],
         "entries": [ { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] } ]
       },
       "male": [ "boxer_shorts" ],
@@ -2579,7 +2839,14 @@
       "bio_power_storage",
       "bio_torsionratchet"
     ],
-    "items": { "both": [ "subsuit_xl", "footrags", "hat_noise_cancelling" ], "male": [ "briefs" ], "female": [ "bra", "panties" ] }
+    "items": {
+      "both": {
+        "items": [ "subsuit_xl", "footrags" ],
+        "entries": [ { "item": "hat_noise_cancelling", "custom-flags": [ "no_auto_equip" ] } ]
+      },
+      "male": [ "briefs" ],
+      "female": [ "bra", "panties" ]
+    }
   },
   {
     "type": "profession",
@@ -3460,18 +3727,12 @@
       { "level": 2, "name": "survival" }
     ],
     "items": {
-      "both": [
-        "tank_top",
-        "shorts_cargo",
-        "footrags",
-        "gloves_wraps",
-        "hat_cotton",
-        "bandana",
-        "hat_noise_cancelling",
-        "wristwatch"
-      ],
+      "both": {
+        "items": [ "tank_top", "shorts_cargo", "footrags", "gloves_wraps", "hat_cotton", "bandana", "wristwatch" ],
+        "entries": [ { "item": "hat_noise_cancelling", "custom-flags": [ "no_auto_equip" ] } ]
+      },
       "male": [ "briefs" ],
-      "female": [ "panties" ]
+      "female": [ "bra", "panties" ]
     }
   },
   {
@@ -4348,7 +4609,6 @@
           "leather_belt",
           "knit_scarf",
           "tricorne",
-          "hatchet",
           "hardtack",
           "pipe_cleaner"
         ],
@@ -4356,6 +4616,7 @@
           { "item": "rifle_flintlock", "ammo-item": "flintlock_ammo", "charges": 1, "contents-item": "shoulder_strap" },
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
           { "item": "flintlock_ammo", "charges": 9 },
+          { "item": "hatchet", "container-item": "axe_ring" },
           { "item": "vinegar", "container-item": "bottle_plastic_small" },
           { "item": "lamp_oil", "container-item": "bottle_plastic_small" }
         ]
@@ -4413,7 +4674,6 @@
           "leather_belt",
           "knit_scarf",
           "tricorne",
-          "hatchet",
           "hardtack",
           "pipe_cleaner"
         ],
@@ -4421,6 +4681,7 @@
           { "item": "rifle_flintlock", "ammo-item": "flintlock_ammo", "charges": 1, "contents-item": "shoulder_strap" },
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
           { "item": "flintlock_ammo", "charges": 9 },
+          { "item": "hatchet", "container-item": "axe_ring" },
           { "item": "vinegar", "container-item": "bottle_plastic_small" },
           { "item": "lamp_oil", "container-item": "bottle_plastic_small" }
         ]
@@ -4521,7 +4782,7 @@
   {
     "type": "profession",
     "id": "skaterkid",
-    "name": { "male": "Skater Boy (Rollerblades)", "female": "Skater Girl (Rollerblades)" },
+    "name": "Rollerblader",
     "description": "You love to skate!  At least now the grown-ups aren't telling you where you can't roll.",
     "points": 1,
     "skills": [ { "level": 1, "name": "dodge" }, { "level": 2, "name": "swimming" } ],
@@ -4550,7 +4811,7 @@
   {
     "type": "profession",
     "id": "skaterkid_board",
-    "name": { "male": "Skater Boy (Skateboard)", "female": "Skater Girl (Skateboard)" },
+    "name": "Skateboarder",
     "description": "You love to skate!  You've probably spent more time on a skateboard than off.  Things have gotten pretty bad, but at least the grown-ups aren't telling you where you can't roll.",
     "points": 1,
     "skills": [ { "level": 1, "name": "driving" }, { "level": 2, "name": "swimming" } ],
@@ -4795,7 +5056,7 @@
     "id": "camper",
     "name": "Camper",
     "description": "You always enjoyed hiking and camping in the wilderness before everything fell apart, so it was a no-brainer to grab your bag and run when the sirens sounded.  The world may be ruined, but you're prepared to make a home wherever you may find yourself.",
-    "points": 6,
+    "points": 4,
     "skills": [ { "level": 1, "name": "survival" }, { "level": 1, "name": "swimming" }, { "level": 1, "name": "firstaid" } ],
     "items": {
       "both": {
@@ -4810,7 +5071,6 @@
           "knit_scarf",
           "backpack",
           "ref_lighter",
-          "hatchet",
           "e_tool",
           "tent_kit",
           "rollmat",
@@ -4824,7 +5084,52 @@
           "wristwatch",
           "1st_aid"
         ],
-        "entries": [ { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "mess_kit" } ]
+        "entries": [
+          { "item": "hatchet", "container-item": "axe_ring" },
+          { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "mess_kit" }
+        ]
+      },
+      "male": [ "briefs" ],
+      "female": [ "sports_bra", "boy_shorts" ]
+    }
+  },
+  {
+    "type": "profession",
+    "id": "rv_camper",
+    "name": "RV Camper",
+    "description": "You always enjoyed life on the road, driving across the country to see the wonders of nature.  Now nature seems a lot less hostile, and it's a lot harder to get your RV hooked up to shore power.",
+    "points": 5,
+    "skills": [
+      { "level": 1, "name": "survival" },
+      { "level": 1, "name": "swimming" },
+      { "level": 1, "name": "firstaid" },
+      { "level": 1, "name": "driving" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "tshirt",
+          "socks",
+          "jeans",
+          "jacket_windbreaker",
+          "boots_hiking",
+          "gloves_light",
+          "hat_cotton",
+          "knit_scarf",
+          "backpack",
+          "ref_lighter",
+          "e_tool",
+          "knife_swissarmy",
+          "canteen",
+          "granola",
+          "pur_tablets",
+          "smart_phone",
+          "wristwatch",
+          "1st_aid",
+          "mess_tin",
+          "jumper_cable"
+        ],
+        "entries": [ { "item": "hatchet", "container-item": "axe_ring" } ]
       },
       "male": [ "briefs" ],
       "female": [ "sports_bra", "boy_shorts" ]
@@ -5465,19 +5770,22 @@
     "traits": [ "PROF_FERAL" ],
     "items": {
       "both": {
-        "items": [ "pockknife", "bottle_plastic", "wristwatch" ],
-        "entries": [
-          { "item": "longshirt", "damage": [ 0, 3 ] },
-          { "item": "jeans", "damage": [ 0, 3 ] },
-          { "item": "socks", "damage": [ 0, 3 ] },
-          { "item": "sneakers", "damage": [ 0, 3 ] },
-          { "item": "mbag", "damage": [ 0, 3 ] },
-          { "item": "wristwatch", "damage": [ 0, 3 ] },
-          { "item": "makeshift_crowbar", "custom-flags": [ "auto_wield" ] }
-        ]
+        "items": [
+          "jeans",
+          "longshirt",
+          "socks",
+          "sneakers",
+          "mbag",
+          "pockknife",
+          "water_clean",
+          "smart_phone",
+          "matches",
+          "wristwatch"
+        ],
+        "entries": [ { "item": "makeshift_crowbar", "custom-flags": [ "auto_wield" ] } ]
       },
-      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] },
-      "female": { "entries": [ { "item": "bra", "damage": [ 0, 3 ] }, { "item": "panties", "damage": [ 0, 3 ] } ] }
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "panties" ]
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -5496,26 +5804,14 @@
     ],
     "items": {
       "both": {
-        "items": [ "pockknife", "bottle_plastic", "wristwatch" ],
+        "items": [ "dress_shirt", "pants", "socks", "boots", "coat_lab", "gloves_rubber", "glasses_safety", "smart_phone", "wristwatch" ],
         "entries": [
-          { "item": "dress_shirt", "damage": [ 0, 3 ] },
-          { "item": "coat_lab", "damage": [ 0, 3 ] },
-          { "item": "jeans", "damage": [ 0, 3 ] },
-          { "item": "socks", "damage": [ 0, 3 ] },
-          { "item": "boots", "damage": [ 0, 3 ] },
-          { "item": "gloves_rubber", "damage": [ 0, 3 ] },
-          { "item": "glasses_safety", "damage": [ 0, 3 ] },
-          {
-            "item": "medium_battery_cell",
-            "ammo-item": "battery",
-            "charges": [ 1, 500 ],
-            "container-item": "chemistry_set"
-          },
+          { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "chemistry_set" },
           { "item": "scalpel", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "male": { "entries": [ { "item": "briefs", "damage": [ 0, 3 ] } ] },
-      "female": { "entries": [ { "item": "bra", "damage": [ 0, 3 ] }, { "item": "panties", "damage": [ 0, 3 ] } ] }
+      "male": [ "briefs" ],
+      "female": [ "bra", "panties" ]
     }
   },
   {
@@ -5529,32 +5825,39 @@
     "traits": [ "PROF_POLICE", "PROF_FERAL" ],
     "items": {
       "both": {
-        "items": [ "two_way_radio", "whistle", "wristwatch", "badge_deputy" ],
+        "items": [
+          "pants_army",
+          "socks",
+          "badge_deputy",
+          "smart_phone",
+          "sheriffshirt",
+          "police_belt",
+          "boots",
+          "whistle",
+          "wristwatch"
+        ],
         "entries": [
-          { "item": "sheriffshirt", "damage": [ 0, 3 ] },
-          { "item": "pants_army", "damage": [ 0, 3 ] },
-          { "item": "socks", "damage": [ 0, 3 ] },
-          { "item": "boots", "damage": [ 0, 3 ] },
-          { "item": "police_belt", "damage": [ 0, 3 ] },
-          { "item": "legpouch_large", "damage": [ 0, 3 ] },
+          { "group": "charged_two_way_radio" },
+          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           {
-            "item": "m9",
-            "ammo-item": "9mm",
-            "charges": [ 1, 15 ],
+            "item": "usp_45",
+            "ammo-item": "45_acp",
+            "charges": 12,
             "container-item": "holster",
             "contents-item": "pistol_lanyard"
           },
+          { "item": "legpouch_large", "contents-group": "army_mags_usp45" },
           {
             "item": "light_battery_cell",
             "ammo-item": "battery",
-            "charges": [ 1, 100 ],
+            "charges": 100,
             "container-item": "heavy_flashlight",
             "custom-flags": [ "auto_wield" ]
           }
         ]
       },
-      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] },
-      "female": { "entries": [ { "item": "bra", "damage": [ 0, 3 ] }, { "item": "boy_shorts", "damage": [ 0, 3 ] } ] }
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "boy_shorts" ]
     }
   },
   {
@@ -5568,21 +5871,24 @@
     "skills": [ { "level": 2, "name": "melee" }, { "level": 1, "name": "firstaid" }, { "level": 1, "name": "swimming" } ],
     "items": {
       "both": {
-        "items": [ "pocketwatch" ],
+        "items": [
+          "bunker_pants",
+          "bunker_coat",
+          "nomex_socks",
+          "boots_bunker",
+          "fire_gauntlets",
+          "glasses_safety",
+          "firehelmet",
+          "pocketwatch",
+          "fireman_belt"
+        ],
         "entries": [
-          { "item": "bunker_coat", "damage": [ 0, 3 ] },
-          { "item": "bunker_pants", "damage": [ 0, 3 ] },
-          { "item": "nomex_socks", "damage": [ 0, 3 ] },
-          { "item": "boots_bunker", "damage": [ 0, 3 ] },
-          { "item": "fire_gauntlets", "damage": [ 0, 3 ] },
-          { "item": "glasses_safety", "damage": [ 0, 3 ] },
-          { "item": "fireman_belt", "damage": [ 0, 3 ] },
-          { "item": "firehelmet", "damage": [ 0, 3 ] },
+          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "fire_ax", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] },
-      "female": { "entries": [ { "item": "bra", "damage": [ 0, 3 ] }, { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] }
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "boxer_shorts" ]
     }
   },
   {
@@ -5595,22 +5901,27 @@
     "skills": [ { "level": 3, "name": "mechanics" } ],
     "items": {
       "both": {
-        "items": [ "wristwatch", "welder" ],
+        "items": [
+          "slingpack",
+          "tank_top",
+          "technician_shirt_gray",
+          "technician_pants_gray",
+          "socks",
+          "boots_steel",
+          "duct_tape",
+          "smart_phone",
+          "wristwatch",
+          "mag_cars"
+        ],
         "entries": [
-          { "item": "technician_shirt_gray", "damage": [ 0, 3 ] },
-          { "item": "technician_pants_gray", "damage": [ 0, 3 ] },
-          { "item": "socks", "damage": [ 0, 3 ] },
-          { "item": "boots_steel", "damage": [ 0, 3 ] },
-          { "item": "gloves_work", "damage": [ 0, 3 ] },
-          { "item": "slingpack", "damage": [ 0, 3 ] },
-          { "item": "tool_belt", "damage": [ 0, 3 ], "contents-item": "screwdriver" },
-          { "item": "duct_tape", "charges": [ 1, 200 ] },
           { "item": "goggles_welding", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "tool_belt", "contents-item": "screwdriver" },
+          { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "welder" },
           { "item": "wrench", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] },
-      "female": { "entries": [ { "item": "bra", "damage": [ 0, 3 ] }, { "item": "boy_shorts", "damage": [ 0, 3 ] } ] }
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "boy_shorts" ]
     }
   },
   {
@@ -5625,29 +5936,34 @@
     "vehicle": "motorcycle",
     "items": {
       "both": {
-        "items": [ "wristwatch", "multitool" ],
+        "items": [
+          "jeans",
+          "tank_top",
+          "chaps_leather",
+          "smart_phone",
+          "socks",
+          "boots",
+          "bandana",
+          "pickelhaube",
+          "jacket_leather",
+          "wristwatch",
+          "meth",
+          "multitool"
+        ],
         "entries": [
-          { "item": "tank_top", "damage": [ 0, 3 ] },
-          { "item": "jacket_leather", "damage": [ 0, 3 ] },
-          { "item": "jeans", "damage": [ 0, 3 ] },
-          { "item": "chaps_leather", "damage": [ 0, 3 ] },
-          { "item": "socks", "damage": [ 0, 3 ] },
-          { "item": "boots", "damage": [ 0, 3 ] },
-          { "item": "bandana", "damage": [ 0, 3 ] },
-          { "item": "pickelhaube", "damage": [ 0, 3 ] },
           { "item": "sheath", "contents-item": "knife_trench" },
-          { "item": "meth", "charges": [ 1, 3 ] },
+          { "item": "bandolier_shotgun", "contents-group": "bandolier_shotgun_hunter" },
           {
             "item": "mossberg_500",
             "ammo-item": "shot_00",
-            "charges": [ 1, 6 ],
+            "charges": 6,
             "contents-item": "shoulder_strap",
             "custom-flags": [ "auto_wield" ]
           }
         ]
       },
-      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] },
-      "female": { "entries": [ { "item": "bra", "damage": [ 0, 3 ] }, { "item": "boy_shorts", "damage": [ 0, 3 ] } ] }
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "boy_shorts" ]
     }
   },
   {
@@ -5668,29 +5984,38 @@
     ],
     "items": {
       "both": {
-        "items": [ "wristwatch", "canteen", "rope_30", "whistle", "lighter" ],
+        "items": [
+          "pants_cargo",
+          "boots",
+          "hat_boonie",
+          "tshirt",
+          "kevlar",
+          "jacket_light",
+          "socks",
+          "backpack",
+          "rope_30",
+          "whistle",
+          "smart_phone",
+          "wristwatch",
+          "canteen"
+        ],
         "entries": [
-          { "item": "kevlar", "damage": [ 0, 3 ] },
-          { "item": "tshirt", "damage": [ 0, 3 ] },
-          { "item": "jacket_light", "damage": [ 0, 3 ] },
-          { "item": "pants_cargo", "damage": [ 0, 3 ] },
-          { "item": "socks", "damage": [ 0, 3 ] },
-          { "item": "boots", "damage": [ 0, 3 ] },
-          { "item": "hat_boonie", "damage": [ 0, 3 ] },
+          { "group": "charged_flashlight" },
+          { "item": "lighter", "charges": 100 },
+          { "item": "knife_rambo", "container-item": "scabbard" },
           { "item": "light_battery_cell", "charges": [ 1, 100 ], "container-item": "wearable_light" },
-          { "item": "backpack", "damage": [ 0, 3 ] },
-          { "item": "makeshift_machete", "container-item": "scabbard" },
+          { "item": "legpouch_large", "contents-group": "mags_mini_14" },
           {
             "item": "ruger_mini",
             "ammo-item": "223",
-            "charges": [ 1, 20 ],
+            "charges": 20,
             "contents-item": "shoulder_strap",
             "custom-flags": [ "auto_wield" ]
           }
         ]
       },
-      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] },
-      "female": { "entries": [ { "item": "bra", "damage": [ 0, 3 ] }, { "item": "boy_shorts", "damage": [ 0, 3 ] } ] }
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "boxer_shorts" ]
     }
   },
   {
@@ -5711,33 +6036,33 @@
     ],
     "items": {
       "both": {
-        "items": [ "wristwatch", "two_way_radio", "grenade" ],
+        "items": [
+          "pants_army",
+          "tshirt",
+          "jacket_army",
+          "helmet_liner",
+          "helmet_army",
+          "mask_gas",
+          "gloves_liner",
+          "gloves_tactical",
+          "socks",
+          "boots_combat",
+          "wristwatch",
+          "canteen",
+          "molle_pack"
+        ],
         "entries": [
-          { "item": "undershirt", "damage": [ 0, 3 ] },
-          { "item": "jacket_army", "damage": [ 0, 3 ] },
-          { "item": "pants_army", "damage": [ 0, 3 ] },
-          { "item": "modularvestceramic", "damage": [ 0, 3 ] },
-          { "item": "socks", "damage": [ 0, 3 ] },
-          { "item": "boots_combat", "damage": [ 0, 3 ] },
-          { "item": "gloves_liner", "damage": [ 0, 3 ] },
-          { "item": "gloves_tactical", "damage": [ 0, 3 ] },
-          { "item": "mask_ski", "damage": [ 0, 3 ] },
-          { "item": "helmet_army", "damage": [ 0, 3 ] },
-          { "item": "mask_gas", "damage": [ 0, 3 ], "charges": [ 1, 100 ] },
-          { "item": "molle_pack", "damage": [ 0, 3 ] },
-          { "item": "webbing_belt", "damage": [ 0, 3 ], "contents-item": "e_tool" },
+          { "group": "charged_two_way_radio" },
+          { "item": "modularvestceramic", "contents-group": "army_mags_m4" },
+          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "e_tool", "container-item": "webbing_belt" },
           { "item": "knife_combat", "container-item": "sheath" },
-          {
-            "item": "m4a1",
-            "ammo-item": "556",
-            "charges": [ 1, 30 ],
-            "contents-item": [ "shoulder_strap", "holo_sight" ],
-            "custom-flags": [ "auto_wield" ]
-          }
+          { "item": "grenadebandolier", "contents-item": [ "grenade", "grenade" ] },
+          { "item": "m4a1", "ammo-item": "556", "charges": 30, "contents-item": [ "shoulder_strap", "holo_sight" ] }
         ]
       },
-      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] },
-      "female": { "entries": [ { "item": "sports_bra", "damage": [ 0, 3 ] }, { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] }
+      "male": [ "boxer_shorts" ],
+      "female": [ "boy_shorts", "sports_bra" ]
     }
   },
   {
@@ -5774,18 +6099,27 @@
     ],
     "items": {
       "both": {
-        "items": [ "wristwatch" ],
-        "entries": [
-          { "item": "tank_top", "damage": [ 0, 3 ] },
-          { "item": "shorts_cargo", "damage": [ 0, 3 ] },
-          { "item": "footrags", "damage": [ 0, 3 ] },
-          { "item": "gloves_wraps", "damage": [ 0, 3 ] },
-          { "item": "hat_cotton", "damage": [ 0, 3 ] },
-          { "item": "bandana", "damage": [ 0, 3 ] }
-        ]
+        "items": [ "tank_top", "shorts_cargo", "footrags", "gloves_wraps", "hat_cotton", "bandana", "wristwatch" ],
+        "entries": [ { "item": "hat_noise_cancelling", "custom-flags": [ "no_auto_equip" ] } ]
       },
-      "male": { "entries": [ { "item": "briefs", "damage": [ 0, 3 ] } ] },
-      "female": { "entries": [ { "item": "panties", "damage": [ 0, 3 ] } ] }
+      "male": [ "briefs" ],
+      "female": [ "panties" ]
+    }
+  },
+  {
+    "type": "profession",
+    "id": "prof_feral_mutant",
+    "copy-from": "prof_feral_mutant",
+    "name": "Feral Mutant",
+    "description": "Your dreamed of becoming a super-human mutant through genetic alteration.  So what if you're a freak of nature now?  ",
+    "traits": [ "PROF_FERAL", "PATCHSKIN1", "SABER_TEETH", "HOOVES", "LARGE", "THRESH_CHIMERA" ],
+    "//": "Contains a Powerwolf reference.  +2 points due to skills but balanced out by mixed bag of Chimera mutations.",
+    "points": 3,
+    "skills": [ { "level": 2, "name": "cooking" }, { "level": 2, "name": "electronics" } ],
+    "items": {
+      "both": [ "dress_shirt", "pants", "socks", "boots", "knit_scarf", "coat_lab", "glasses_safety", "wristwatch" ],
+      "male": [ "briefs" ],
+      "female": [ "bra", "panties" ]
     }
   },
   {
@@ -5798,23 +6132,11 @@
     "skills": [ { "level": 2, "name": "cooking" }, { "level": 1, "name": "driving" }, { "level": 2, "name": "tailor" } ],
     "items": {
       "both": {
-        "items": [ "pocketwatch" ],
-        "entries": [
-          { "item": "socks", "damage": [ 0, 3 ] },
-          { "item": "dress_shoes", "damage": [ 0, 3 ] },
-          { "item": "knife_butcher", "container-item": "sheath" },
-          { "item": "broom", "custom-flags": [ "auto_wield" ] }
-        ]
+        "items": [ "pocketwatch", "smart_phone", "knife_steak" ],
+        "entries": [ { "item": "knife_butcher", "container-item": "sheath" }, { "item": "broom", "custom-flags": [ "auto_wield" ] } ]
       },
-      "male": { "entries": [ { "item": "briefs", "damage": [ 0, 3 ] }, { "item": "suit", "damage": [ 0, 3 ] } ] },
-      "female": {
-        "entries": [
-          { "item": "bra", "damage": [ 0, 3 ] },
-          { "item": "panties", "damage": [ 0, 3 ] },
-          { "item": "maid_dress", "damage": [ 0, 3 ] },
-          { "item": "maid_hat", "damage": [ 0, 3 ] }
-        ]
-      }
+      "male": [ "briefs", "socks", "dress_shoes", "tux" ],
+      "female": [ "panties", "bra", "stockings", "dress_shoes", "maid_dress", "maid_hat" ]
     }
   },
   {
@@ -5823,7 +6145,12 @@
     "copy-from": "prof_feral_unemployed",
     "name": "Feral Socialite",
     "description": "Elegant as always, the end of the world hardly fazed you at all.  Your entourage is as lively as ever, just a bit peckish.  Best to not keep them waiting, let the hunt begin.",
-    "points": 5,
+    "points": 6,
+    "pets": [
+      { "name": "mon_feral_maid_broom", "amount": 1 },
+      { "name": "mon_feral_maid_candlestick", "amount": 1 },
+      { "name": "mon_feral_maid_knife", "amount": 1 }
+    ],
     "skills": [
       { "level": 3, "name": "dodge" },
       { "level": 3, "name": "melee" },
@@ -5833,30 +6160,15 @@
     ],
     "items": {
       "both": {
-        "items": [ "quiver", "pocketwatch" ],
+        "items": [ "socks", "dress_shoes", "pocketwatch" ],
         "entries": [
-          { "item": "socks", "damage": [ 0, 3 ] },
-          { "item": "dress_shoes", "damage": [ 0, 3 ] },
           { "item": "rapier", "container-item": "scabbard" },
-          { "item": "rep_crossbow", "ammo-item": "bolt_cf", "charges": [ 1, 10 ], "custom-flags": [ "auto_wield" ] }
+          { "item": "rep_crossbow", "ammo-item": "bolt_cf", "charges": 10, "custom-flags": [ "auto_wield" ] },
+          { "item": "quiver", "contents-group": "quiver_feral_socialite" }
         ]
       },
-      "male": {
-        "entries": [
-          { "item": "boxer_shorts", "damage": [ 0, 3 ] },
-          { "item": "tux", "damage": [ 0, 3 ] },
-          { "item": "bowhat", "damage": [ 0, 3 ] }
-        ]
-      },
-      "female": {
-        "entries": [
-          { "item": "bra", "damage": [ 0, 3 ] },
-          { "item": "panties", "damage": [ 0, 3 ] },
-          { "item": "gown", "damage": [ 0, 3 ] },
-          { "item": "long_glove_white", "damage": [ 0, 3 ] },
-          { "item": "purse", "damage": [ 0, 3 ] }
-        ]
-      }
+      "male": [ "boxer_shorts", "tux", "bowhat" ],
+      "female": [ "bra", "panties", "gown", "long_glove_white", "purse" ]
     }
   },
   {
@@ -5866,7 +6178,7 @@
     "name": "Feral Reenactor",
     "//": "Contains a (rearranged) Manowar reference.",
     "description": "You were all set to attend the faire, only for these impudent knaves to spoil your fun.  With mace in hand, may steel meet blood and bone.",
-    "points": 5,
+    "points": 6,
     "skills": [
       { "level": 2, "name": "melee" },
       { "level": 1, "name": "bashing" },
@@ -5875,19 +6187,11 @@
     ],
     "items": {
       "both": {
-        "items": [ "leather_pouch" ],
-        "entries": [
-          { "item": "chainmail_hauberk", "damage": [ 0, 3 ] },
-          { "item": "socks", "damage": [ 0, 3 ] },
-          { "item": "boots_plate", "damage": [ 0, 3 ] },
-          { "item": "gloves_plate", "damage": [ 0, 3 ] },
-          { "item": "helmet_barbute", "damage": [ 0, 3 ] },
-          { "item": "shield_leather", "damage": [ 0, 3 ] },
-          { "item": "mace", "custom-flags": [ "auto_wield" ] }
-        ]
+        "items": [ "chainmail_hauberk", "socks", "boots_plate", "gloves_plate", "helmet_barbute", "leather_pouch", "shield_leather" ],
+        "entries": [ { "item": "mace", "custom-flags": [ "auto_wield" ] } ]
       },
-      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] },
-      "female": { "entries": [ { "item": "bra", "damage": [ 0, 3 ] }, { "item": "panties", "damage": [ 0, 3 ] } ] }
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "panties" ]
     }
   },
   {
@@ -5900,22 +6204,24 @@
     "points": 1,
     "items": {
       "both": {
-        "items": [ "wristwatch", "attached_ear_plugs_off" ],
-        "entries": [
-          { "item": "longshirt", "damage": [ 0, 3 ] },
-          { "item": "apron_leather", "damage": [ 0, 3 ] },
-          { "item": "jeans", "damage": [ 0, 3 ] },
-          { "item": "socks", "damage": [ 0, 3 ] },
-          { "item": "boots_steel", "damage": [ 0, 3 ] },
-          { "item": "armguard_hard", "damage": [ 0, 3 ] },
-          { "item": "gloves_work", "damage": [ 0, 3 ] },
-          { "item": "glasses_safety", "damage": [ 0, 3 ] },
-          { "item": "hat_hard_hooded", "damage": [ 0, 3 ] },
-          { "item": "chainsaw_off", "ammo-item": "gasoline", "charges": [ 1, 450 ], "custom-flags": [ "auto_wield" ] }
-        ]
+        "items": [
+          "longshirt",
+          "apron_leather",
+          "jeans",
+          "socks",
+          "boots_steel",
+          "armguard_hard",
+          "gloves_work",
+          "glasses_safety",
+          "hat_hard_hooded",
+          "smart_phone",
+          "wristwatch",
+          "attached_ear_plugs_off"
+        ],
+        "entries": [ { "item": "chainsaw_off", "ammo-item": "gasoline", "charges": 450, "custom-flags": [ "auto_wield" ] } ]
       },
-      "male": { "entries": [ { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] },
-      "female": { "entries": [ { "item": "bra", "damage": [ 0, 3 ] }, { "item": "boxer_shorts", "damage": [ 0, 3 ] } ] }
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "boxer_shorts" ]
     }
   }
 ]

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -51,7 +51,7 @@
       "bionic_diver",
       "fisher",
       "davy_jones",
-      "specops",
+      "specops_frogman",
       "lagoon_creature",
       "sharkboy"
     ],
@@ -263,6 +263,7 @@
       "prof_feral_survivalist",
       "prof_feral_soldier",
       "prof_feral_cyborg",
+      "prof_feral_mutant",
       "prof_feral_maid",
       "prof_feral_socialite",
       "prof_feral_armored",
@@ -355,7 +356,17 @@
     "points": -8,
     "description": "You were deemed non-essential and made to stay behind during the lab evacuation.  Find a way to escape or starve to death.",
     "start_name": "Locked Lab",
-    "professions": [ "labtech", "bionic_labtech", "security", "medic", "bionic_installer", "bio_medic", "bionic_mentat", "bionic_spy" ],
+    "professions": [
+      "labtech",
+      "bionic_labtech",
+      "security",
+      "medic",
+      "bionic_installer",
+      "bio_medic",
+      "bionic_mentat",
+      "bionic_spy",
+      "military_saboteur"
+    ],
     "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale" ],
     "flags": [ "CHALLENGE", "CITY_START", "LONE_START" ]
   },
@@ -400,7 +411,9 @@
       "waste_ranger",
       "player_bandit",
       "monster_hunter",
-      "monster_slayer"
+      "monster_slayer",
+      "gyro_pilot",
+      "bird_pilot"
     ]
   },
   {
@@ -435,7 +448,9 @@
       "waste_ranger",
       "player_bandit",
       "monster_hunter",
-      "monster_slayer"
+      "monster_slayer",
+      "gyro_pilot",
+      "bird_pilot"
     ]
   },
   {
@@ -636,7 +651,11 @@
       "mil_marksman",
       "prof_combat_engineer",
       "specops",
+      "specops_frogman",
       "power_armor_soldier",
+      "lifter_mech_pilot",
+      "combat_mech_pilot",
+      "recon_mech_pilot",
       "bio_soldier",
       "bio_sniper",
       "bionic_spy",
@@ -664,6 +683,7 @@
       "gangster",
       "prof_ninja",
       "specops",
+      "specops_frogman",
       "bionic_spy",
       "bionic_hitman",
       "bio_gangster",
@@ -681,7 +701,17 @@
     "description": "You were participating in a mining operation when you found… something.  You're not sure what, but it sure is dark down here.",
     "start_name": "Bottom of a mine",
     "allowed_locs": [ "sloc_mine_finale" ],
-    "professions": [ "miner", "labtech", "bionic_labtech", "security", "bionic_worker", "archaeologist", "drone_op", "demolition_expert" ],
+    "professions": [
+      "miner",
+      "labtech",
+      "bionic_labtech",
+      "security",
+      "bionic_worker",
+      "archaeologist",
+      "drone_op",
+      "demolition_expert",
+      "lifter_mech_pilot"
+    ],
     "flags": [ "CITY_START", "LONE_START" ]
   },
   {
@@ -693,7 +723,7 @@
     "start_name": "Emergency Landing Site",
     "allowed_locs": [ "sloc_field", "sloc_forest" ],
     "missions": [ "MISSION_HELICOPTER_REFUEL" ],
-    "professions": [ "heli_pilot_scenario", "gyro_pilot", "mili_pilot_blackhawk" ],
+    "professions": [ "heli_pilot_scenario", "medic_pilot", "gyro_pilot", "bird_pilot", "mili_pilot_blackhawk" ],
     "flags": [ "LONE_START" ]
   },
   {
@@ -738,7 +768,11 @@
       "mil_marksman",
       "prof_combat_engineer",
       "specops",
+      "specops_frogman",
       "power_armor_soldier",
+      "lifter_mech_pilot",
+      "combat_mech_pilot",
+      "recon_mech_pilot",
       "bio_soldier",
       "bio_sniper",
       "labtech",
@@ -789,7 +823,11 @@
       "mil_grenadier",
       "mil_marksman",
       "specops",
+      "specops_frogman",
       "power_armor_soldier",
+      "lifter_mech_pilot",
+      "combat_mech_pilot",
+      "recon_mech_pilot",
       "bio_soldier",
       "bio_sniper",
       "medic",


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This adds some more professions for fun, and makes a couple changes to modernize a few related professions.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Adds the following professions:
1. RV campers. Take the camper profession, give them an RV, swap out the tools that an RV can do the job of for you, add driving skill and jumper cables for glomming onto power grids when available.
2. Military sabotuer, exclusive to lab staff scenario. Kitted out mostly like you'd expect a basic military officer assigned to a lab's security detail to be...except for the electrohack and mininuke.
3. Industrial, combat, and recon mech pilots. Each of them centers around starting with one of the three mechs and a power cell at 10-25% charge. The industrial one is a lil cheaper and flavored as more civilian than the other two. Exclusive to military scenarios.
4. Medevac Pilot, added to Last Flight. Based off the medic profession but given access to a medical heli, 3 points higher instead of 2 points because otherwise it'd be the same cost as the less-impressive heli pilot profession.
5. Avian heli pilot, added to Last Flight, Ambushed, and Next Summer scenarios. Yo dawg I heard you like flight so I gave your heli pilot bird wings so you can fly while you fly. Starts with a smaller heli than the normal pilot gets. Post-thresh, same as the three mutant professions in Pond Scum.
5. Feral mutant, added to Lost and Damned as a playable counterpart to lab mutants, like how cyborgs are represented by the feral cyborg profession. Gains a selection of Chimera traits and the threshold. Like with a couple of the Pond Scum professions this does admittedly push the forced negative traits a bit above the default point limit.

Made the following changes to existing professions:
1. Split up special operator into two separate professions. Standard version no longer gets a swimming focus but instead more mundane military gear, while the swimming-focused variant given to Pond Scum is named Spec Ops Combat Diver. Standard profession additionally injected into military scenarios, same as the original version.
3. Lowered point cost of camper profession slightly, because they're basically the much cheaper survivalist profession with better gear in exchange for way fewer skills.
4. Modernized some profession items here and there to use entries like `charged_two_way_radio`, putting hatchets in axe rings, etc.
5. Allowed gyrojet pilot to be used in Ambushed and Next Summer, being post-apoc scenarios where it pairs well with road warrior's presence given I based the profession on the gyro pilot in Mad Max 2.
6. Misc: Named the two skater professions Rollerblader and Skateboarder.
7. Misc: Removed the whole "random clothing damage and missing lots of items" thing from feral professions, and in the process fixed feral survivors having two watches. Feral socialite also finally gets their harem of feral servants, but bumped it and feral reenactor up a point.

## Describe alternatives you've considered

1. Making mech pilots non-scenario-locked since power armor soldiers can be picked in standard scenarios too.
2. Not starting mech pilots off with a power cell, making their mech a paperweight until one is found. Could be done as a balancing measure if point one is done, could also be done as an excuse to lower the point cost.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
