### PR TITLE
feat: fix profession vehicles spawning on water, add professions that start with boats

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -199,6 +199,15 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "smuggler_mags_tec9",
+    "entries": [
+      { "item": "tec9mag", "ammo-item": "9mmfmj", "charges": 32 },
+      { "item": "tec9mag", "ammo-item": "9mmfmj", "charges": 32 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "quiver_bow_hunter",
     "entries": [ { "item": "arrow_cf", "charges": 8 } ]
   },
@@ -319,6 +328,7 @@
       { "item": "hat_hunting", "new": [ { "item": "hat_cotton", "ratio": 2 } ] },
       { "item": "hat_newsboy", "new": [ { "item": "hat_cotton", "ratio": 2 } ] },
       { "item": "peacoat", "new": [ "jacket_flannel" ] },
+      { "item": "greatcoat", "new": [ "duster" ] },
       { "item": "sweater", "new": [ "sweatshirt" ] },
       { "item": "boots_winter", "new": [ "boots_fur" ] },
       { "item": "cloak_wool", "new": [ "cloak_leather" ] },
@@ -1763,6 +1773,51 @@
       "female": [ "bra", "panties" ]
     }
   },
+
+
+  {
+    "type": "profession",
+    "id": "smuggler",
+    "name": "Smuggler",
+    "description": "Ever since the heat (both climate and police presence) got too bad in Miami, you found a niche running all sorts of tax-free goods into New England.  You're used to outrunning the cops, but now both the pigs and your clientele want your brains instead of your product.",
+    "points": 5,
+    "vehicle": "boat_motor_smuggler",
+    "skills": [
+      { "level": 1, "name": "melee" },
+      { "level": 1, "name": "swimming" },
+      { "level": 1, "name": "stabbing" },
+      { "level": 2, "name": "gun" },
+      { "level": 1, "name": "smg" },
+      { "level": 1, "name": "driving" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "tank_top",
+          "hoodie",
+          "socks",
+          "lowtops",
+          "gloves_fingerless",
+          "knit_scarf",
+          "smart_phone",
+          "cig",
+          "switchblade",
+          "mag_porn",
+          "sunglasses",
+          "diving_watch"
+        ],
+        "entries": [
+          { "item": "tec9", "ammo-item": "9mmfmj", "container-item": "shoulder_holster", "charges": 32 },
+          { "item": "chestrig", "contents-group": "smuggler_mags_tec9" },
+          { "item": "lighter", "charges": 100 }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "panties" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+
   {
     "type": "profession",
     "id": "security",
@@ -4552,6 +4607,44 @@
       "female": [ "bikini_top_fur", "hot_pants_fur" ]
     }
   },
+
+
+  {
+    "type": "profession",
+    "id": "castaway",
+    "name": "Castaway",
+    "description": "You were shipwrecked out on an island in the lake.  No one sent a search party, so after weeks of trying to signal for help you salvaged every scrap of clothing you could to set sail on a makeshift raft.  Where is everyone, and why do the sharks look so hungry?",
+    "points": 2,
+    "vehicle": "raft",
+    "skills": [
+      { "level": 2, "name": "cooking" },
+      { "level": 3, "name": "fabrication" },
+      { "level": 2, "name": "mechanics" },
+      { "level": 1, "name": "tailor" },
+      { "level": 2, "name": "survival" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "loincloth",
+          "straw_sandals",
+          "straw_basket",
+          "fire_drill",
+          "pot_makeshift",
+          "pockknife",
+          "bottle_plastic",
+          "needle_bone"
+        ],
+        "entries": [
+          { "item": "primitive_axe", "custom-flags": [ "auto_wield" ] }
+        ]
+      },
+      "female": [ "chestwrap" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+
+
   {
     "type": "profession",
     "id": "fisher",
@@ -4731,6 +4824,7 @@
     "name": "Pirate",
     "description": "Arr!  Your costume may be shipshape, but the end of the world's scuppered all your plans.  Strike up your Jolly Roger and hoist the Bloody Red, for no quarter shall be given.",
     "points": 4,
+    "vehicle": "pirate_ship",
     "skills": [
       { "level": 2, "name": "swimming" },
       { "level": 2, "name": "gun" },
@@ -4764,6 +4858,50 @@
       "female": [ "boy_shorts", "sports_bra" ]
     }
   },
+
+  {
+    "type": "profession",
+    "id": "prof_pirate_captain",
+    "name": "Pirate Captain",
+    "description": "Land ho!  Ye went all out on the reenactment, got your letters of marque in order and cast off in a fine sloop, to prowl the New England waters with.",
+    "points": 6,
+    "vehicle": "pirate_ship",
+    "skills": [
+      { "level": 2, "name": "swimming" },
+      { "level": 2, "name": "driving" },
+      { "level": 2, "name": "gun" },
+      { "level": 2, "name": "melee" },
+      { "level": 1, "name": "pistol" },
+      { "level": 1, "name": "cutting" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "socks",
+          "breeches",
+          "longshirt",
+          "greatcoat",
+          "tricorne",
+          "boots",
+          "mbag",
+          "leather_pouch",
+          "scabbard",
+          "gold_ear",
+          "rum"
+        ],
+        "entries": [
+          { "item": "cutlass_inferior", "custom-flags": [ "auto_wield" ] },
+          { "item": "baldric_holster", "contents-group": "pistols_pirate" },
+          { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
+          { "item": "flintlock_ammo", "charges": 4 }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "boy_shorts", "sports_bra" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+
   {
     "type": "profession",
     "id": "drone_op",

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -46,6 +46,9 @@
     ],
     "professions": [
       "prof_pirate",
+      "prof_pirate_captain",
+      "smuggler",
+      "castaway",
       "professional_diver",
       "underwater_welder",
       "bionic_diver",

--- a/data/json/vehicles/boats.json
+++ b/data/json/vehicles/boats.json
@@ -150,10 +150,10 @@
       [ "OO" ]
     ],
     "parts": [
-      { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "seat", "hand_paddles", "boat_board" ] },
-      { "x": 1, "y": 0, "parts": [ "frame_wood_cross", "seat", "boat_board" ] },
-      { "x": 1, "y": 1, "parts": [ "frame_wood_cross", "seat", "boat_board" ] },
-      { "x": 0, "y": 1, "parts": [ "frame_wood_cross", "seat", "boat_board" ] }
+      { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "hand_paddles", "raft_board" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_wood_cross", "raft_board" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_wood_cross", "raft_board" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_wood_cross", "sail", "raft_board" ] }
     ]
   },
   {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -831,8 +831,9 @@ vehicle *game::place_vehicle_nearby(
     if( search_types.empty() ) {
         vehicle veh( id );
         if( veh.can_float() ) {
-            search_types.emplace_back( "river" );
-            search_types.emplace_back( "lake" );
+            search_types.emplace_back( "river_shore" );
+            search_types.emplace_back( "lake_shore" );
+            search_types.emplace_back( "lake_surface" );
         } else {
             search_types.emplace_back( "field" );
             search_types.emplace_back( "road" );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

@shmakota had been wanting the ability to have professions that start with boats, but found that trying to implement that was causing the vehicles to error and not spawn. Turns out to be a fairly trivial case of the wrong `overmap_terrain` IDs being used so woe, more content upon thee.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

C++ changes:
1. In game.cpp, set `game::place_vehicle_nearby` so that when trying to decide what overmap terrain to search for, it picks IDs for lake shores, lake surface (for research stations where shore may be far away), and river shores that actually spawn, and not the hardcoded IDs that seem to get eaten during river generation (in the case of lakes are just LITERALLY WRONG because the id for generic lake tiles is `lake_surface', not `lake`).

JSON changes:
1. Added a pirate captain profession, exclusive to Pond Scum scenario. Two more points to get some driving skill, a greatcoat instead of a leather vest, a tricorne instead of a head bandana, and most importantly getting to start with a pirate ship.
2. Added a smuggler profession, an upgrade to the gangster profession who gets a tec-9, a briefcase, and a smuggling boat to play with.
3. Added castaway, a fittingly makeshift-item-laden survivalist profession who starts off with a raft, some basic tools, and enough skills to have likely made everything needed to obtain that raft. Watch out for Grace the Shark.
4. Added all three professions to Pond Scum scenario.
5. Misc: Tweaked the raft to use the new raft parts, add a small sail and sanity-check the seats to just one wooden seat.
6. Misc: Added a wool allergy profession substitution for greatcoats.

## Describe alternatives you've considered

We could change the search function it uses when looking to spawn a starter vehicle from `ot_match_type::type` to `ot_match_type::contains` but that will likely cause undue lag and other potential for jank when starting gameplay.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON changes for syntax and lint errors.
2. Compiled and load-tested.
3. Spawned in as a castaway, my boat usually spawns just fine whether I pick lake cabins or freshwater research station, albeit often out on the water.

Sometimes it gets a bit goofy though...
<img width="668" height="480" alt="image" src="https://github.com/user-attachments/assets/28dc0f21-4d27-4046-9c3c-893158efe753" />

But when it does work, it's fun:
<img width="1115" height="857" alt="1" src="https://github.com/user-attachments/assets/c27c0ae6-3508-4c49-9c16-8363c658da42" />
<img width="1076" height="384" alt="2" src="https://github.com/user-attachments/assets/f9203332-20b8-48d1-bb16-56a35eb3acc9" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![7dc](https://github.com/user-attachments/assets/8f1445c0-5008-43dd-84c7-9ede5e7a7954)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
