### PR TITLE
feat: add a parameterized palette to allow different linoleum colors in houses kitchens

### DIFF
--- a/data/json/mapgen_palettes/house_general_palette.json
+++ b/data/json/mapgen_palettes/house_general_palette.json
@@ -271,6 +271,30 @@
   },
   {
     "type": "palette",
+    "id": "parameterized_linoleum_color_kitchen",
+    "//1": "Intended to be used in conjunction with standard_domestic_palette.",
+    "//2": "Load the domestic palette first, then this one to add white or gray linoleum flooring under kitchen furniture.",
+    "parameters": {
+      "linoleum_color_kitchen": { "type": "ter_str_id", "default": { "distribution": [ [ "t_linoleum_white", 1 ], [ "t_linoleum_gray", 1 ] ] } }
+    },
+    "terrain": {
+      "O": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "F": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "m": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "5": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "n": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "J": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "1": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "2": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "3": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "4": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "6": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "7": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" },
+      "˙": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_white" }
+    }
+  },
+  {
+    "type": "palette",
     "id": "parameterized_linoleum_color_bathroom",
     "//1": "Intended to be used in conjunction with standard_domestic_palette.",
     "//2": "Load the domestic palette first, then this one to add white or gray linoleum flooring under bathroom furniture.",


### PR DESCRIPTION
## Purpose of change (The Why)
Because gray linoleum is the only color for kitchens in houses using `standard_domestic_lino_kitchen`
## Describe the solution (The How)
Add the palette `parameterized_linoleum_color_kitchen` to house_general_palette.json
## Describe alternatives you've considered
none
## Testing
No errors when starting a new game.
## Additional context
Like `parameterized_linoleum_color_bathroom`, `parameterized_linoleum_color_kitchen` is unused for the moment but will be used in future PR.
## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.