### PR TITLE
refactor: move dozens of recipes to crafting standards

### DIFF
--- a/data/json/recipes/ammo/arrows.json
+++ b/data/json/recipes/ammo/arrows.json
@@ -38,18 +38,15 @@
     "subcategory": "CSC_AMMO_ARROWS",
     "skill_used": "fabrication",
     "skills_required": [ [ "archery", 4 ], [ "survival", 1 ] ],
-    "using": [ [ "forging_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ] ],
     "difficulty": 5,
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
     "qualities": [
-      { "id": "HAMMER", "level": 2 },
       { "id": "CUT", "level": 1 },
-      { "id": "ANVIL", "level": 1 },
       { "id": "SANDING", "level": 1 }
     ],
-    "tools": [ [ [ "tongs", -1 ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ], [ "scrap_bronze", 1 ] ],
@@ -64,18 +61,15 @@
     "subcategory": "CSC_AMMO_ARROWS",
     "skill_used": "fabrication",
     "skills_required": [ [ "archery", 4 ], [ "survival", 1 ] ],
-    "using": [ [ "forging_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ] ],
     "difficulty": 5,
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
     "qualities": [
-      { "id": "HAMMER", "level": 2 },
       { "id": "CUT", "level": 1 },
-      { "id": "ANVIL", "level": 1 },
       { "id": "SANDING", "level": 1 }
     ],
-    "tools": [ [ [ "tongs", -1 ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ] ],
@@ -90,18 +84,15 @@
     "subcategory": "CSC_AMMO_ARROWS",
     "skill_used": "fabrication",
     "skills_required": [ [ "archery", 4 ], [ "survival", 1 ] ],
-    "using": [ [ "forging_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ] ],
     "difficulty": 5,
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
     "qualities": [
-      { "id": "HAMMER", "level": 2 },
       { "id": "CUT", "level": 1 },
-      { "id": "ANVIL", "level": 1 },
       { "id": "SANDING", "level": 1 }
     ],
-    "tools": [ [ [ "tongs", -1 ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ] ],
@@ -244,18 +235,15 @@
     "subcategory": "CSC_AMMO_ARROWS",
     "skill_used": "fabrication",
     "skills_required": [ [ "survival", 1 ] ],
-    "using": [ [ "forging_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ] ],
     "difficulty": 5,
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
     "qualities": [
-      { "id": "HAMMER", "level": 2 },
       { "id": "CUT", "level": 1 },
-      { "id": "ANVIL", "level": 1 },
       { "id": "SANDING", "level": 1 }
     ],
-    "tools": [ [ [ "tongs", -1 ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ], [ "scrap_bronze", 1 ] ],
@@ -270,18 +258,15 @@
     "subcategory": "CSC_AMMO_ARROWS",
     "skill_used": "fabrication",
     "skills_required": [ [ "survival", 1 ] ],
-    "using": [ [ "forging_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ] ],
     "difficulty": 5,
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
     "qualities": [
-      { "id": "HAMMER", "level": 2 },
       { "id": "CUT", "level": 1 },
-      { "id": "ANVIL", "level": 1 },
       { "id": "SANDING", "level": 1 }
     ],
-    "tools": [ [ [ "tongs", -1 ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ] ],
@@ -296,18 +281,15 @@
     "subcategory": "CSC_AMMO_ARROWS",
     "skill_used": "fabrication",
     "skills_required": [ [ "survival", 1 ] ],
-    "using": [ [ "forging_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ] ],
     "difficulty": 5,
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
     "qualities": [
-      { "id": "HAMMER", "level": 2 },
       { "id": "CUT", "level": 1 },
-      { "id": "ANVIL", "level": 1 },
       { "id": "SANDING", "level": 1 }
     ],
-    "tools": [ [ [ "tongs", -1 ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ] ],

--- a/data/json/recipes/ammo/arrows.json
+++ b/data/json/recipes/ammo/arrows.json
@@ -43,10 +43,7 @@
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
-    "qualities": [
-      { "id": "CUT", "level": 1 },
-      { "id": "SANDING", "level": 1 }
-    ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ], [ "scrap_bronze", 1 ] ],
@@ -66,10 +63,7 @@
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
-    "qualities": [
-      { "id": "CUT", "level": 1 },
-      { "id": "SANDING", "level": 1 }
-    ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ] ],
@@ -89,10 +83,7 @@
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
-    "qualities": [
-      { "id": "CUT", "level": 1 },
-      { "id": "SANDING", "level": 1 }
-    ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ] ],
@@ -240,10 +231,7 @@
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
-    "qualities": [
-      { "id": "CUT", "level": 1 },
-      { "id": "SANDING", "level": 1 }
-    ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ], [ "scrap_bronze", 1 ] ],
@@ -263,10 +251,7 @@
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
-    "qualities": [
-      { "id": "CUT", "level": 1 },
-      { "id": "SANDING", "level": 1 }
-    ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ] ],
@@ -286,10 +271,7 @@
     "time": "30 m",
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
-    "qualities": [
-      { "id": "CUT", "level": 1 },
-      { "id": "SANDING", "level": 1 }
-    ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SANDING", "level": 1 } ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "steel_tiny", 1, "LIST" ] ],

--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -33,8 +33,8 @@
     "time": "60 m",
     "autolearn": true,
     "book_learn": [ [ "glassblowing_book", 5 ] ],
+    "using": [ [ "glassblowing_easy", 5 ] ],
     "charges": 25,
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 25 ] ] ],
     "components": [ [ [ "glass_shard", 1 ], [ "flask_glass", 1 ], [ "test_tube", 2 ] ] ]
   },
   {

--- a/data/json/recipes/other/containers.json
+++ b/data/json/recipes/other/containers.json
@@ -152,8 +152,7 @@
     "difficulty": 3,
     "time": "2 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 2 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "swage", -1 ] ] ],
+    "using": [ [ "blacksmithing_advanced", 2 ] ],
     "components": [ [ [ "scrap", 2 ] ] ]
   },
   {
@@ -331,8 +330,7 @@
     "difficulty": 4,
     "time": "1 h 30 m",
     "book_learn": [ [ "glassblowing_book", 5 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 150 ] ] ],
+    "using": [ [ "glassblowing_standard", 30 ] ],
     "components": [ [ [ "glass_shard", 3 ], [ "flask_glass", 5 ], [ "test_tube", 10 ], [ "marble", 125 ] ] ]
   },
   {
@@ -344,8 +342,7 @@
     "difficulty": 4,
     "time": "1 h",
     "book_learn": [ [ "glassblowing_book", 5 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 75 ] ] ],
+    "using": [ [ "glassblowing_standard", 15 ] ],
     "components": [ [ [ "glass_shard", 2 ], [ "pipe_glass", 1 ], [ "flask_glass", 3 ], [ "test_tube", 6 ], [ "marble", 75 ] ] ]
   },
   {
@@ -357,8 +354,7 @@
     "difficulty": 4,
     "time": "40 m",
     "book_learn": [ [ "glassblowing_book", 4 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 50 ] ] ],
+    "using": [ [ "glassblowing_standard", 10 ] ],
     "components": [ [ [ "glass_shard", 2 ], [ "flask_glass", 2 ], [ "test_tube", 4 ], [ "marble", 50 ] ] ]
   },
   {
@@ -370,8 +366,7 @@
     "difficulty": 4,
     "time": "20 m",
     "book_learn": [ [ "glassblowing_book", 4 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 25 ] ] ],
+    "using": [ [ "glassblowing_standard", 5 ] ],
     "components": [ [ [ "glass_shard", 1 ], [ "test_tube", 2 ], [ "marble", 25 ] ] ]
   },
   {
@@ -384,8 +379,7 @@
     "time": "20 m",
     "book_learn": [ [ "glassblowing_book", 4 ] ],
     "result_mult": 2,
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 5 ] ] ],
+    "using": [ [ "glassblowing_standard", 1 ] ],
     "components": [ [ [ "glass_shard", 1 ], [ "flask_glass", 1 ], [ "marble", 25 ] ] ]
   },
   {

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -483,11 +483,9 @@
     "difficulty": 3,
     "time": "1 h",
     "autolearn": true,
+    "using": [ [ "glassblowing_easy", 15 ] ],
     "tools": [
-      [ [ "tongs", -1 ] ],
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
-      [ [ "tool_flat_press_large", 1, "LIST" ] ],
-      [ [ "forge", 75 ] ]
+      [ [ "tool_flat_press_large", 1, "LIST" ] ]
     ],
     "components": [ [ [ "glass_shard", 18 ], [ "jar_glass", 9 ], [ "flask_glass", 18 ], [ "test_tube", 36 ] ] ]
   },
@@ -531,8 +529,7 @@
     "difficulty": 5,
     "time": "1 h 30 m",
     "autolearn": true,
-    "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ], [ [ "forge", 50 ], [ "oxy_torch", 10 ] ] ],
+    "using": [ [ "blacksmithing_advanced", 2 ] ],
     "components": [ [ [ "copper_scrap_equivalent", 7, "LIST" ] ] ]
   },
   {
@@ -1192,11 +1189,9 @@
     "difficulty": 4,
     "time": "1 h",
     "autolearn": true,
+    "using": [ [ "glassblowing_easy", 15 ] ],
     "tools": [
-      [ [ "tongs", -1 ] ],
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
-      [ [ "tool_flat_press_large", 1, "LIST" ] ],
-      [ [ "forge", 75 ] ]
+      [ [ "tool_flat_press_large", 1, "LIST" ] ]
     ],
     "components": [ [ [ "glass_shard", 40 ], [ "flask_glass", 12 ], [ "jar_glass", 4 ] ] ]
   },
@@ -1724,12 +1719,10 @@
     "time": "30 m",
     "book_learn": [ [ "glassblowing_book", 4 ], [ "textbook_fabrication", 5 ], [ "welding_book", 5 ] ],
     "batch_time_factors": [ 90, 2 ],
+    "using": [ [ "glassblowing_easy", 12 ] ],
     "qualities": [ { "id": "CHEM", "level": 1 } ],
     "tools": [
-      [ [ "tongs", -1 ] ],
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
-      [ [ "tool_flat_press_large", 1, "LIST" ], [ "tool_flat_press_small", 1, "LIST" ] ],
-      [ [ "forge", 60 ] ]
+      [ [ "tool_flat_press_large", 1, "LIST" ], [ "tool_flat_press_small", 1, "LIST" ] ]
     ],
     "components": [ [ [ "glass_shard", 2 ] ], [ [ "chem_sulphur", 1 ] ], [ [ "scrap", 1 ] ], [ [ "charcoal", 1 ] ] ]
   },

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -484,9 +484,7 @@
     "time": "1 h",
     "autolearn": true,
     "using": [ [ "glassblowing_easy", 15 ] ],
-    "tools": [
-      [ [ "tool_flat_press_large", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "tool_flat_press_large", 1, "LIST" ] ] ],
     "components": [ [ [ "glass_shard", 18 ], [ "jar_glass", 9 ], [ "flask_glass", 18 ], [ "test_tube", 36 ] ] ]
   },
   {
@@ -1190,9 +1188,7 @@
     "time": "1 h",
     "autolearn": true,
     "using": [ [ "glassblowing_easy", 15 ] ],
-    "tools": [
-      [ [ "tool_flat_press_large", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "tool_flat_press_large", 1, "LIST" ] ] ],
     "components": [ [ [ "glass_shard", 40 ], [ "flask_glass", 12 ], [ "jar_glass", 4 ] ] ]
   },
   {
@@ -1721,9 +1717,7 @@
     "batch_time_factors": [ 90, 2 ],
     "using": [ [ "glassblowing_easy", 12 ] ],
     "qualities": [ { "id": "CHEM", "level": 1 } ],
-    "tools": [
-      [ [ "tool_flat_press_large", 1, "LIST" ], [ "tool_flat_press_small", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "tool_flat_press_large", 1, "LIST" ], [ "tool_flat_press_small", 1, "LIST" ] ] ],
     "components": [ [ [ "glass_shard", 2 ] ], [ [ "chem_sulphur", 1 ] ], [ [ "scrap", 1 ] ], [ [ "charcoal", 1 ] ] ]
   },
   {

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -768,8 +768,7 @@
     "difficulty": 4,
     "time": "35 m",
     "book_learn": [ [ "glassblowing_book", 4 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 50 ] ] ],
+    "using": [ [ "glassblowing_standard", 10 ] ],
     "components": [ [ [ "glass_shard", 2 ], [ "flask_glass", 2 ], [ "test_tube", 4 ], [ "marble", 50 ] ] ]
   },
   {

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -1102,9 +1102,7 @@
     "difficulty": 4,
     "time": "2 h 20 m",
     "autolearn": true,
-    "using": [ [ "forging_standard", 12 ], [ "steel_standard", 2 ] ],
-    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "tongs", -1 ] ] ],
+    "using": [ [ "blacksmithing_standard", 12 ], [ "steel_standard", 2 ] ],
     "components": [ [ [ "2x4", 1 ], [ "stick", 2 ], [ "splinter", 6 ] ] ]
   },
   {
@@ -1791,7 +1789,7 @@
     "difficulty": 4,
     "time": "30 m",
     "book_learn": [ [ "glassblowing_book", 3 ] ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 75 ] ] ],
+    "using": [ [ "glassblowing_easy", 15 ] ],
     "components": [ [ [ "glass_sheet", 1 ] ], [ [ "silver_small", 10 ] ] ]
   },
   {
@@ -1805,7 +1803,8 @@
     "time": "10 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "polisher", 20 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 50 ] ] ],
+    "using": [ [ "glassblowing_easy", 10 ] ],
+    "tools": [ [ [ "polisher", 20 ] ] ],
     "components": [ [ [ "steel_chunk", 3 ] ] ]
   },
   {
@@ -1817,8 +1816,7 @@
     "difficulty": 4,
     "time": "1 h",
     "book_learn": [ [ "glassblowing_book", 6 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 25 ] ] ],
+    "using": [ [ "glassblowing_standard", 5 ] ],
     "components": [ [ [ "glass_shard", 3 ], [ "bottle_glass", 1 ], [ "flask_glass", 3 ], [ "test_tube", 6 ], [ "marble", 75 ] ] ]
   },
   {
@@ -2245,10 +2243,8 @@
     "difficulty": 4,
     "time": "90 m",
     "autolearn": true,
-    "using": [ [ "forging_standard", 4 ] ],
+    "using": [ [ "blacksmithing_advanced", 4 ] ],
     "book_learn": [ [ "textbook_tailor", 3 ], [ "manual_tailor", 3 ] ],
-    "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ] ],
     "components": [ [ [ "scrap", 2 ] ] ]
   },
   {

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -259,5 +259,18 @@
         [ "wood_sheet", -1 ]
       ]
     ]
+  },
+  {
+    "id": "glassblowing_easy",
+    "type": "requirement",
+    "//": "Forge, crucible, tongs, glassblowing pipe. Units of 5 because someone made test tubes craftable at 5 forge.",
+    "tools": [ [ [ "forge", 5 ], [ "oxy_torch", 5 ] ], [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+  },
+  {
+    "id": "glassblowing_standard",
+    "type": "requirement",
+    "//": "Because apparently we need chiseling.",
+    "qualities": [ { "id": "CHISEL", "level": 3 } ],
+    "tools": [ [ [ "forge", 5 ], [ "oxy_torch", 5 ] ], [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
   }
 ]

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -264,13 +264,23 @@
     "id": "glassblowing_easy",
     "type": "requirement",
     "//": "Forge, crucible, tongs, glassblowing pipe. Units of 5 because someone made test tubes craftable at 5 forge.",
-    "tools": [ [ [ "forge", 5 ], [ "oxy_torch", 5 ] ], [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "tools": [
+      [ [ "forge", 5 ], [ "oxy_torch", 5 ] ],
+      [ [ "tongs", -1 ] ],
+      [ [ "pipe", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
+    ]
   },
   {
     "id": "glassblowing_standard",
     "type": "requirement",
     "//": "Because apparently we need chiseling.",
     "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "forge", 5 ], [ "oxy_torch", 5 ] ], [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "tools": [
+      [ [ "forge", 5 ], [ "oxy_torch", 5 ] ],
+      [ [ "tongs", -1 ] ],
+      [ [ "pipe", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
+    ]
   }
 ]

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -46,7 +46,7 @@
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for basic blacksmithing.  Permits working hot metal on stone surfaces.",
     "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ], [ [ "tongs", -1 ] ] ]
+    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ], [ [ "tongs", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
   },
   {
     "id": "blacksmithing_intermediate",
@@ -54,14 +54,14 @@
     "//": "Includes forging resources as well as tools needed for mid-level blacksmithing.  Require a harder work surface for hot-cut chiseling and other uses of chisel quality.",
     "//2": "TODO: Downgrade chisel requirement to 2 if we ever get a chisel in between stone and steel",
     "qualities": [ { "id": "ANVIL", "level": 2 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ], [ [ "tongs", -1 ] ] ]
+    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ], [ [ "tongs", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
   },
   {
     "id": "blacksmithing_advanced",
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for advanced blacksmithing.  Require a proper dediciated anvil for use of a swage and die set.",
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ], [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ] ]
+    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ], [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
   },
   {
     "id": "mutagen_production_standard",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -61,7 +61,12 @@
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for advanced blacksmithing.  Require a proper dediciated anvil for use of a swage and die set.",
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ], [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "tools": [
+      [ [ "forge", 20 ], [ "oxy_torch", 20 ] ],
+      [ [ "tongs", -1 ] ],
+      [ [ "swage", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
+    ]
   },
   {
     "id": "mutagen_production_standard",

--- a/data/mods/CheesyInnaWoodsFixes/recipes/existing_recipe_changes/tool_recipe_bn.json
+++ b/data/mods/CheesyInnaWoodsFixes/recipes/existing_recipe_changes/tool_recipe_bn.json
@@ -41,8 +41,7 @@
     "difficulty": 7,
     "time": "1 h",
     "autolearn": true,
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "pipe", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 75 ] ] ],
+    "using": [ [ "glassblowing_standard", 15 ] ],
     "components": [
       [ [ "glass_shard", 3 ], [ "pipe_glass", 1 ], [ "flask_glass", 3 ], [ "test_tube", 6 ], [ "marble", 75 ] ],
       [ [ "plastic_chunk", 1 ] ]
@@ -59,9 +58,7 @@
     "time": "300 m",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "forging_standard", 10 ], [ "steel_standard", 5 ] ],
-    "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ] ]
+    "using": [ [ "blacksmithing_advanced", 10 ], [ "steel_standard", 5 ] ]
   },
   {
     "result": "jack_small",

--- a/data/mods/MagicalNights/recipes/weapons.json
+++ b/data/mods/MagicalNights/recipes/weapons.json
@@ -50,14 +50,8 @@
     "difficulty": 4,
     "time": "360 m",
     "autolearn": true,
-    "using": [ [ "forging_standard", 2 ], [ "steel_tiny", 1 ] ],
-    "qualities": [
-      { "id": "ANVIL", "level": 3 },
-      { "id": "HAMMER", "level": 3 },
-      { "id": "CHISEL", "level": 3 },
-      { "id": "MANA_INFUSE", "level": 1 }
-    ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ] ],
+    "using": [ [ "blacksmithing_advanced", 2 ], [ "steel_tiny", 1 ] ],
+    "qualities": [ { "id": "MANA_INFUSE", "level": 1 } ],
     "components": [ [ [ "2x4", 1 ], [ "stick", 1 ] ], [ [ "rune_animist", 1 ] ] ]
   },
   {
@@ -83,14 +77,8 @@
     "skills_required": [ [ "spellcraft", 2 ], [ "mechanics", 2 ] ],
     "time": "360 m",
     "autolearn": true,
-    "using": [ [ "forging_standard", 14 ], [ "steel_standard", 3 ] ],
-    "qualities": [
-      { "id": "ANVIL", "level": 3 },
-      { "id": "HAMMER", "level": 3 },
-      { "id": "CHISEL", "level": 3 },
-      { "id": "MANA_INFUSE", "level": 1 }
-    ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ] ],
+    "using": [ [ "blacksmithing_advanced", 14 ], [ "steel_standard", 3 ] ],
+    "qualities": [ { "id": "MANA_INFUSE", "level": 1 } ],
     "components": [ [ [ "rune_technomancer", 1 ] ] ]
   },
   {
@@ -136,14 +124,8 @@
     "skills_required": [ [ "spellcraft", 2 ], [ "cutting", 2 ] ],
     "time": "420 m",
     "autolearn": true,
-    "using": [ [ "forging_standard", 4 ], [ "steel_standard", 2 ] ],
-    "qualities": [
-      { "id": "ANVIL", "level": 3 },
-      { "id": "HAMMER", "level": 3 },
-      { "id": "CHISEL", "level": 3 },
-      { "id": "MANA_INFUSE", "level": 1 }
-    ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ] ],
+    "using": [ [ "blacksmithing_advanced", 4 ], [ "steel_standard", 2 ] ],
+    "qualities": [ { "id": "MANA_INFUSE", "level": 1 } ],
     "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ], [ [ "rune_kelvinist", 1 ] ] ]
   },
   {
@@ -260,9 +242,7 @@
     "difficulty": 10,
     "time": 480000,
     "book_learn": [ [ "book_mythological", 10 ] ],
-    "using": [ [ "forging_standard", 3 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "anvil", -1 ] ], [ [ "swage", -1 ] ] ],
+    "using": [ [ "blacksmithing_advanced", 3 ] ],
     "components": [
       [ [ "warhammer", 1 ] ],
       [ [ "gold_small", 1 ] ],
@@ -281,9 +261,7 @@
     "difficulty": 10,
     "time": 480000,
     "book_learn": [ [ "book_mythological", 10 ] ],
-    "using": [ [ "forging_standard", 3 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "anvil", -1 ] ], [ [ "swage", -1 ] ] ],
+    "using": [ [ "blacksmithing_advanced", 3 ] ],
     "components": [ [ [ "spear_steel", 1 ] ], [ [ "gold_small", 1 ] ], [ [ "silver_small", 2 ] ], [ [ "orichalcum_ingot", 2 ] ] ]
   },
   {
@@ -296,9 +274,7 @@
     "difficulty": 10,
     "time": 480000,
     "book_learn": [ [ "book_mythological", 10 ] ],
-    "using": [ [ "forging_standard", 3 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "anvil", -1 ] ], [ [ "swage", -1 ] ] ],
+    "using": [ [ "blacksmithing_advanced", 3 ] ],
     "components": [ [ [ "jian", 1 ] ], [ [ "gold_small", 1 ] ], [ [ "orichalcum_ingot", 2 ] ] ]
   },
   {
@@ -311,9 +287,7 @@
     "difficulty": 10,
     "time": 480000,
     "book_learn": [ [ "book_mythological", 10 ] ],
-    "using": [ [ "forging_standard", 3 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "anvil", -1 ] ], [ [ "swage", -1 ] ] ],
+    "using": [ [ "blacksmithing_advanced", 3 ] ],
     "components": [ [ [ "compositebow", 1 ] ], [ [ "gold_small", 1 ] ], [ [ "orichalcum_ingot", 1 ] ] ]
   },
   {
@@ -326,9 +300,7 @@
     "difficulty": 10,
     "time": 480000,
     "book_learn": [ [ "book_mythological", 10 ] ],
-    "using": [ [ "forging_standard", 3 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "anvil", -1 ] ], [ [ "swage", -1 ] ] ],
+    "using": [ [ "blacksmithing_advanced", 3 ] ],
     "components": [ [ [ "i_staff", 1 ] ], [ [ "gold_small", 1 ] ], [ [ "orichalcum_ingot", 1 ] ] ]
   },
   {
@@ -338,13 +310,12 @@
     "subcategory": "CSC_AMMO_ARROWS",
     "skill_used": "fabrication",
     "skills_required": [ [ "archery", 4 ], [ "spellcraft", 5 ] ],
-    "using": [ [ "forging_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ] ],
     "difficulty": 5,
     "charges": 4,
     "time": "30 m",
     "book_learn": [ [ "book_mythological", 9 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CUT", "level": 1 }, { "id": "ANVIL", "level": 3 } ],
-    "tools": [ [ [ "tongs", -1 ] ] ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "orichalcum_ingot", 1 ] ],
       [ [ "adhesive", 1, "LIST" ], [ "filament", 10, "LIST" ] ],


### PR DESCRIPTION
## Purpose of change (The Why)

In preparation for the blacksmithing tool quality PR, this PR migrates a ton of recipes to tool qualities without actually changing anything. Qualities aren't added and things are more internally consistent.

This has the benefits of:

- Less JSON lines
- Easier to update crafting as a whole, for harder or easier
- Easier for modders
- Globalized standardization

This brings us in line where I need to change the fewest recipes possible from direct tool calls to qualities.

## Describe the solution (The How)

Migrates recipes to correct blacksmithing or to one of the new glassblowing crafting standards. 

This only touches what ISN'T going to change balance. And it only changes stuff that doesn't require ridiculous new hyper-specific craft standards.

That is to say, casings doesn't get touched. It would require decision making and I haven't done that.

## Describe alternatives you've considered

All in one.

## Testing

Well it loads and I can't find the difference. 
<img width="2050" height="1210" alt="image" src="https://github.com/user-attachments/assets/d3441b71-94dd-42e2-8e69-58c09c661679" />


## Additional context
## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.