### PR TITLE
feat: Move recipes to tool qualities

### DIFF
--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -477,7 +477,7 @@
     "type": "TOOL",
     "name": { "str": "installed reloading press" },
     "//": "Doesn't substitute for hand press because we want to define this tool in crafting requirements separately, due to disassembly code.",
-    "qualities": [ [ "PULL", 2 ] ]
+    "qualities": [ [ "PULL", 2 ], [ "CASING_PRESSING", 3 ] ]
   },
   {
     "id": "grid_hydraulic_press",

--- a/data/json/items/resources/metal.json
+++ b/data/json/items/resources/metal.json
@@ -11,7 +11,7 @@
     "color": "dark_gray",
     "symbol": "/",
     "material": [ "steel" ],
-    "qualities": [ [ "HAMMER", 1 ] ],
+    "qualities": [ [ "HAMMER", 1 ], [ "GLASSBLOWING", 1 ] ],
     "techniques": [ "WBLOCK_1" ],
     "volume": "500 ml",
     "bashing": 12,
@@ -91,7 +91,8 @@
     "volume": "250 ml",
     "bashing": 5,
     "price": "75 USD",
-    "price_postapoc": "10 cent"
+    "price_postapoc": "10 cent",
+    "qualities": [ [ "GLASSBLOWING", 1 ] ]
   },
   {
     "id": "material_aluminium_ingot",

--- a/data/json/items/tool/handloading.json
+++ b/data/json/items/tool/handloading.json
@@ -13,7 +13,8 @@
     "bashing": 6,
     "material": [ "steel", "plastic" ],
     "symbol": ";",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "qualities": [ [ "CASING_PRESSING", 2 ] ]
   },
   {
     "id": "press_dowel",
@@ -30,7 +31,8 @@
     "material": [ "wood", "plastic", "brass" ],
     "symbol": ";",
     "color": "dark_gray",
-    "flags": [ "TRADER_AVOID" ]
+    "flags": [ "TRADER_AVOID" ],
+    "qualities": [ [ "CASING_PRESSING", 1 ] ]
   },
   {
     "id": "puller",

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -153,7 +153,7 @@
     "material": "ceramic",
     "symbol": ";",
     "color": "dark_gray",
-    "qualities": [ [ "COOK", 1 ], [ "CHEM", 1 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
+    "qualities": [ [ "COOK", 1 ], [ "CHEM", 1 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "CONTAIN_HOT", 2 ] ]
   },
   {
     "id": "crucible_clay",
@@ -170,7 +170,7 @@
     "material": "clay",
     "symbol": ";",
     "color": "brown",
-    "qualities": [ [ "COOK", 1 ], [ "CHEM", 1 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ] ]
+    "qualities": [ [ "COOK", 1 ], [ "CHEM", 1 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "CONTAIN_HOT", 1 ] ]
   },
   {
     "id": "forge",
@@ -341,6 +341,7 @@
     "material": "steel",
     "symbol": ";",
     "color": "light_gray",
+    "qualities": [ [ "SWAGING", 1 ], [ "CASING_FORMING", 1 ] ],
     "flags": [ "DURABLE_MELEE" ]
   },
   {
@@ -357,7 +358,7 @@
     "material": "steel",
     "symbol": ";",
     "color": "light_gray",
-    "qualities": [ [ "COOK", 1 ] ],
+    "qualities": [ [ "COOK", 1 ], [ "GRIP_HOT", 2 ] ],
     "use_action": "HEAT_FOOD",
     "flags": [ "BELT_CLIP", "ALLOWS_REMOTE_USE" ]
   }

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -563,7 +563,8 @@
       [ "SCREW", 1 ],
       [ "CHISEL", 3 ],
       [ "DRILL", 3 ],
-      [ "PULL", 2 ]
+      [ "PULL", 2 ],
+      [ "CASING_FORMING", 1 ]
     ],
     "use_action": [ "GUN_CLEAN", "GUN_REPAIR", "CROWBAR", "HAMMER" ],
     "magazines": [
@@ -828,7 +829,7 @@
     "material": "steel",
     "symbol": ";",
     "color": "light_gray",
-    "qualities": [ [ "WRENCH", 1 ], [ "PULL", 1 ], [ "PULL_FINE", 2 ] ],
+    "qualities": [ [ "WRENCH", 1 ], [ "PULL", 1 ], [ "PULL_FINE", 2 ], [ "GRIP_HOT", 1 ] ],
     "flags": [ "BELT_CLIP" ]
   },
   {
@@ -952,7 +953,8 @@
       [ "WRENCH", 2 ],
       [ "SCREW_FINE", 1 ],
       [ "SCREW", 1 ],
-      [ "CHISEL", 3 ]
+      [ "CHISEL", 3 ],
+      [ "CASING_FORMING", 1 ]
     ],
     "use_action": [ "GUN_CLEAN", "GUN_REPAIR", "CROWBAR", "HAMMER" ],
     "magazines": [

--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -120,8 +120,7 @@
     "charges": 1,
     "decomp_learn": 6,
     "book_learn": [ [ "manual_pistol", 3 ], [ "recipe_bullets", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "components": [
       [ [ "copper", 1 ], [ "cartridgebrass", 2 ], [ "aluminum_foil", 2 ] ],
       [ [ "oxy_powder", 1 ], [ "chem_match_head_powder", 1 ] ]
@@ -139,8 +138,7 @@
     "time": "22 m 30 s",
     "charges": 50,
     "book_learn": [ [ "manual_pistol", 3 ], [ "recipe_bullets", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "components": [
       [
         [ "can_drink_unsealed", 1 ],
@@ -167,8 +165,7 @@
     "charges": 1,
     "decomp_learn": 6,
     "book_learn": [ [ "manual_pistol", 3 ], [ "recipe_bullets", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "components": [
       [ [ "copper", 1 ], [ "cartridgebrass", 2 ], [ "aluminum_foil", 2 ] ],
       [ [ "oxy_powder", 1 ], [ "chem_match_head_powder", 1 ] ]
@@ -186,8 +183,7 @@
     "time": "22 m 30 s",
     "charges": 50,
     "book_learn": [ [ "manual_pistol", 3 ], [ "recipe_bullets", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "components": [
       [
         [ "can_drink_unsealed", 1 ],
@@ -214,8 +210,7 @@
     "charges": 1,
     "decomp_learn": 6,
     "book_learn": [ [ "mag_rifle", 3 ], [ "recipe_bullets", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "components": [
       [ [ "copper", 1 ], [ "cartridgebrass", 2 ], [ "aluminum_foil", 2 ] ],
       [ [ "oxy_powder", 1 ], [ "chem_match_head_powder", 1 ] ]
@@ -233,8 +228,7 @@
     "time": "22 m 30 s",
     "charges": 50,
     "book_learn": [ [ "mag_rifle", 3 ], [ "recipe_bullets", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "components": [
       [
         [ "can_drink_unsealed", 1 ],
@@ -261,8 +255,7 @@
     "charges": 1,
     "decomp_learn": 6,
     "book_learn": [ [ "mag_rifle", 3 ], [ "recipe_bullets", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "components": [
       [ [ "copper", 1 ], [ "cartridgebrass", 2 ], [ "aluminum_foil", 2 ] ],
       [ [ "oxy_powder", 1 ], [ "chem_match_head_powder", 1 ] ]
@@ -280,8 +273,7 @@
     "time": "22 m 30 s",
     "charges": 50,
     "book_learn": [ [ "mag_rifle", 3 ], [ "recipe_bullets", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "components": [
       [
         [ "can_drink_unsealed", 1 ],
@@ -308,8 +300,7 @@
     "charges": 1,
     "decomp_learn": 6,
     "book_learn": [ [ "manual_shotgun", 3 ], [ "recipe_bullets", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "components": [
       [ [ "copper", 1 ], [ "cartridgebrass", 2 ], [ "aluminum_foil", 2 ] ],
       [ [ "oxy_powder", 1 ], [ "chem_match_head_powder", 1 ] ]
@@ -327,8 +318,7 @@
     "time": "22 m 30 s",
     "charges": 50,
     "book_learn": [ [ "manual_shotgun", 3 ], [ "recipe_bullets", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "components": [
       [
         [ "can_drink_unsealed", 1 ],
@@ -354,8 +344,8 @@
     "time": "2 m 6 s",
     "batch_time_factors": [ 80, 5 ],
     "book_learn": [ [ "manual_pistol", 5 ], [ "recipe_bullets", 3 ] ],
-    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "DRILL", "level": 2 } ],
-    "tools": [ [ [ "press", -1 ] ], [ [ "cordless_drill", 2 ] ] ],
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "DRILL", "level": 2 }, { "id": "CASING_PRESSING", "level": 2 } ],
+    "tools": [ [ [ "cordless_drill", 2 ] ] ],
     "components": [ [ [ "223_casing", 1 ] ] ]
   },
   {
@@ -370,8 +360,7 @@
     "time": "2 m 6 s",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "manual_rifle", 5 ], [ "recipe_bullets", 3 ] ],
-    "qualities": [ { "id": "SAW_M", "level": 1 } ],
-    "tools": [ [ [ "press", -1 ] ] ],
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "CASING_PRESSING", "level": 2 } ],
     "components": [ [ [ "223_casing", 1 ] ] ]
   },
   {
@@ -386,7 +375,6 @@
     "reversible": true,
     "book_learn": [ [ "manual_launcher", 6 ], [ "textbook_anarch", 7 ] ],
     "using": [ [ "blacksmithing_intermediate", 12 ], [ "steel_tiny", 12 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "volatile_explosive", 75, "LIST" ], [ "stable_explosive", 75, "LIST" ], [ "military_explosive", 75, "LIST" ] ],
       [
@@ -411,7 +399,7 @@
     "reversible": true,
     "autolearn": true,
     "using": [ [ "forging_standard", 8 ], [ "steel_tiny", 8 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "qualities": [ { "id": "CONTAIN_HOT", "level": 1 } ]
   },
   {
     "type": "recipe",
@@ -436,10 +424,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 5 ] ] ]
@@ -453,10 +441,10 @@
     "difficulty": 3,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 2 ] ] ]
@@ -470,10 +458,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
@@ -487,10 +475,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
@@ -504,10 +492,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 6 ] ] ]
@@ -521,10 +509,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 6 ] ] ]
@@ -538,10 +526,10 @@
     "difficulty": 3,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 2 ] ] ]
@@ -555,10 +543,10 @@
     "difficulty": 4,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
@@ -572,10 +560,10 @@
     "difficulty": 4,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
@@ -589,10 +577,10 @@
     "difficulty": 4,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
@@ -606,10 +594,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]
@@ -622,11 +610,11 @@
     "skill_used": "fabrication",
     "difficulty": 4,
     "time": "5 m",
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]
@@ -640,10 +628,10 @@
     "difficulty": 4,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]
@@ -657,10 +645,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
@@ -674,10 +662,10 @@
     "difficulty": 6,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 18 ] ] ]
@@ -691,10 +679,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
@@ -708,10 +696,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 6 ] ] ]
@@ -725,10 +713,10 @@
     "difficulty": 3,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
@@ -742,10 +730,10 @@
     "difficulty": 3,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
@@ -759,10 +747,10 @@
     "difficulty": 3,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
@@ -776,10 +764,10 @@
     "difficulty": 3,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
@@ -793,10 +781,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 5 ] ] ]
@@ -810,10 +798,10 @@
     "difficulty": 3,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_shotgun", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
       [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ],
       [ [ "mold_plastic", -1 ] ]
     ],
     "charges": 1,
@@ -828,10 +816,10 @@
     "difficulty": 3,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_shotgun", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
       [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ],
       [ [ "mold_plastic", -1 ] ]
     ],
     "charges": 1,
@@ -849,8 +837,7 @@
     "reversible": true,
     "decomp_learn": 8,
     "book_learn": [ [ "manual_traps_mil", 5 ], [ "manual_launcher", 6 ], [ "textbook_anarch", 7 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "//": "Components called for explicitly instead of volatile_explosive in order to use smaller amounts, and to place HTMD first",
     "components": [
       [ [ "copper", 1 ], [ "cartridgebrass", 2 ], [ "aluminum_foil", 2 ] ],
@@ -876,8 +863,7 @@
     "reversible": true,
     "decomp_learn": 9,
     "book_learn": [ [ "manual_traps_mil", 6 ], [ "manual_launcher", 7 ], [ "textbook_anarch", 8 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 }, { "id": "CASING_FORMING", "level": 1 } ],
     "components": [
       [ [ "copper", 2 ], [ "cartridgebrass", 4 ], [ "aluminum_foil", 4 ] ],
       [

--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -425,10 +425,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 5 ] ] ]
   },
@@ -442,10 +439,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 2 ] ] ]
   },
@@ -459,10 +453,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
   },
@@ -476,10 +467,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
   },
@@ -493,10 +481,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 6 ] ] ]
   },
@@ -510,10 +495,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 6 ] ] ]
   },
@@ -527,10 +509,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 2 ] ] ]
   },
@@ -544,10 +523,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
   },
@@ -561,10 +537,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
   },
@@ -578,10 +551,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
   },
@@ -595,10 +565,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]
   },
@@ -612,10 +579,7 @@
     "time": "5 m",
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]
   },
@@ -629,10 +593,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]
   },
@@ -646,10 +607,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
   },
@@ -663,10 +621,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 18 ] ] ]
   },
@@ -680,10 +635,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
   },
@@ -697,10 +649,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 6 ] ] ]
   },
@@ -714,10 +663,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
   },
@@ -731,10 +677,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
   },
@@ -748,10 +691,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
   },
@@ -765,10 +705,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
   },
@@ -782,10 +719,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 5 ] ] ]
   },
@@ -799,11 +733,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_shotgun", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "mold_plastic", -1 ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ], [ [ "mold_plastic", -1 ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 2 ] ], [ [ "plastic_scrap", 2 ] ] ]
   },
@@ -817,11 +747,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_shotgun", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "mold_plastic", -1 ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ], [ [ "mold_plastic", -1 ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 1 ] ], [ [ "plastic_scrap", 1 ] ] ]
   },

--- a/data/json/recipes/ammo/launcher.json
+++ b/data/json/recipes/ammo/launcher.json
@@ -13,8 +13,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 16 ] ],
-    "tools": [ [ [ "swage", -1 ] ] ],
-    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SWAGING", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
       [ [ "paper", 1 ], [ "wax", 1 ] ],
@@ -37,8 +36,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 16 ] ],
-    "tools": [ [ [ "swage", -1 ] ] ],
-    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SWAGING", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
       [ [ "paper", 1 ], [ "wax", 1 ] ],
@@ -60,8 +58,7 @@
     "book_learn": [ [ "recipe_bullets", 3 ], [ "manual_shotgun", 3 ] ],
     "charges": 1,
     "reversible": true,
-    "tools": [ [ [ "press", -1 ] ], [ [ "swage", -1 ] ] ],
-    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SWAGING", "level": 1 }, { "id": "CASING_PRESSING", "level": 2 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
       [ [ "paper", 1 ], [ "wax", 1 ] ],
@@ -85,8 +82,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 12 ] ],
-    "tools": [ [ [ "swage", -1 ] ] ],
-    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SWAGING", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
       [ [ "paper", 1 ], [ "wax", 1 ] ],
@@ -109,8 +105,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 12 ] ],
-    "tools": [ [ [ "swage", -1 ] ] ],
-    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SWAGING", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
       [ [ "paper", 1 ], [ "wax", 1 ] ],
@@ -133,8 +128,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 12 ] ],
-    "tools": [ [ [ "swage", -1 ] ] ],
-    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SWAGING", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
       [ [ "paper", 1 ], [ "wax", 1 ] ],
@@ -157,8 +151,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 12 ] ],
-    "tools": [ [ [ "swage", -1 ] ] ],
-    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SWAGING", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
       [ [ "paper", 1 ], [ "wax", 1 ] ],
@@ -180,8 +173,7 @@
     "book_learn": [ [ "recipe_bullets", 3 ], [ "manual_shotgun", 3 ] ],
     "charges": 1,
     "reversible": true,
-    "tools": [ [ [ "press", -1 ] ], [ [ "swage", -1 ] ] ],
-    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SWAGING", "level": 1 }, { "id": "CASING_PRESSING", "level": 2 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
       [ [ "paper", 1 ], [ "wax", 1 ] ],
@@ -204,8 +196,7 @@
     "book_learn": [ [ "recipe_bullets", 3 ], [ "manual_shotgun", 3 ] ],
     "charges": 1,
     "reversible": true,
-    "tools": [ [ [ "press", -1 ] ], [ [ "swage", -1 ] ] ],
-    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SWAGING", "level": 1 }, { "id": "CASING_PRESSING", "level": 2 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
       [ [ "paper", 1 ], [ "wax", 1 ] ],

--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -49,7 +49,7 @@
     "autolearn": true,
     "book_learn": [ [ "textbook_fabrication", 1 ] ],
     "using": [ [ "forging_standard", 5 ] ],
-    "tools": [ [ [ "press", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 2 }, { "id": "CONTAIN_HOT", "level": 1 } ],
     "components": [ [ [ "weights", 34, "LIST" ], [ "steel_tiny", 2, "LIST" ] ] ]
   },
   {
@@ -112,8 +112,7 @@
     "time": "30 m",
     "batch_time_factors": [ 70, 1 ],
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 16 ], [ "steel_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 16 ], [ "steel_standard", 1 ] ]
   },
   {
     "type": "recipe",
@@ -149,10 +148,8 @@
     "batch_time_factors": [ 70, 1 ],
     "autolearn": true,
     "charges": 1,
-    "tools": [
-      [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ],
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
-    ],
+    "qualities": [ { "id": "CONTAIN_HOT", "level": 1 } ],
+    "tools": [ [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ] ],
     "components": [ [ [ "lead", 50 ], [ "bismuth", 125 ] ] ]
   },
   {
@@ -166,10 +163,8 @@
     "batch_time_factors": [ 70, 1 ],
     "autolearn": true,
     "charges": 6,
-    "tools": [
-      [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ],
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
-    ],
+    "qualities": [ { "id": "CONTAIN_HOT", "level": 1 } ],
+    "tools": [ [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ] ],
     "components": [ [ [ "lead", 50 ], [ "bismuth", 125 ] ] ]
   },
   {
@@ -210,7 +205,6 @@
     "time": "30 m",
     "batch_time_factors": [ 70, 1 ],
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 16 ], [ "steel_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 16 ], [ "steel_standard", 1 ] ]
   }
 ]

--- a/data/json/recipes/ammo/shot.json
+++ b/data/json/recipes/ammo/shot.json
@@ -183,7 +183,6 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "shot_forming", 1 ], [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press_dowel", -1 ], [ "press", -1 ] ] ],
     "components": [ [ [ "gunpowder", 3 ] ], [ [ "magnesium", 5 ] ] ]
   },
   {
@@ -200,7 +199,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press_dowel", -1 ], [ "press", -1 ] ] ],
+    "qualities": [ { "id": "CASING_PRESSING", "level": 1 } ],
     "components": [ [ [ "gunpowder", 6 ] ], [ [ "combatnail", 10 ] ] ]
   },
   {
@@ -265,7 +264,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press_dowel", -1 ], [ "press", -1 ] ] ],
+    "qualities": [ { "id": "CASING_PRESSING", "level": 1 } ],
     "components": [ [ [ "chem_black_powder", 3 ] ], [ [ "magnesium", 5 ] ] ]
   },
   {
@@ -282,7 +281,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press_dowel", -1 ], [ "press", -1 ] ] ],
+    "qualities": [ { "id": "CASING_PRESSING", "level": 1 } ],
     "components": [ [ [ "chem_black_powder", 6 ] ], [ [ "combatnail", 10 ] ] ]
   },
   {
@@ -315,7 +314,7 @@
     "charges": 2,
     "reversible": true,
     "using": [ [ "ammo_shot", 2 ] ],
-    "tools": [ [ [ "press_dowel", -1 ], [ "press", -1 ] ] ],
+    "qualities": [ { "id": "CASING_PRESSING", "level": 1 } ],
     "components": [
       [ [ "gunpowder", 12 ] ],
       [
@@ -349,7 +348,7 @@
     "charges": 2,
     "reversible": true,
     "using": [ [ "ammo_shot", 2 ] ],
-    "tools": [ [ [ "press_dowel", -1 ], [ "press", -1 ] ] ],
+    "qualities": [ { "id": "CASING_PRESSING", "level": 1 } ],
     "components": [
       [ [ "chem_black_powder", 12 ] ],
       [
@@ -383,7 +382,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press_dowel", -1 ], [ "press", -1 ] ] ],
+    "qualities": [ { "id": "CASING_PRESSING", "level": 1 } ],
     "components": [ [ [ "incendiary", 25 ] ] ]
   },
   {

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -438,7 +438,6 @@
     "time": "9 h",
     "book_learn": [ [ "textbook_armwest", 5 ] ],
     "using": [ [ "blacksmithing_intermediate", 40 ], [ "steel_standard", 10 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "fabric_hides_proper", 4, "LIST" ] ] ]
   },
   {
@@ -451,7 +450,6 @@
     "time": "9 h",
     "book_learn": [ [ "textbook_armwest", 7 ] ],
     "using": [ [ "blacksmithing_intermediate", 40 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "alloy_sheet", 10 ] ], [ [ "fabric_hides_proper", 4, "LIST" ] ] ]
   },
   {
@@ -490,7 +488,6 @@
     "time": "4 h",
     "book_learn": [ [ "textbook_armschina", 5 ] ],
     "using": [ [ "sewing_standard", 18 ], [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "fur", 6 ] ] ]
   },
   {
@@ -503,7 +500,6 @@
     "time": "5 h",
     "book_learn": [ [ "textbook_armwest", 5 ] ],
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "fabric_hides_proper", 4, "LIST" ] ] ]
   },
   {
@@ -516,7 +512,6 @@
     "time": "7 h",
     "book_learn": [ [ "textbook_armeast", 8 ] ],
     "using": [ [ "blacksmithing_intermediate", 48 ], [ "steel_standard", 12 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "fabric_hides_proper", 14, "LIST" ] ], [ [ "fabric_standard", 4, "LIST" ] ] ]
   },
   {
@@ -556,7 +551,6 @@
     "time": "5 h",
     "book_learn": [ [ "textbook_armwest", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 4 ], [ "steel_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "fabric_hides_proper", 3, "LIST" ] ] ]
   },
   {
@@ -581,7 +575,6 @@
     "time": "9 h",
     "book_learn": [ [ "textbook_armwest", 6 ] ],
     "using": [ [ "blacksmithing_intermediate", 56 ], [ "steel_standard", 14 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "fabric_hides_proper", 4, "LIST" ] ] ]
   },
   {
@@ -594,7 +587,6 @@
     "time": "9 h",
     "book_learn": [ [ "textbook_armwest", 8 ] ],
     "using": [ [ "blacksmithing_intermediate", 56 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "alloy_sheet", 14 ] ], [ [ "fabric_hides_proper", 4, "LIST" ] ] ]
   },
   {
@@ -1457,7 +1449,6 @@
     "time": "9 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 16 ], [ "steel_standard", 4 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "goggles_welding", 1 ] ] ]
   },
   {
@@ -1471,7 +1462,6 @@
     "autolearn": true,
     "book_learn": [ [ "textbook_armwest", 3 ], [ "textbook_armeast", 3 ] ],
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "fabric_standard", 1, "LIST" ], [ "fabric_hides_any", 1, "LIST" ] ] ]
   },
   {

--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -369,8 +369,8 @@
     "batch_time_factors": [ 50, 5 ],
     "//": "abstracted chloralkali process, followed by 'burning' resulting chlorine and hydrogen with electric arc as uv source and crucible serving as reaction furnace, then dissolving resulting hydrogen chloride gas in water",
     "book_learn": [ [ "adv_chemistry", 4 ], [ "textbook_chemistry", 4 ], [ "reference_cooking", 4 ] ],
-    "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "electrolysis_kit", 500 ] ], [ [ "welder", 100 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "qualities": [ { "id": "CHEM", "level": 2 }, { "id": "CONTAIN_HOT", "level": 1 } ],
+    "tools": [ [ [ "electrolysis_kit", 500 ] ], [ [ "welder", 100 ] ] ],
     "components": [ [ [ "salt_water", 4 ] ], [ [ "water_clean", 1 ] ] ]
   },
   {

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -487,8 +487,7 @@
     "autolearn": true,
     "charges": 1,
     "using": [ [ "surface_heat", 1 ] ],
-    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 }, { "id": "CONTAIN_HOT", "level": 1 } ],
     "components": [
       [ [ "copper", 1 ] ],
       [ [ "duct_tape", 1 ], [ "medical_tape", 1 ], [ "paper", 2 ], [ "filament", 10, "LIST" ], [ "pitch_wood", 1 ] ]
@@ -508,8 +507,7 @@
     "autolearn": true,
     "charges": 10,
     "using": [ [ "surface_heat", 10 ] ],
-    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 }, { "id": "CONTAIN_HOT", "level": 1 } ],
     "components": [
       [ [ "copper", 10 ] ],
       [

--- a/data/json/recipes/electronic/parts.json
+++ b/data/json/recipes/electronic/parts.json
@@ -696,7 +696,7 @@
       { "id": "ANVIL", "level": 1 },
       { "id": "HAMMER", "level": 2 },
       { "id": "CHEM", "level": 1 },
-      { "id": "DISTILL", "level": 1 }, 
+      { "id": "DISTILL", "level": 1 },
       { "id": "CONTAIN_HOT", "level": 1 }
     ],
     "components": [ [ [ "lead", 25 ] ], [ [ "tin", 25 ] ], [ [ "pitch_wood", 1 ] ] ]

--- a/data/json/recipes/electronic/parts.json
+++ b/data/json/recipes/electronic/parts.json
@@ -696,9 +696,9 @@
       { "id": "ANVIL", "level": 1 },
       { "id": "HAMMER", "level": 2 },
       { "id": "CHEM", "level": 1 },
-      { "id": "DISTILL", "level": 1 }
+      { "id": "DISTILL", "level": 1 }, 
+      { "id": "CONTAIN_HOT", "level": 1 }
     ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "lead", 25 ] ], [ [ "tin", 25 ] ], [ [ "pitch_wood", 1 ] ] ]
   },
   {

--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -665,7 +665,6 @@
     "time": "45 m",
     "book_learn": [ [ "adv_chemistry", 6 ], [ "reference_cooking", 6 ] ],
     "using": [ [ "blacksmithing_intermediate", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "chem_manganese_dioxide", 29 ] ],
       [ [ "zinc_metal", 2 ] ],
@@ -685,7 +684,6 @@
     "time": "1 h",
     "book_learn": [ [ "adv_chemistry", 6 ], [ "reference_cooking", 6 ] ],
     "using": [ [ "blacksmithing_intermediate", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "chem_manganese_dioxide", 87 ] ],
       [ [ "zinc_metal", 6 ] ],
@@ -705,7 +703,6 @@
     "time": "1 h 20 m",
     "book_learn": [ [ "adv_chemistry", 6 ], [ "reference_cooking", 6 ] ],
     "using": [ [ "blacksmithing_intermediate", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "chem_manganese_dioxide", 348 ] ],
       [ [ "zinc_metal", 24 ] ],
@@ -725,7 +722,6 @@
     "time": "1 h 45 m",
     "book_learn": [ [ "adv_chemistry", 6 ], [ "reference_cooking", 6 ] ],
     "using": [ [ "blacksmithing_intermediate", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "chem_manganese_dioxide", 725 ] ],
       [ [ "zinc_metal", 50 ] ],

--- a/data/json/recipes/other/containers.json
+++ b/data/json/recipes/other/containers.json
@@ -212,8 +212,7 @@
     "difficulty": 3,
     "time": "30 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 1 ], [ "steel_tiny", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 1 ], [ "steel_tiny", 1 ] ]
   },
   {
     "type": "recipe",
@@ -224,8 +223,7 @@
     "difficulty": 3,
     "time": "30 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 1 ], [ "steel_tiny", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 1 ], [ "steel_tiny", 1 ] ]
   },
   {
     "type": "recipe",
@@ -266,8 +264,7 @@
     "difficulty": 4,
     "time": "3 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 64 ], [ "steel_standard", 16 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 64 ], [ "steel_standard", 16 ] ]
   },
   {
     "type": "recipe",
@@ -279,8 +276,7 @@
     "difficulty": 4,
     "time": "2 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 40 ], [ "steel_standard", 10 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 40 ], [ "steel_standard", 10 ] ]
   },
   {
     "type": "recipe",
@@ -533,8 +529,7 @@
     "difficulty": 4,
     "time": "90 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 30 ], [ "steel_standard", 8 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 30 ], [ "steel_standard", 8 ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -257,7 +257,6 @@
     "time": "30 m",
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 2 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "scrap", 3 ] ] ]
   },
   {
@@ -282,8 +281,8 @@
     "difficulty": 3,
     "time": "1 h",
     "autolearn": true,
-    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "swage", -1 ] ], [ [ "surface_heat", 2, "LIST" ], [ "forge", 2 ], [ "oxy_torch", 2 ] ] ],
+    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 }, { "id": "SWAGING", "level": 1 } ],
+    "tools": [ [ [ "surface_heat", 2, "LIST" ], [ "forge", 2 ], [ "oxy_torch", 2 ] ] ],
     "components": [ [ [ "wire", 3 ] ] ]
   },
   {
@@ -421,8 +420,7 @@
     "difficulty": 4,
     "time": "1 h 40 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_advanced", 32 ], [ "steel_standard", 8 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_advanced", 32 ], [ "steel_standard", 8 ] ]
   },
   {
     "type": "recipe",
@@ -460,10 +458,9 @@
     "book_learn": [ [ "glassblowing_book", 5 ], [ "reference_cooking", 7 ] ],
     "result_mult": 4,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "using": [ [ "glassblowing_easy", 5 ] ],
     "tools": [
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
       [ [ "tool_flat_press_large", 1, "LIST" ], [ "tool_flat_press_small", 1, "LIST" ] ],
-      [ [ "forge", 25 ] ],
       [ [ "surface_heat", 15, "LIST" ] ]
     ],
     "components": [
@@ -500,7 +497,8 @@
     "batch_time_factors": [ 90, 4 ],
     "autolearn": [ [ "fabrication", 4 ], [ "cooking", 4 ] ],
     "book_learn": [ [ "concrete_book", 3 ], [ "adv_chemistry", 3 ], [ "textbook_chemistry", 3 ], [ "reference_cooking", 4 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 50 ], [ "oxy_torch", 10 ] ] ],
+    "qualities": [ { "id": "CONTAIN_HOT", "level": 1 } ],
+    "tools": [ [ [ "forge", 50 ], [ "oxy_torch", 10 ] ] ],
     "components": [ [ [ "material_limestone", 10 ] ] ]
   },
   {
@@ -515,7 +513,8 @@
     "autolearn": [ [ "cooking", 6 ] ],
     "book_learn": [ [ "concrete_book", 4 ] ],
     "batch_time_factors": [ 90, 3 ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 250 ], [ "oxy_torch", 50 ] ] ],
+    "qualities": [ { "id": "CONTAIN_HOT", "level": 1 } ],
+    "tools": [ [ [ "forge", 250 ], [ "oxy_torch", 50 ] ] ],
     "components": [ [ [ "material_quicklime", 50 ] ], [ [ "material_sand", 50 ] ] ]
   },
   {
@@ -657,7 +656,6 @@
     "autolearn": true,
     "using": [ [ "forging_standard", 10 ], [ "steel_standard", 5 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 2 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "2x4", 24 ] ], [ [ "nail_glue", 40, "LIST" ] ] ]
   },
   {
@@ -1142,7 +1140,6 @@
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
     "using": [ [ "forging_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "tin", 10 ], [ "aluminum_foil", 10 ], [ "chem_aluminium_powder", 15 ], [ "can_drink_unsealed", 2 ] ],
       [ [ "copper_scrap_equivalent", 4, "LIST" ] ]
@@ -1161,7 +1158,6 @@
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
     "using": [ [ "forging_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "material_aluminium_ingot", 1 ] ], [ [ "copper_scrap_equivalent", 40, "LIST" ] ] ]
   },
   {
@@ -1173,7 +1169,6 @@
     "difficulty": 1,
     "time": "30 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "charges": 100,
     "using": [ [ "blacksmithing_intermediate", 1 ] ],
     "components": [ [ [ "zinc_metal", 400 ] ], [ [ "copper", 35 ] ] ]
@@ -1256,7 +1251,7 @@
     "//": "sawing it down doesn't teach anything useful",
     "autolearn": true,
     "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "qualities": [ { "id": "CONTAIN_HOT", "level": 1 } ]
   },
   {
     "type": "recipe",
@@ -1269,7 +1264,6 @@
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
     "using": [ [ "forging_standard", 6 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "//": "Additional coal and flux to increase carbon content, oil for quenching.",
     "components": [
       [ [ "steel_armor", 1 ] ],
@@ -1400,7 +1394,6 @@
     "reversible": true,
     "autolearn": true,
     "using": [ [ "forging_standard", 4 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "can_drink_unsealed", 27 ], [ "aluminum_foil", 68 ], [ "chem_aluminium_powder", 135 ] ] ]
   },
   {
@@ -1427,7 +1420,6 @@
     "reversible": true,
     "autolearn": true,
     "using": [ [ "forging_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "scrap", 5 ] ] ]
   },
   {
@@ -1441,8 +1433,7 @@
     "batch_time_factors": [ 90, 4 ],
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "forging_standard", 4 ], [ "steel_tiny", 4 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "forging_standard", 4 ], [ "steel_tiny", 4 ] ]
   },
   {
     "result": "steel_lump",
@@ -1465,7 +1456,6 @@
       [ "welding_book", 3 ]
     ],
     "using": [ [ "forging_standard", 6 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "//": "Additional coal required for carburization, proportionate by weight.  Yield is roughly 25%.",
     "components": [
       [ [ "iron_ore", 1 ] ],
@@ -1495,7 +1485,6 @@
       [ "welding_book", 3 ]
     ],
     "using": [ [ "forging_standard", 6 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "//": "25% yield, coal and flux also used in reduction.",
     "components": [
       [ [ "copper_ore", 1 ] ],
@@ -1525,7 +1514,6 @@
       [ "welding_book", 3 ]
     ],
     "using": [ [ "forging_standard", 6 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "//": "25% yield, coal and flux also used in reduction.",
     "components": [
       [ [ "lead_ore", 1 ] ],
@@ -1554,7 +1542,6 @@
       [ "welding_book", 2 ]
     ],
     "using": [ [ "forging_standard", 4 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "//": "25% yield, coal and flux also used in reduction.",
     "components": [
       [ [ "tin_ore", 1 ] ],
@@ -1584,7 +1571,6 @@
       [ "welding_book", 2 ]
     ],
     "using": [ [ "forging_standard", 4 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "//": "25% yield, coal and flux also used in reduction.",
     "components": [
       [ [ "silver_ore", 1 ] ],

--- a/data/json/recipes/other/parts.json
+++ b/data/json/recipes/other/parts.json
@@ -102,8 +102,7 @@
     "skills_required": [ "mechanics", 1 ],
     "time": "30 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 1 ], [ "steel_tiny", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 1 ], [ "steel_tiny", 1 ] ]
   },
   {
     "result": "sheet_metal",
@@ -114,8 +113,7 @@
     "difficulty": 3,
     "time": "30 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 5 ], [ "steel_standard", 6 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_standard", 5 ], [ "steel_standard", 6 ] ]
   },
   {
     "result": "sheet_metal",
@@ -139,8 +137,7 @@
     "difficulty": 3,
     "time": "20 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 1 ], [ "steel_tiny", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 1 ], [ "steel_tiny", 1 ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -137,7 +137,8 @@
     "autolearn": [ [ "fabrication", 6 ] ],
     "book_learn": [ [ "recipe_bullets", 3 ], [ "textbook_fabrication", 4 ] ],
     "using": [ [ "soldering_standard", 10 ], [ "surface_heat", 10 ] ],
-    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "swage", -1 ] ] ],
+    "qualities": [ { "id": "SWAGING", "level": 1 } ],
+    "tools": [ [ [ "mold_plastic", -1 ] ] ],
     "components": [ [ [ "plastic_chunk", 5 ] ], [ [ "scrap", 1 ] ] ]
   },
   {
@@ -151,7 +152,7 @@
     "time": "60 m",
     "using": [ [ "forging_standard", 3 ], [ "bronzesmithing_tools", 1 ], [ "steel_standard", 3 ] ],
     "book_learn": [ [ "manual_shotgun", 3 ], [ "manual_rifle", 3 ], [ "manual_smg", 3 ], [ "manual_pistol", 3 ], [ "recipe_bullets", 2 ] ],
-    "tools": [ [ [ "swage", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "qualities": [ { "id": "SWAGING", "level": 1 }, { "id": "CONTAIN_HOT", "level": 1 } ],
     "components": [
       [
         [ "tin", 10 ],
@@ -652,7 +653,6 @@
     "autolearn": true,
     "using": [ [ "blacksmithing_advanced", 2 ], [ "steel_tiny", 2 ] ],
     "qualities": [ { "id": "SAW_M", "level": 2 }, { "id": "CUT", "level": 1 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "plastic_chunk", 2 ], [ "2x4", 1 ], [ "stick", 2 ] ] ]
   },
   {
@@ -714,8 +714,7 @@
     "time": "3 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_advanced", 2 ], [ "steel_tiny", 2 ] ],
-    "qualities": [ { "id": "SAW_M", "level": 2 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "qualities": [ { "id": "SAW_M", "level": 2 } ]
   },
   {
     "type": "recipe",
@@ -1015,8 +1014,8 @@
     "difficulty": 3,
     "time": "2 h",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 150 ], [ "oxy_torch", 30 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CONTAIN_HOT", "level": 1 } ],
+    "tools": [ [ [ "forge", 150 ], [ "oxy_torch", 30 ] ] ],
     "components": [ [ [ "steel_chunk", 160 ], [ "steel_lump", 40 ], [ "frame", 4 ], [ "hdframe", 2 ] ] ]
   },
   {
@@ -1126,8 +1125,8 @@
     "difficulty": 2,
     "time": "1 h 30 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 3 } ],
-    "tools": [ [ [ "press", -1 ] ], [ [ "surface_heat", 10, "LIST" ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CASING_PRESSING", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
     "components": [ [ [ "copper_scrap_equivalent", 14, "LIST" ] ], [ [ "tin", 30 ] ] ]
   },
   {
@@ -1159,8 +1158,8 @@
     "difficulty": 2,
     "time": "1 h",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 3 } ],
-    "tools": [ [ [ "press", -1 ] ], [ [ "surface_heat", 7, "LIST" ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CASING_PRESSING", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ],
     "components": [ [ [ "copper_scrap_equivalent", 10, "LIST" ] ], [ [ "tin", 20 ] ] ]
   },
   {
@@ -1230,8 +1229,7 @@
     "difficulty": 4,
     "time": "2 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 4 ], [ "steel_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 4 ], [ "steel_standard", 1 ] ]
   },
   {
     "type": "recipe",
@@ -1243,7 +1241,6 @@
     "time": "1 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 1 ], [ "steel_tiny", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "plastic_chunk", 1 ], [ "stick", 1 ], [ "2x4", 1 ], [ "scrap", 1 ] ] ]
   },
   {
@@ -1256,7 +1253,6 @@
     "time": "1 h 30 m",
     "autolearn": true,
     "using": [ [ "blacksmithing_advanced", 4 ], [ "steel_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "plastic_chunk", 1 ] ] ]
   },
   {
@@ -1301,8 +1297,7 @@
     "time": "2 h 20 m",
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
-    "book_learn": [ [ "manual_mechanics", 3 ], [ "manual_fabrication", 3 ], [ "textbook_fabrication", 3 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "book_learn": [ [ "manual_mechanics", 3 ], [ "manual_fabrication", 3 ], [ "textbook_fabrication", 3 ] ]
   },
   {
     "type": "recipe",
@@ -1315,7 +1310,6 @@
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
     "book_learn": [ [ "manual_fabrication", 2 ], [ "textbook_fabrication", 3 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "wood_structural", 1, "LIST" ] ] ]
   },
   {
@@ -1343,7 +1337,6 @@
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
     "book_learn": [ [ "manual_fabrication", 2 ], [ "textbook_fabrication", 3 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
@@ -1356,8 +1349,7 @@
     "time": "2 h 20 m",
     "autolearn": true,
     "using": [ [ "blacksmithing_advanced", 16 ], [ "steel_standard", 4 ] ],
-    "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ]
   },
   {
     "type": "recipe",
@@ -1370,7 +1362,6 @@
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 3 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ] ]
   },
   {
@@ -1384,7 +1375,6 @@
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 12 ], [ "steel_standard", 3 ] ],
     "book_learn": [ [ "textbook_fabrication", 4 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "wood_structural_small", 3, "LIST" ] ] ]
   },
   {
@@ -1411,7 +1401,6 @@
     "autolearn": true,
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "wood_structural", 1, "LIST" ] ] ]
   },
   {
@@ -1425,7 +1414,6 @@
     "byproducts": [ [ "splinter", 13 ] ],
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 32 ], [ "steel_standard", 8 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
@@ -1440,7 +1428,6 @@
     "byproducts": [ [ "splinter", 14 ] ],
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 32 ], [ "steel_standard", 8 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
@@ -1468,7 +1455,6 @@
     "byproducts": [ [ "splinter", 13 ] ],
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 32 ], [ "steel_standard", 20 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
@@ -1482,7 +1468,6 @@
     "byproducts": [ [ "splinter", 16 ] ],
     "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 32 ], [ "steel_standard", 4 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
@@ -2352,7 +2337,6 @@
     "autolearn": true,
     "using": [ [ "forging_standard", 5 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "ANVIL", "level": 1 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "scrap_bronze", 10 ] ] ]
   },
   {
@@ -2431,15 +2415,8 @@
     "difficulty": 4,
     "time": "90 m",
     "book_learn": [ [ "glassblowing_book", 5 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [
-      [ [ "tongs", -1 ] ],
-      [ [ "pipe", -1 ] ],
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
-      [ [ "forge", 75 ] ],
-      [ [ "mold_plastic", -1 ] ],
-      [ [ "surface_heat", 5, "LIST" ] ]
-    ],
+    "using": [ [ "glassblowing_standard", 15 ] ],
+    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 5, "LIST" ] ] ],
     "components": [
       [ [ "glass_shard", 3 ], [ "pipe_glass", 1 ], [ "flask_glass", 3 ], [ "test_tube", 6 ], [ "marble", 75 ] ],
       [ [ "plastic_chunk", 1 ] ]
@@ -2752,8 +2729,7 @@
     "skills_required": [ "mechanics", 3 ],
     "time": "3 h",
     "book_learn": [ [ "manual_mechanics", 3 ], [ "manual_fabrication", 5 ], [ "textbook_fabrication", 5 ] ],
-    "using": [ [ "blacksmithing_advanced", 10 ], [ "steel_standard", 5 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_advanced", 10 ], [ "steel_standard", 5 ] ]
   },
   {
     "result": "jack_makeshift",
@@ -2794,7 +2770,6 @@
     "autolearn": true,
     "book_learn": [ [ "textbook_carpentry", 5 ], [ "textbook_fabrication", 6 ] ],
     "using": [ [ "blacksmithing_intermediate", 2 ], [ "steel_standard", 2 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ] ]
   },
   {
@@ -2850,7 +2825,6 @@
     "time": "20 m",
     "reversible": true,
     "autolearn": true,
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "using": [ [ "welding_standard", 1 ], [ "blacksmithing_intermediate", 1 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
     "components": [ [ [ "foot_crank", 1 ] ], [ [ "scrap", 8 ] ], [ [ "steel_chunk", 4 ] ], [ [ "steel_lump", 2 ] ] ]
@@ -2957,8 +2931,7 @@
     "difficulty": 3,
     "time": "2 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 8 ], [ "steel_standard", 2 ] ]
   },
   {
     "result": "halligan",
@@ -2969,8 +2942,7 @@
     "difficulty": 8,
     "time": "3 h",
     "book_learn": [ [ "textbook_fireman", 8 ] ],
-    "using": [ [ "blacksmithing_intermediate", 20 ], [ "steel_standard", 3 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 20 ], [ "steel_standard", 3 ] ]
   },
   {
     "result": "claw_bar",
@@ -2981,8 +2953,7 @@
     "difficulty": 3,
     "time": "100 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 6 ], [ "steel_standard", 2 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 6 ], [ "steel_standard", 2 ] ]
   },
   {
     "result": "iceaxe",
@@ -2994,7 +2965,6 @@
     "time": "3 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 8 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "steel_lump", 1 ], [ "steel_chunk", 4 ], [ "scrap", 20 ] ],
       [ [ "filament", 100, "LIST" ] ],

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -1292,7 +1292,8 @@
     "time": "20 m",
     "autolearn": true,
     "using": [ [ "steel_standard", 20 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 50 ] ] ]
+    "qualities": [ { "id": "CONTAIN_HOT", "level": 1 } ],
+    "tools": [ [ [ "forge", 50 ] ] ]
   },
   {
     "type": "recipe",
@@ -1306,7 +1307,8 @@
     "time": "50 m",
     "autolearn": true,
     "using": [ [ "steel_standard", 100 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 50 ] ] ]
+    "qualities": [ { "id": "CONTAIN_HOT", "level": 1 } ],
+    "tools": [ [ [ "forge", 50 ] ] ]
   },
   {
     "type": "recipe",
@@ -1830,8 +1832,7 @@
     "difficulty": 4,
     "time": "3 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_intermediate", 20 ], [ "steel_standard", 5 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "using": [ [ "blacksmithing_intermediate", 20 ], [ "steel_standard", 5 ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -35,11 +35,8 @@
     "difficulty": 4,
     "time": "30 m",
     "autolearn": true,
-    "qualities": [ { "id": "DRILL", "level": 1 } ],
-    "tools": [
-      [ [ "brick_kiln", 100 ], [ "kiln", 100 ], [ "surface_heat", 100, "LIST" ] ],
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
-    ],
+    "qualities": [ { "id": "DRILL", "level": 1 }, { "id": "CONTAIN_HOT", "level": 1 } ],
+    "tools": [ [ [ "brick_kiln", 100 ], [ "kiln", 100 ], [ "surface_heat", 100, "LIST" ] ] ],
     "components": [ [ [ "shillelagh", 1 ], [ "log", 1 ], [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "weights", 15, "LIST" ] ] ]
   },
   {

--- a/data/json/recipes/weapon/cutting.json
+++ b/data/json/recipes/weapon/cutting.json
@@ -138,7 +138,6 @@
     "time": "6 h",
     "book_learn": [ [ "textbook_fireman", 6 ] ],
     "using": [ [ "blacksmithing_intermediate", 4 ], [ "steel_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "filament", 100, "LIST" ] ],
       [ [ "fabric_standard", 2, "LIST" ], [ "felt_patch", 2 ], [ "fabric_hides_any", 2, "LIST" ] ]
@@ -239,7 +238,6 @@
     "book_learn": [ [ "textbook_fireman", 8 ], [ "textbook_fabrication", 9 ] ],
     "using": [ [ "blacksmithing_intermediate", 16 ], [ "steel_standard", 4 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ] ]
   },
   {

--- a/data/json/recipes/weapon/magazines.json
+++ b/data/json/recipes/weapon/magazines.json
@@ -413,7 +413,7 @@
     "batch_time_factors": [ 50, 3 ],
     "autolearn": [ [ "fabrication", 5 ], [ "gun", 2 ] ],
     "book_learn": [ [ "manual_rifle", 3 ], [ "recipe_bullets", 3 ] ],
-    "tools": [ [ [ "swage", -1 ] ], [ [ "tongs", -1 ] ] ],
+    "qualities": [ { "id": "SWAGING", "level": 1 }, { "id": "GRIP_HOT", "level": 2 } ],
     "using": [ [ "forging_standard", 3 ] ],
     "components": [ [ [ "sheet_metal", 1 ], [ "sheet_metal_small", 24 ] ] ]
   },
@@ -431,7 +431,7 @@
     "batch_time_factors": [ 50, 3 ],
     "autolearn": [ [ "fabrication", 5 ], [ "gun", 2 ] ],
     "book_learn": [ [ "manual_rifle", 3 ], [ "recipe_bullets", 3 ] ],
-    "tools": [ [ [ "swage", -1 ] ], [ [ "tongs", -1 ] ] ],
+    "qualities": [ { "id": "SWAGING", "level": 1 }, { "id": "GRIP_HOT", "level": 2 } ],
     "using": [ [ "forging_standard", 3 ] ],
     "components": [ [ [ "sheet_metal", 1 ], [ "sheet_metal_small", 24 ] ] ]
   },
@@ -449,7 +449,7 @@
     "batch_time_factors": [ 50, 3 ],
     "autolearn": [ [ "fabrication", 5 ], [ "gun", 2 ] ],
     "book_learn": [ [ "manual_rifle", 3 ], [ "recipe_bullets", 3 ] ],
-    "tools": [ [ [ "swage", -1 ] ], [ [ "tongs", -1 ] ] ],
+    "qualities": [ { "id": "SWAGING", "level": 1 }, { "id": "GRIP_HOT", "level": 2 } ],
     "using": [ [ "forging_standard", 3 ] ],
     "components": [ [ [ "sheet_metal", 1 ], [ "sheet_metal_small", 24 ] ] ]
   },
@@ -467,7 +467,7 @@
     "batch_time_factors": [ 50, 3 ],
     "autolearn": [ [ "fabrication", 6 ], [ "gun", 2 ] ],
     "book_learn": [ [ "recipe_bullets", 4 ] ],
-    "tools": [ [ [ "swage", -1 ] ], [ [ "tongs", -1 ] ] ],
+    "qualities": [ { "id": "SWAGING", "level": 1 }, { "id": "GRIP_HOT", "level": 2 } ],
     "using": [ [ "forging_standard", 4 ] ],
     "components": [ [ [ "sheet_metal", 2 ], [ "sheet_metal_small", 48 ] ] ]
   },

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -200,7 +200,8 @@
       [ "manual_smg", 4 ],
       [ "manual_rifle", 4 ]
     ],
-    "tools": [ [ [ "large_repairkit", 75 ] ], [ [ "swage", -1 ] ] ],
+    "qualities": [ { "id": "SWAGING", "level": 1 } ],
+    "tools": [ [ [ "large_repairkit", 75 ] ] ],
     "components": [ [ [ "pipe", 1 ] ] ]
   },
   {
@@ -250,7 +251,8 @@
     "difficulty": 8,
     "time": "1 h",
     "book_learn": [ [ "textbook_mechanics", 4 ], [ "manual_shotgun", 5 ], [ "manual_rifle", 5 ] ],
-    "tools": [ [ [ "large_repairkit", 150 ] ], [ [ "swage", -1 ] ] ],
+    "qualities": [ { "id": "SWAGING", "level": 1 } ],
+    "tools": [ [ [ "large_repairkit", 150 ] ] ],
     "components": [ [ [ "pipe", 1 ] ] ]
   },
   {

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -788,7 +788,6 @@
     "time": "60 m",
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 1 ], [ "steel_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "stick_long", 1 ] ],
       [ [ "filament", 100, "LIST" ] ],

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -1179,9 +1179,10 @@
       { "id": "SAW_M", "level": 1 },
       { "id": "SAW_M_FINE", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
-      { "id": "WRENCH_FINE", "level": 1 }
+      { "id": "WRENCH_FINE", "level": 1 },
+      { "id": "CONTAIN_HOT", "level": 1 }
     ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "mold_plastic", -1 ] ] ],
+    "tools": [ [ [ "mold_plastic", -1 ] ] ],
     "components": [
       [ [ "plastic_chunk", 20 ] ],
       [ [ "sheet_metal", 1 ] ],
@@ -1233,10 +1234,10 @@
       { "id": "WRENCH", "level": 1 },
       { "id": "HAMMER", "level": 3 },
       { "id": "ANVIL", "level": 2 },
-      { "id": "SAW_M_FINE", "level": 1 }
+      { "id": "SAW_M_FINE", "level": 1 },
+      { "id": "GRIP_HOT", "level": 2 }
     ],
     "using": [ [ "soldering_standard", 60 ], [ "surface_heat", 200 ] ],
-    "tools": [ [ [ "tongs", -1 ] ] ],
     "components": [
       [ [ "copper_scrap_equivalent", 80, "LIST" ] ],
       [ [ "cu_pipe", 2 ] ],

--- a/data/json/requirements/ammo.json
+++ b/data/json/requirements/ammo.json
@@ -185,6 +185,7 @@
     "id": "explosives_casting_standard",
     "type": "requirement",
     "//": "References needed for forge and crucible to recast your stabilized explosives",
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 25 ] ] ]
+    "qualities": [ { "id": "CONTAIN_HOT", "level": 1 } ],
+    "tools": [ [ [ "forge", 25 ] ] ]
   }
 ]

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -73,7 +73,7 @@
       { "id": "CHISEL", "level": 3 },
       { "id": "GRIP_HOT", "level": 2 },
       { "id": "CONTAIN_HOT", "level": 1 },
-      { "id": "SWAGING", "level": 3 }
+      { "id": "SWAGING", "level": 1 }
     ],
     "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ] ]
   },

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -10,15 +10,16 @@
     "id": "bullet_forming",
     "type": "requirement",
     "//": "Forming of bullets from raw materials",
-    "tools": [ [ [ "press", -1 ], [ "press_workbench", -1 ] ], [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ] ]
+    "qualities": [ { "id": "CASING_PRESSING", "level": 2 } ],
+    "tools": [ [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ] ]
   },
   {
     "id": "shot_forming",
     "type": "requirement",
     "//": "Forming of shot from raw materials, allows use of makeshift press",
     "//2": "Shotshell press being first on the list makes it require cutting quality to reverse instead of pulling",
+    "qualities": [ { "id": "CASING_PRESSING", "level": 1 } ],
     "tools": [
-      [ [ "press_dowel", -1 ], [ "press", -1 ], [ "press_workbench", -1 ] ],
       [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ]
     ]
   },
@@ -27,7 +28,8 @@
     "type": "requirement",
     "//": "Forming of rifle bullets from raw materials",
     "//2": "Reloading bench press being first on the list makes reversal bump required pulling quality up to level 2",
-    "tools": [ [ [ "press_workbench", -1 ], [ "press", -1 ] ], [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ] ]
+    "qualities": [ { "id": "CASING_PRESSING", "level": 2 } ],
+    "tools": [ [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ] ]
   },
   {
     "id": "earthenware_firing",
@@ -38,35 +40,44 @@
   {
     "id": "forging_standard",
     "type": "requirement",
-    "//": "Forging of steel items (per steel chunk), charcoal forge is already a substitute for forge",
+    "//": "Forging of steel items (per steel chunk), charcoal forge is already a substitute for forge. Crucible because melting brass and steel",
+    "qualities": [ { "id": "CONTAIN_HOT", "level": 1 } ],
     "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ] ]
   },
   {
     "id": "blacksmithing_standard",
     "type": "requirement",
-    "//": "Includes forging resources as well as tools needed for basic blacksmithing.  Permits working hot metal on stone surfaces.",
-    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ], [ [ "tongs", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "//": "Includes forging resources as well as tools needed for basic blacksmithing.  Wooden tongs (if added) or pliers works here.",
+    "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 }, { "id": "GRIP_HOT", "level": 1 } ],
+    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ] ]
   },
   {
     "id": "blacksmithing_intermediate",
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for mid-level blacksmithing.  Require a harder work surface for hot-cut chiseling and other uses of chisel quality.",
     "//2": "TODO: Downgrade chisel requirement to 2 if we ever get a chisel in between stone and steel",
-    "qualities": [ { "id": "ANVIL", "level": 2 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ], [ [ "tongs", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "qualities": [ 
+      { "id": "ANVIL", "level": 2 }, 
+      { "id": "HAMMER", "level": 3 }, 
+      { "id": "CHISEL", "level": 3 }, 
+      { "id": "GRIP_HOT", "level": 2 }, 
+      { "id": "CONTAIN_HOT", "level": 1 } 
+    ],
+    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ] ]
   },
   {
     "id": "blacksmithing_advanced",
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for advanced blacksmithing.  Require a proper dediciated anvil for use of a swage and die set.",
-    "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [
-      [ [ "forge", 20 ], [ "oxy_torch", 20 ] ],
-      [ [ "tongs", -1 ] ],
-      [ [ "swage", -1 ] ],
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
-    ]
+    "qualities": [ 
+      { "id": "ANVIL", "level": 3 }, 
+      { "id": "HAMMER", "level": 3 }, 
+      { "id": "CHISEL", "level": 3 }, 
+      { "id": "GRIP_HOT", "level": 2 }, 
+      { "id": "CONTAIN_HOT", "level": 1 }, 
+      { "id": "SWAGING", "level": 3 }  
+    ],
+    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ] ]
   },
   {
     "id": "mutagen_production_standard",
@@ -150,8 +161,7 @@
     "id": "bronzesmithing_tools",
     "type": "requirement",
     "//": "Tools for casting and work hardening items made from bronze",
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "ANVIL", "level": 2 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "ANVIL", "level": 2 }, { "id": "CONTAIN_HOT", "level": 1 } ]
   },
   {
     "id": "concrete_removal_standard",
@@ -269,23 +279,19 @@
     "id": "glassblowing_easy",
     "type": "requirement",
     "//": "Forge, crucible, tongs, glassblowing pipe. Units of 5 because someone made test tubes craftable at 5 forge.",
-    "tools": [
-      [ [ "forge", 5 ], [ "oxy_torch", 5 ] ],
-      [ [ "tongs", -1 ] ],
-      [ [ "pipe", -1 ] ],
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
-    ]
+    "qualities": [ { "id": "GRIP_HOT", "level": 2 }, { "id": "CONTAIN_HOT", "level": 1 }, { "id": "GLASSBLOWING", "level": 1 } ],
+    "tools": [ [ [ "forge", 5 ], [ "oxy_torch", 5 ] ] ]
   },
   {
     "id": "glassblowing_standard",
     "type": "requirement",
     "//": "Because apparently we need chiseling.",
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [
-      [ [ "forge", 5 ], [ "oxy_torch", 5 ] ],
-      [ [ "tongs", -1 ] ],
-      [ [ "pipe", -1 ] ],
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
-    ]
+    "qualities": [ 
+      { "id": "CHISEL", "level": 3 }, 
+      { "id": "GRIP_HOT", "level": 2 }, 
+      { "id": "CONTAIN_HOT", "level": 1 }, 
+      { "id": "GLASSBLOWING", "level": 1 } 
+    ],
+    "tools": [ [ [ "forge", 5 ], [ "oxy_torch", 5 ] ] ]
   }
 ]

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -19,9 +19,7 @@
     "//": "Forming of shot from raw materials, allows use of makeshift press",
     "//2": "Shotshell press being first on the list makes it require cutting quality to reverse instead of pulling",
     "qualities": [ { "id": "CASING_PRESSING", "level": 1 } ],
-    "tools": [
-      [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ]
-    ]
+    "tools": [ [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ] ]
   },
   {
     "id": "rifle_bullet_forming",
@@ -56,12 +54,12 @@
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for mid-level blacksmithing.  Require a harder work surface for hot-cut chiseling and other uses of chisel quality.",
     "//2": "TODO: Downgrade chisel requirement to 2 if we ever get a chisel in between stone and steel",
-    "qualities": [ 
-      { "id": "ANVIL", "level": 2 }, 
-      { "id": "HAMMER", "level": 3 }, 
-      { "id": "CHISEL", "level": 3 }, 
-      { "id": "GRIP_HOT", "level": 2 }, 
-      { "id": "CONTAIN_HOT", "level": 1 } 
+    "qualities": [
+      { "id": "ANVIL", "level": 2 },
+      { "id": "HAMMER", "level": 3 },
+      { "id": "CHISEL", "level": 3 },
+      { "id": "GRIP_HOT", "level": 2 },
+      { "id": "CONTAIN_HOT", "level": 1 }
     ],
     "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ] ]
   },
@@ -69,13 +67,13 @@
     "id": "blacksmithing_advanced",
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for advanced blacksmithing.  Require a proper dediciated anvil for use of a swage and die set.",
-    "qualities": [ 
-      { "id": "ANVIL", "level": 3 }, 
-      { "id": "HAMMER", "level": 3 }, 
-      { "id": "CHISEL", "level": 3 }, 
-      { "id": "GRIP_HOT", "level": 2 }, 
-      { "id": "CONTAIN_HOT", "level": 1 }, 
-      { "id": "SWAGING", "level": 3 }  
+    "qualities": [
+      { "id": "ANVIL", "level": 3 },
+      { "id": "HAMMER", "level": 3 },
+      { "id": "CHISEL", "level": 3 },
+      { "id": "GRIP_HOT", "level": 2 },
+      { "id": "CONTAIN_HOT", "level": 1 },
+      { "id": "SWAGING", "level": 3 }
     ],
     "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ] ] ]
   },
@@ -286,11 +284,11 @@
     "id": "glassblowing_standard",
     "type": "requirement",
     "//": "Because apparently we need chiseling.",
-    "qualities": [ 
-      { "id": "CHISEL", "level": 3 }, 
-      { "id": "GRIP_HOT", "level": 2 }, 
-      { "id": "CONTAIN_HOT", "level": 1 }, 
-      { "id": "GLASSBLOWING", "level": 1 } 
+    "qualities": [
+      { "id": "CHISEL", "level": 3 },
+      { "id": "GRIP_HOT", "level": 2 },
+      { "id": "CONTAIN_HOT", "level": 1 },
+      { "id": "GLASSBLOWING", "level": 1 }
     ],
     "tools": [ [ [ "forge", 5 ], [ "oxy_torch", 5 ] ] ]
   }

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -350,5 +350,20 @@
     "type": "tool_quality",
     "id": "CUT_M",
     "name": { "str": "metal cutting" }
+  },
+  {
+    "type": "tool_quality",
+    "id": "GRIP_HOT",
+    "name": { "str": "hot gripping" }
+  },
+  {
+    "type": "tool_quality",
+    "id": "CONTAIN_HOT",
+    "name": { "str": "hot containing" }
+  },
+  {
+    "type": "tool_quality",
+    "id": "SWAGING",
+    "name": { "str": "swaging" }
   }
 ]

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -365,5 +365,20 @@
     "type": "tool_quality",
     "id": "SWAGING",
     "name": { "str": "swaging" }
+  },
+  {
+    "type": "tool_quality",
+    "id": "GLASSBLOWING",
+    "name": { "str": "glassblowing" }
+  },
+  {
+    "type": "tool_quality",
+    "id": "CASING_FORMING",
+    "name": { "str": "casing forming" }
+  },
+  {
+    "type": "tool_quality",
+    "id": "CASING_PRESSING",
+    "name": { "str": "casing pressing" }
   }
 ]

--- a/data/json/uncraft/ammo/40x46mm.json
+++ b/data/json/uncraft/ammo/40x46mm.json
@@ -6,8 +6,7 @@
     "difficulty": 4,
     "skills_required": [ "launcher", 2 ],
     "time": "5 m",
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "PULL", "level": 1 } ],
-    "tools": [ [ [ "swage", -1 ] ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "PULL", "level": 1 }, { "id": "SWAGING", "level": 1 } ],
     "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 30 ] ], [ [ "40x46mm_m212_casing", 1 ] ], [ [ "rubber_slug", 1 ] ] ],
     "charges": 1
   },
@@ -18,8 +17,7 @@
     "difficulty": 4,
     "skills_required": [ "launcher", 2 ],
     "time": "5 m",
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "PULL", "level": 1 } ],
-    "tools": [ [ [ "swage", -1 ] ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "PULL", "level": 1 }, { "id": "SWAGING", "level": 1 } ],
     "components": [
       [ [ "smpistol_primer", 1 ] ],
       [ [ "chem_compositionb", 30 ] ],
@@ -36,9 +34,8 @@
     "difficulty": 4,
     "skills_required": [ "launcher", 2 ],
     "time": "5 m",
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "PULL", "level": 1 }, { "id": "SWAGING", "level": 1 } ],
     "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 30 ] ], [ [ "40x46mm_m195_casing", 1 ] ] ],
-    "tools": [ [ [ "swage", -1 ] ] ],
     "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/40x53mm.json
+++ b/data/json/uncraft/ammo/40x53mm.json
@@ -6,8 +6,7 @@
     "difficulty": 4,
     "skills_required": [ "launcher", 2 ],
     "time": "10 m",
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "PULL", "level": 1 } ],
-    "tools": [ [ [ "swage", -1 ] ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "PULL", "level": 1 }, { "id": "SWAGING", "level": 1 } ],
     "components": [
       [ [ "40x53mm_m169_casing", 1 ] ],
       [ [ "chem_compositionb", 32 ] ],

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -2419,8 +2419,7 @@
     "result": "material_shrd_limestone",
     "type": "uncraft",
     "time": "10 m",
-    "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN_HOT", "level": 1 } ],
     "components": [ [ [ "material_limestone", 10 ] ] ]
   },
   {

--- a/data/mods/Aftershock/recipes/recipes.json
+++ b/data/mods/Aftershock/recipes/recipes.json
@@ -401,7 +401,6 @@
     "reversible": true,
     "autolearn": true,
     "using": [ [ "forging_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "afs_titanium_small", 400 ] ] ]
   },
   {
@@ -416,7 +415,6 @@
     "reversible": true,
     "autolearn": true,
     "using": [ [ "forging_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "afs_titanium_small", 400 ] ] ]
   },
   {

--- a/data/mods/MagicalNights/recipes/blacksmithing.json
+++ b/data/mods/MagicalNights/recipes/blacksmithing.json
@@ -9,7 +9,8 @@
     "time": "180 m",
     "batch_time_factors": [ 50, 2 ],
     "book_learn": [ [ "welding_book", 4 ] ],
-    "tools": [ [ [ "demon_forge", 15 ] ], [ [ "tongs", -1 ] ] ],
+    "qualities": [ { "id": "GRIP_HOT", "level": 2 } ],
+    "tools": [ [ [ "demon_forge", 15 ] ] ],
     "components": [ [ [ "orichalcum_sliver", 8 ], [ "orichalcum_lump", 2 ] ], [ [ "mercury", 100 ] ] ]
   },
   {
@@ -22,7 +23,8 @@
     "time": "180 m",
     "batch_time_factors": [ 50, 2 ],
     "book_learn": [ [ "welding_book", 4 ] ],
-    "tools": [ [ [ "demon_forge", 15 ] ], [ [ "tongs", -1 ] ] ],
+    "qualities": [ { "id": "GRIP_HOT", "level": 2 } ],
+    "tools": [ [ [ "demon_forge", 15 ] ] ],
     "components": [ [ [ "scrap_bronze", 9 ] ], [ [ "mercury", 400 ] ] ]
   },
   {
@@ -35,7 +37,8 @@
     "time": "180 m",
     "batch_time_factors": [ 50, 2 ],
     "book_learn": [ [ "welding_book", 5 ] ],
-    "tools": [ [ [ "demon_forge", 15 ] ], [ [ "tongs", -1 ] ] ],
+    "qualities": [ { "id": "GRIP_HOT", "level": 2 } ],
+    "tools": [ [ [ "demon_forge", 15 ] ] ],
     "components": [ [ [ "mithril_lump", 2 ] ], [ [ "mercury", 100 ] ] ]
   },
   {
@@ -48,7 +51,8 @@
     "time": "180 m",
     "batch_time_factors": [ 50, 2 ],
     "book_learn": [ [ "welding_book", 5 ] ],
-    "tools": [ [ [ "demon_forge", 15 ] ], [ [ "tongs", -1 ] ] ],
+    "qualities": [ { "id": "GRIP_HOT", "level": 2 } ],
+    "tools": [ [ [ "demon_forge", 15 ] ] ],
     "components": [ [ [ "silver_small", 9 ] ], [ [ "mercury", 400 ] ] ]
   },
   {

--- a/data/mods/MagicalNights/recipes/weapons.json
+++ b/data/mods/MagicalNights/recipes/weapons.json
@@ -11,8 +11,8 @@
     "time": "360 m",
     "autolearn": true,
     "using": [ [ "forging_standard", 2 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 1 }, { "id": "MANA_INFUSE", "level": 1 } ],
-    "tools": [ [ [ "water", -1 ] ], [ [ "tongs", -1 ] ] ],
+    "qualities": [ { "id": "CHISEL", "level": 1 }, { "id": "MANA_INFUSE", "level": 1 }, { "id": "GRIP_HOT", "level": 2 } ],
+    "tools": [ [ [ "water", -1 ] ] ],
     "components": [
       [ [ "q_staff", 1 ] ],
       [ [ "jar_glass", 2 ] ],
@@ -454,7 +454,6 @@
     "time": "7 h",
     "book_learn": [ [ "textbook_fireman", 8 ], [ "textbook_fabrication", 9 ] ],
     "using": [ [ "blacksmithing_intermediate", 16 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "orichalcum_ingot", 2 ] ], [ [ "2x4", 2 ], [ "stick", 4 ] ] ]
   },
   {

--- a/data/mods/exotic_ammo/recipes/casings.json
+++ b/data/mods/exotic_ammo/recipes/casings.json
@@ -8,10 +8,10 @@
     "difficulty": 4,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
@@ -25,10 +25,10 @@
     "difficulty": 4,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
@@ -42,10 +42,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 18 ] ] ]
@@ -62,8 +62,8 @@
     "time": "3 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "manual_pistol", 5 ], [ "recipe_bullets", 3 ] ],
-    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "DRILL", "level": 2 } ],
-    "tools": [ [ [ "press", -1 ] ], [ [ "cordless_drill", 2 ] ] ],
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "DRILL", "level": 2 }, { "id": "CASING_PRESSING", "level": 2 } ],
+    "tools": [ [ [ "cordless_drill", 2 ] ] ],
     "components": [ [ [ "308_casing", 1 ], [ "3006_casing", 1 ] ] ]
   },
   {
@@ -75,10 +75,10 @@
     "difficulty": 4,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]
@@ -92,10 +92,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
@@ -109,10 +109,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
@@ -126,10 +126,10 @@
     "difficulty": 4,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 2 ] ] ]
@@ -143,10 +143,10 @@
     "difficulty": 3,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 2 ] ] ]
@@ -160,10 +160,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]
@@ -177,10 +177,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
@@ -194,10 +194,10 @@
     "difficulty": 5,
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
+    "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
     "tools": [
       [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ],
-      [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ]
+      [ [ "forging_standard", 1, "LIST" ] ]
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]

--- a/data/mods/exotic_ammo/recipes/casings.json
+++ b/data/mods/exotic_ammo/recipes/casings.json
@@ -9,10 +9,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
   },
@@ -26,10 +23,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 3 ] ] ]
   },
@@ -43,10 +37,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 18 ] ] ]
   },
@@ -76,10 +67,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]
   },
@@ -93,10 +81,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
   },
@@ -110,10 +95,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
   },
@@ -127,10 +109,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 2 ] ] ]
   },
@@ -144,10 +123,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 2 ] ] ]
   },
@@ -161,10 +137,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]
   },
@@ -178,10 +151,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 7 ] ] ]
   },
@@ -195,10 +165,7 @@
     "time": "5 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 3 ] ],
     "qualities": [ { "id": "CASING_FORMING", "level": 1 } ],
-    "tools": [
-      [ [ "hydraulic_press", 10 ] ],
-      [ [ "forging_standard", 1, "LIST" ] ]
-    ],
+    "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 4 ] ] ]
   }


### PR DESCRIPTION
## Purpose of change (The Why)

The great tool quality PR has arrived. This moves the rest of the reasonable tools into quailities for a number of benefits. We discussed the benefits of standardization in dev chat, and even if we don't want to diversify tool quality levels, having everything line up neatly is nice.

This has the benefits of:

- Less JSON lines
- Easier to update crafting as a whole, for harder or easier
- Easier for modders
- Globalized standardization

Examples of what mods will do: @NobleJake  uses hardlight to mimic weaponry and I brought up hardlight tools. Being able to combine tongs with a hammer, chisel, and swage set would be cool.

Essence does a lot of "I can craft simply with my mind" power of magic. This facilitates doing that more without changing craft standards. `sub` does not work well because you can only use it once and it's better for acetylene torches or soldering irons. The existence of `sub` largely predates tool qualities, and is a bit hacky for mimicking something like tongs or pliers. Some day I would like to see a way for tool qualities to consume their own charges so we can better add forges, torches, soldering irons, power tools, and so on, but this is out of reach for my skill set.

## Describe the solution (The How)

Adds  `GRIP_HOT` `CONTAIN_HOT` `SWAGING` `GLASSBLOWING` `CASING_FORMING` and `CASING_PRESSING` to respective tools. Switches craft standards to use the qualities, and switches recipes around to not use redundant qualities or tools and to add ones in place of tools.

Copper tubing and metal pipes are both glassblowing instruments, the press dowel press and reloading bench are levels 1 2 and 3 on casing pressing, while the swage and both firearm kits are casing forming 1.

Swaging is just the swage and die set, if we need higher quality swaging for advanced machines we can do it now. 

CONTAIN_HOT is named so because some acids need boiling in a crucible, so it's actually used in chemistry, the clay crucible is only 1 while the better one is level 2, which helps if we want high temperature smithing. 

GRIP_HOT is used by pliers at level 1, and tongs at level 2, blacksmithing standard uses level 1 and lost the crucible requirement as Chaos didn't like it and most meltables seem to use intermediate already.


## Describe alternatives you've considered

This is a better direction I think, for all listed reasons.

## Testing

I threw it all into my save. There were no errors.
<img width="2046" height="1206" alt="image" src="https://github.com/user-attachments/assets/de71626b-b999-40f4-a042-da25e9fe50e6" />


## Additional context

https://tenor.com/view/13sentinels-me-gif-25942564

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.