### PR TITLE
feat(balance): simplify and standarize wooden vehiclepart recipes, add light wooden seat

### DIFF
--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -946,7 +946,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "2x4", 5 ] ], [ [ "nail_glue", 15, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural_small", 5, "LIST" ] ], [ [ "nail_glue", 15, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1050,7 +1050,7 @@
     "time": "1 h",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 }, { "id": "SANDING", "level": 1 } ],
-    "components": [ [ [ "2x4", 4 ] ], [ [ "nail_glue", 10, "LIST" ] ] ]
+    "components": [ [ [ "wood_structural", 2, "LIST" ] ], [ [ "nail_glue", 10, "LIST" ] ] ]
   },
   {
     "result": "cargo_aisle",
@@ -1332,8 +1332,8 @@
     "time": "4 m",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "rope_natural_short", 3 ] ],
-    "components": [ [ [ "2x4", 3 ], [ "stick", 6 ] ] ]
+    "using": [ [ "rope_natural_short", 1 ] ],
+    "components": [ [ [ "wood_structural_small", 3, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1384,7 +1384,8 @@
     "time": "6 m",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "2x4", 6 ] ], [ [ "rope_natural_short", 1, "LIST" ], [ "nail", 5 ], [ "adhesive", 2, "LIST" ] ] ]
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
+    "components": [ [ [ "wood_structural", 3, "LIST" ] ], [ [ "rope_natural_short", 1, "LIST" ], [ "nail_glue", 20, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2693,6 +2693,27 @@
   },
   {
     "type": "vehicle_part",
+    "id": "seat_wood_light",
+    "copy-from": "seat_wood",
+    "name": { "str": "light wooden seat" },
+    "looks_like": "seat_wood",
+    "durability": 80,
+    "item": "frame_wood_light",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 0 ] ], "time": "10 m", "using": [ [ "rope_natural_short", 1 ] ] },
+      "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "5 m", "using": [  ] },
+      "repair": {
+        "skills": [ [ "mechanics", 0 ] ],
+        "time": "5 m",
+        "using": [ [ "nail_any_adhesive", 1 ], [ "vehicle_repair_small_wood", 4 ] ]
+      }
+    },
+    "delete": { "flags": [ "BELTABLE" ] },
+    "breaks_into": [ { "item": "splinter", "count": [ 3, 5 ] }, { "item": "string_36", "count": [ 10, 15 ] } ],
+    "damage_reduction": { "all": 6 }
+  },
+  {
+    "type": "vehicle_part",
     "id": "spike_wood",
     "name": { "str": "wooden spike" },
     "symbol": ".",

--- a/data/json/vehicles/boats.json
+++ b/data/json/vehicles/boats.json
@@ -5,7 +5,7 @@
     "name": "canoe",
     "blueprint": [ [ "<OO>" ] ],
     "parts": [
-      { "x": 0, "y": 0, "parts": [ "frame_wood_horizontal", "seat", "hand_paddles", "boat_board" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_wood_horizontal", "seat_wood_light", "hand_paddles", "boat_board" ] },
       { "x": 1, "y": 0, "parts": [ "frame_wood_horizontal", "boat_board", "seat" ] },
       { "x": 2, "y": 0, "parts": [ "frame_wood_horizontal", "boat_board" ] },
       { "x": -1, "y": 0, "parts": [ "frame_wood_horizontal", "boat_board" ] }

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -294,7 +294,7 @@ TEST_CASE( "vehicle_drag", "[vehicle] [engine]" )
     test_vehicle_drag( "schoolbus", 0.411188, 3.331642, 1491.510227, 12930, 15101 );
     test_vehicle_drag( "security_van", 0.541800, 7.617575, 6252.103125, 11074, 13079 );
     test_vehicle_drag( "wienermobile", 1.063697, 2.385608, 1957.981250, 11253, 13409 );
-    test_vehicle_drag( "canoe", 0.609525, 7.741047, 2.191938, 298, 628 );
+    test_vehicle_drag( "canoe", 0.609525, 7.551118, 2.138157, 337, 707 );
     test_vehicle_drag( "kayak", 0.609525, 4.036067, 1.523792, 544, 1067 );
     test_vehicle_drag( "kayak_racing", 0.609525, 3.704980, 1.398792, 586, 1133 );
     test_vehicle_drag( "DUKW", 0.776903, 3.8956, 84.26, 9993, 12063 );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This updates some wooden vehicle parts so you don't have to get a full forge setup and make a wood saw (or scrounge up some copper) to make a basic canoe.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Set wooden boat boards to use `wood_structural_small` instead of being limited to just planks, since they're the main boat board option for making boats.
2. Set oar recipe to use `wood_structural` instead of just planks, making it possible to make them from sticks.
3. Merged and consistency-checked the use of planks vs sticks in the recipe for light wooden frames via `wood_structural_small`, since we've generally been moving away from recipes using twice as many sticks when both weight about the same. In addition, lowered amount of rope required from 3 to 1, which combined with it still needing 1 rope to install cuts the total ropes needed in half.
4. Allowed wooden armor kits to use `wood_structural` and made its use of nails/glue consistent with wooden frames. These are used for aisles and roofs after all, not just armor and rams.
5. Added a light wooden seat vehiclepart that uses a light wooden frame, so you don't need to have the ability to make planks to get a control surface to use oars with.
6. Misc: Set canoes to use light wooden seats, to contrast with the wider wooden rowboat having regular wooden seats.

## Describe alternatives you've considered

1. Leaving boat board recipe untouched since we do have raft boards as an alternative that also doesn't need access to a saw.
2. Allowing you to install light wooden frames with `nail_glue` as an alternative to rope.
3. Saying "fuck it" and just letting you make regular wooden frames out of sticks too.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

~~If this scrungles the vehicle tests I'm gonna cry.~~

![dragon-crying-letty](https://github.com/user-attachments/assets/11985524-d750-4182-b47c-f06adeaa7662)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
