### PR TITLE
feat(balance): carbon fiber parts are shock resistant, superalloy parts shock immune

### DIFF
--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -341,7 +341,8 @@
     "name": { "str": "carbon cargo space" },
     "size": "600 L",
     "item": "cargo_rack_carbon",
-    "breaks_into": [  ]
+    "breaks_into": "ig_vp_carbon",
+    "extend": { "flags": [ "SHOCK_RESISTANT" ] }
   },
   {
     "copy-from": "cargo_space_carbon",
@@ -351,7 +352,7 @@
     "location": "structure",
     "description": "Storage space, mounted outside your vehicle's armor and vulnerable to damage.",
     "size": "300 L",
-    "flags": [ "UNMOUNT_ON_DAMAGE", "CARGO", "PROTRUSION", "COVERED", "BOARDABLE" ]
+    "flags": [ "UNMOUNT_ON_DAMAGE", "CARGO", "PROTRUSION", "COVERED", "BOARDABLE", "SHOCK_RESISTANT" ]
   },
   {
     "copy-from": "cargo_space",

--- a/data/json/vehicleparts/frames.json
+++ b/data/json/vehicleparts/frames.json
@@ -186,7 +186,7 @@
         "using": [ [ "welding_standard", 5 ], [ "vehicle_repair_carbon", 10 ] ]
       }
     },
-    "flags": [ "MOUNTABLE" ],
+    "flags": [ "MOUNTABLE", "SHOCK_RESISTANT" ],
     "damage_reduction": { "all": 84 }
   },
   {

--- a/data/json/vehicleparts/rams.json
+++ b/data/json/vehicleparts/rams.json
@@ -37,6 +37,7 @@
         "using": [ [ "welding_standard", 5 ], [ "vehicle_repair_superalloy", 1 ] ]
       }
     },
+    "extend": { "flags": [ "SHOCK_IMMUNE" ] },
     "damage_reduction": { "all": 120 }
   },
   {

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1283,8 +1283,8 @@
       "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 7 ] ], "time": "60 m", "using": [ [ "armor_kevlar_plate", 1 ] ] }
     },
-    "flags": [ "FLOATS", "BOARDABLE" ],
-    "breaks_into": [ { "item": "kevlar_plate", "count": [ 1, 3 ] } ],
+    "flags": [ "FLOATS", "BOARDABLE", "SHOCK_RESISTANT" ],
+    "breaks_into": "ig_vp_carbon",
     "damage_reduction": { "all": 14 }
   },
   {
@@ -2216,7 +2216,7 @@
         "using": [ [ "welding_standard", 5 ], [ "vehicle_repair_superalloy", 1 ] ]
       }
     },
-    "flags": [ "ARMOR" ],
+    "flags": [ "ARMOR", "SHOCK_IMMUNE" ],
     "breaks_into": [
       { "item": "steel_lump", "count": [ 4, 6 ] },
       { "item": "steel_chunk", "count": [ 4, 6 ] },


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This is an idea that came up while discussing adding shock-resistance flags to more vehicleparts, the idea of making carbon fiber and superalloy parts take less indirect damage from collosions to encourage players to dabble in the fancier materials for their deathmobile. Making superalloy in particular even better for this came up in the BN server as potentially neat given superalloy can't be crafted barring nanofab shenagians, while carbon fiber is craftable later in the game.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added `SHOCK_RESISTANT` to all carbon fiber parts.
2. Added `SHOCK_IMMUNE` to all superalloy parts.
3. Misc: Fixed a couple carbon fiber parts not yielding filaments when broken.

## Describe alternatives you've considered

Making superalloy parts merely resistant and not immune.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Note to self: add carbon fiber versions of all vehicleparts that use a steel frame, and superalloy versions of all parts that use steel plating, in a followup PR.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
