### PR TITLE
feat: civilians are smarter, futile fighter profession

### DIFF
--- a/data/mods/Civilians/civilians.json
+++ b/data/mods/Civilians/civilians.json
@@ -30,7 +30,7 @@
     "upgrades": { "half_life": 1, "age_grow": 1, "into_group": "GROUP_CIVILIANS_UPGRADE" },
     "dodge": 1,
     "death_drops": "default_zombie_death_drops",
-    "flags": [ "SEES", "HEARS", "WARM", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER_1", "GUILT" ]
+    "flags": [ "SEES", "HEARS", "WARM", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER_2", "PRIORITIZE_TARGETS", "GUILT" ]
   },
   {
     "id": "mon_civilian_stationary",

--- a/data/mods/Civilians/professions.json
+++ b/data/mods/Civilians/professions.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "profession",
+    "id": "futile_fighter",
+    "name": "Futile Fighter",
+    "description": "The cataclysm may have caught you off guard, but you're not going down without a fight!",
+    "points": -1,
+    "items": {
+      "both": {
+        "entries": [
+          { "item": "tank_top" },
+          { "item": "jeans" },
+          { "item": "flip_flops" },
+          { "item": "stick", "custom-flags": [ "auto_wield" ] }
+        ]
+      },
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "panties" } ] }
+    }
+  }
+]


### PR DESCRIPTION
## Purpose of change (The Why)
Civilians are pretty dumb. This makes them a little bit smarter, although they probably won't survive longer.

## Describe the solution (The How)
Adds two flags, PATH_AVOID_DANGER2 and PRIORITIZE_TARGETS. This makes them avoid traps and prioritize their targets in combat.

Additionally, ports  a -1 point profession to the mod from DDA, that only starts with a stick and no stats.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Tiering the civilians, so smarter ones (futile fighter, overconfident officer, panicked person) avoid traps while the dumber ones don't. This wouldn't affect gameplay much in practice and would probably just bloat the JSON a bit.

Making the profession give more points? -2 perhaps?
## Testing
Spawned a bunch of overconfident officers, futile fighters and monsters in, they seemed much less happy to shoot me once they killed the mons than before. Punched one a bit and they still fought me.

Started as the new profession.
## Additional context
## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
