### PR TITLE
feat: crouching reduces target size and dispersion

### DIFF
--- a/data/raw/tips.json
+++ b/data/raw/tips.json
@@ -86,7 +86,9 @@
       "Take cover!  Standing next to sandbags or other obstacles will let you shoot past them unimpeded, while blocking some return fire.",
       "Ballistic windows can take the bite out of bullets flying your way.  Boulders or other hard obstacles can also block shots, or be shot over if you're next to them.",
       "Many types of furniture have a chance to intercept bullets, reducing some of the damage taken.  The bigger and harder the obstacle, the better.",
-      "If you prefer a more subtle approach to breaking and entering, crouching will make you automatically prioritize lockpicking over prying tools."
+      "If you prefer a more subtle approach to breaking and entering, crouching will make you automatically prioritize lockpicking over prying tools.",
+      "Crouching slows you down, but allows you to hide behind obstacles and makes you a smaller target when bullets start flying.",
+      "Make every shot count.  Take time to steady your aim, or crouch for more accurate fire."
     ]
   }
 ]

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1143,7 +1143,7 @@ void avatar::set_movement_mode( character_movemode new_mode )
                     recoil = MAX_RECOIL;
                     add_msg( _( "You stand up." ) );
                 } else {
-                add_msg( _( "You start walking." ) );
+                    add_msg( _( "You start walking." ) );
                 }
             }
             break;
@@ -1160,14 +1160,14 @@ void avatar::set_movement_mode( character_movemode new_mode )
                         add_msg( _( "You spur your steed into a gallop." ) );
                     }
                 } else {
-                // Spend moves to stand up if crouched, otherwise just stop running.
-                if( move_mode == CMM_CROUCH ) {
-                    mod_moves( -100 );
-                    recoil = MAX_RECOIL;
-                    add_msg( _( "You stand up and start running." ) );
-                } else {
-                add_msg( _( "You start running." ) );
-                }
+                    // Spend moves to stand up if crouched, otherwise just stop running.
+                    if( move_mode == CMM_CROUCH ) {
+                        mod_moves( -100 );
+                        recoil = MAX_RECOIL;
+                        add_msg( _( "You stand up and start running." ) );
+                    } else {
+                        add_msg( _( "You start running." ) );
+                    }
                 }
             } else {
                 if( is_mounted() ) {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1137,7 +1137,14 @@ void avatar::set_movement_mode( character_movemode new_mode )
                     add_msg( _( "You nudge your steed into a steady trot." ) );
                 }
             } else {
+                // Spend moves to stand up if crouched, otherwise just stop running.
+                if( move_mode == CMM_CROUCH ) {
+                    mod_moves( -100 );
+                    recoil = MAX_RECOIL;
+                    add_msg( _( "You stand up." ) );
+                } else {
                 add_msg( _( "You start walking." ) );
+                }
             }
             break;
         }
@@ -1153,7 +1160,14 @@ void avatar::set_movement_mode( character_movemode new_mode )
                         add_msg( _( "You spur your steed into a gallop." ) );
                     }
                 } else {
-                    add_msg( _( "You start running." ) );
+                // Spend moves to stand up if crouched, otherwise just stop running.
+                if( move_mode == CMM_CROUCH ) {
+                    mod_moves( -100 );
+                    recoil = MAX_RECOIL;
+                    add_msg( _( "You stand up and start running." ) );
+                } else {
+                add_msg( _( "You start running." ) );
+                }
                 }
             } else {
                 if( is_mounted() ) {
@@ -1176,6 +1190,11 @@ void avatar::set_movement_mode( character_movemode new_mode )
                     add_msg( _( "You slow your steed to a walk." ) );
                 }
             } else {
+                // Don't spend moves if we were already crouching.
+                if( move_mode != CMM_CROUCH ) {
+                    recoil = MAX_RECOIL;
+                    mod_moves( -100 );
+                }
                 add_msg( _( "You start crouching." ) );
             }
             break;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -556,11 +556,11 @@ double Creature::ranged_target_size() const
         return 0.0;
     }
     bool is_crouched = false;
-            if( Character *ch = const_cast<Creature &>( *this ).as_character() ) {
-                if( ch->movement_mode_is( CMM_CROUCH ) ) {
-                    is_crouched = true;
-                }
-            }
+    if( Character *ch = const_cast<Creature &>( *this ).as_character() ) {
+        if( ch->movement_mode_is( CMM_CROUCH ) ) {
+            is_crouched = true;
+        }
+    }
     if( has_flag( MF_HARDTOSHOOT ) || is_crouched ) {
         switch( get_size() ) {
             case creature_size::tiny:

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -555,9 +555,17 @@ double Creature::ranged_target_size() const
     if( const_cast<Creature &>( *this ).uncanny_dodge() ) {
         return 0.0;
     }
-    if( has_flag( MF_HARDTOSHOOT ) ) {
+    bool is_crouched = false;
+            if( Character *ch = const_cast<Creature &>( *this ).as_character() ) {
+                if( ch->movement_mode_is( CMM_CROUCH ) ) {
+                    is_crouched = true;
+                }
+            }
+    if( has_flag( MF_HARDTOSHOOT ) || is_crouched ) {
         switch( get_size() ) {
             case creature_size::tiny:
+                // We can't be smaller than tiny, but we can make the hit rate lower.
+                return 0.05;
             case creature_size::small:
                 return occupied_tile_fraction( creature_size::tiny );
             case creature_size::medium:
@@ -2102,6 +2110,10 @@ dispersion_sources ranged::get_weapon_dispersion( const Character &who, const it
     dispersion.add_range( dispersion_from_skill( avgSkill, weapon_dispersion ) );
 
     if( who.has_bionic( bio_targeting ) ) {
+        dispersion.add_multiplier( 0.75 );
+    }
+    // If we're crouched, it's easier to steady our aim.
+    if( who.movement_mode_is( CMM_CROUCH ) ) {
         dispersion.add_multiplier( 0.75 );
     }
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This adds some utility to crouching in a firefight, in exchange for making it cost moves to switch stances.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In avatar.cpp, `avatar::set_movement_mode` now has it so that switching back and forth from crouch mode takes a turn and resets any aim you've accumulated. It also prints a different message for flavor if you switch from crouching to walking or running. Set it so it doesn't cost any moves or mess with your aim bar if you for whatever reason (the reason is usually the player hit the wrong key) select the same stance you were already in.
2. In ranged.cpp, set `Creature::ranged_target_size` so that crouching triggers the same bonus that `HARDTOSHOOT` monsters get, with a lil logic to make sure it only tries to check your stance if it's actually a character doing it (as checking a monster's stance would segfault). In addition, tiny `HARDTOSHOOT` monsters or tiny characters who're crouching now actually return a smaller value instead of making them no easier or harder to hit than before.
3. Also in ranged.cpp, `ranged::get_weapon_dispersion` now adds a bonus to dispersion if you're crouched, a 0.75x multiplier like what targeting module grants.
4. Added mention of the effects of crouching, plus a general note that aiming is good, to mauin menu tips.

## Describe alternatives you've considered

I was initially tempted to make crouching affect aim speed instead of dispersion, either works I guess.

Also, NPCs crouching when under fire when.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Temporarily added a message that prints to tell you what size you're considered to be for testing purposes.
2. Compiled and load-tested.
3. Let myself get shot at with a turret, test message prints the medium target size when standing, small when I crouch.
4. Confirmed that crouching and uncrouching costs time, but hitting the same move mode twice in a row doesn't.
5. Took aim to fire back at the turret, and confirm that it doesn't try to get the turret's stance which would otherwise cause a crash.
6. Checked the aim menu, hit chances at max aim bar were higher when crouched.
7. Switched stances after maxing out aim bar, aim bar reset as expected.
8. Used the test messages one last time to confirm that being attacked by a zombie in melee wasn't calling the function, to confirm that crouching won't give you a free buff when in melee.

Test messages from earlier:
<img width="603" height="202" alt="image" src="https://github.com/user-attachments/assets/274e6d9c-1af0-45f6-a1c8-c6191bd37c85" />

Max aim bar, standing:
<img width="444" height="512" alt="image" src="https://github.com/user-attachments/assets/fadbfd4a-4971-41a9-b9a1-2ca4935225e6" />

Max aim bar, crouched:
<img width="436" height="512" alt="image" src="https://github.com/user-attachments/assets/b620127e-53cb-4769-92db-f196db8fac0a" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="384" height="335" alt="384px-DeusEx-PrereleasePoster-JC_Denton" src="https://github.com/user-attachments/assets/c50b595e-00fd-456c-b80b-d823f27982dc" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
