### PR TITLE
feat(balance): add `HIDE_PLACE` to tall grass and pond weed, fix hide message not printing when swimming

### DIFF
--- a/data/json/furniture_and_terrain/furniture-flora.json
+++ b/data/json/furniture_and_terrain/furniture-flora.json
@@ -391,7 +391,7 @@
     "move_cost_mod": 4,
     "coverage": 40,
     "required_str": -1,
-    "flags": [ "CONTAINER" ],
+    "flags": [ "CONTAINER", "HIDE_PLACE" ],
     "bash": {
       "str_min": 4,
       "str_max": 30,

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -2270,7 +2270,7 @@
     "color": "green",
     "move_cost": 5,
     "coverage": 50,
-    "flags": [ "TRANSPARENT", "PLOWABLE", "VEH_TREAT_AS_BASH_BELOW" ],
+    "flags": [ "TRANSPARENT", "PLOWABLE", "VEH_TREAT_AS_BASH_BELOW", "HIDE_PLACE" ],
     "digging_results": { "digging_min": 1, "result_ter": "t_pit_shallow", "num_minutes": 60 },
     "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -600,6 +600,9 @@ void avatar_action::swim( map &m, avatar &you, const tripoint &p )
             return;
         }
     }
+    if( m.has_flag_ter_or_furn( TFLAG_HIDE_PLACE, p ) ) {
+        add_msg( m_good, _( "You are hiding in the %s." ), m.name( p ) );
+    }
     you.setpos( p );
     g->update_map( you );
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This makes it so players (or monsters, which should be Fun) can hide in tall grass and pond weed, the former being described as nearly head height and the latter outright tall enough to block vision entirely.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

C++ changes:
1. In avatar_action.cpp, `avatar_action::swim` now prints the message for hiding in relevant terrain just like walking does.

JSON changes:
1. Gave the `HIDE_PLACE` flag to tall grass and pond weed.

## Describe alternatives you've considered

1. Making tall grass opaque like pond weed is would be funny but eh.
2. Demanding we make a LUA mod that spawns pokemon when you enter tall grass.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested.
3. Confirmed that when I swim into pondweed while in a lake bed it prints the message now.
4. Spawned a zombie swimmer, confirmed it can't see me if I'm in pond weed, and likewise if I swap places with it I lose sight of it.

<img width="896" height="482" alt="image" src="https://github.com/user-attachments/assets/09a53510-8417-4354-9b4d-5873047a3440" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
