### PR TITLE
feat(balance): actually make wood axes better than copper and other inferior axes, increase chainsaw treecutting quality to make room

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -1557,7 +1557,7 @@
     "max_charges": 800,
     "charges_per_use": 75,
     "techniques": [ "WBLOCK_1", "SPIN", "SWEEP" ],
-    "qualities": [ [ "AXE", 3 ] ],
+    "qualities": [ [ "AXE", 4 ] ],
     "use_action": {
       "type": "transform",
       "active": true,
@@ -1605,7 +1605,7 @@
     "ammo": "battery",
     "charges_per_use": 375,
     "techniques": [ "WBLOCK_1", "SPIN", "SWEEP" ],
-    "qualities": [ [ "AXE", 3 ] ],
+    "qualities": [ [ "AXE", 4 ] ],
     "use_action": {
       "type": "transform",
       "active": true,
@@ -1762,7 +1762,7 @@
     "ammo": "gasoline",
     "charges_per_use": 75,
     "max_charges": 450,
-    "qualities": [ [ "AXE", 3 ] ],
+    "qualities": [ [ "AXE", 4 ] ],
     "use_action": {
       "type": "transform",
       "active": true,
@@ -1809,7 +1809,7 @@
     "color": "light_gray",
     "ammo": "battery",
     "charges_per_use": 375,
-    "qualities": [ [ "AXE", 3 ] ],
+    "qualities": [ [ "AXE", 4 ] ],
     "use_action": {
       "type": "transform",
       "active": true,

--- a/data/json/items/tool/masonry.json
+++ b/data/json/items/tool/masonry.json
@@ -19,7 +19,7 @@
     "charges_per_use": 75,
     "max_charges": 450,
     "techniques": [ "SWEEP" ],
-    "qualities": [ [ "AXE", 3 ] ],
+    "qualities": [ [ "AXE", 4 ] ],
     "use_action": {
       "type": "transform",
       "active": true,

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -16,7 +16,7 @@
     "material": [ "wood", "steel" ],
     "symbol": "/",
     "color": "light_gray",
-    "qualities": [ [ "AXE", 2 ], [ "BUTCHER", -36 ] ],
+    "qualities": [ [ "AXE", 3 ], [ "BUTCHER", -36 ] ],
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
     "flags": [ "NONCONDUCTIVE", "SHEATH_AXE" ]
   },
@@ -51,7 +51,7 @@
     "charges_per_use": 50,
     "max_charges": 450,
     "techniques": [ "SWEEP" ],
-    "qualities": [ [ "AXE", 4 ] ],
+    "qualities": [ [ "AXE", 5 ] ],
     "use_action": {
       "type": "transform",
       "active": true,
@@ -186,7 +186,7 @@
     "ammo": "battery",
     "charges_per_use": 125,
     "techniques": [ "SWEEP" ],
-    "qualities": [ [ "AXE", 4 ] ],
+    "qualities": [ [ "AXE", 5 ] ],
     "use_action": {
       "type": "transform",
       "active": true,

--- a/data/mods/MagicalNights/items/class_items.json
+++ b/data/mods/MagicalNights/items/class_items.json
@@ -194,7 +194,7 @@
     "symbol": "/",
     "color": "brown",
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
-    "qualities": [ [ "AXE", 1 ], [ "BUTCHER", -20 ] ],
+    "qualities": [ [ "AXE", 2 ], [ "BUTCHER", -20 ] ],
     "use_action": "WEATHER_TOOL",
     "flags": [ "DURABLE_MELEE", "BELT_CLIP", "TRADER_AVOID", "MAGIC_FOCUS", "HYGROMETER", "BAROMETER" ]
   },


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This makes it so that the wood axe is actually better at woodcutting than copper axes, battle axes, and the like, while making chainsaws a lil bit more worth using as a consequence.

Plus, https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4628 bumped wood saws up in quality under the mistaken assumption that a dedicated woodcutting axe would still be faster to cut trees than a wood saw. Turns out wood axes have been level 2 for...uh...fucked if I know how long, and I never noticed.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Increased woodcutting quality of wood axe from 2 to 3, so it's now actually above hatchets, battelaxes, copper axes, fire axes, etc.
3. In turn, bumped the quality of combat chainsaws and chainsaw lajatangs up from 3 to 4.
4. Bumped regular chainsaws up from 4 woodcutting to 5.
5. Misc: Fixed stormshaper axe in Magical Nights saying it's comparable to copper axe but only having axe quality of 1.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
