### PR TITLE
fix: prevent infinite speech loop via requesting equipment

### DIFF
--- a/data/json/npcs/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/TALK_COMMON_OTHER.json
@@ -286,7 +286,7 @@
       {
         "text": "These aren't enough to finish the job, you want me to succeed, don't you…",
         "switch": true,
-        "condition": { "npc_has_effect": "asked_for_item", "or": [ "has_assigned_mission", "has_many_assigned_missions" ] },
+        "condition": { "and": [ "asked_for_item", {"or": ["has_assigned_mission", "has_many_assigned_missions"] } ] },
         "trial": { "type": "PERSUADE", "difficulty": 0, "mod": [ [ "TRUST", 1 ], [ "VALUE", 1 ] ] },
         "success": { "topic": "TALK_GIVE_EQUIPMENT", "effect": "give_equipment", "opinion": { "value": -1 } },
         "failure": { "topic": "TALK_DENY_EQUIPMENT", "opinion": { "value": -1 } }

--- a/data/json/npcs/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/TALK_COMMON_OTHER.json
@@ -286,7 +286,7 @@
       {
         "text": "These aren't enough to finish the job, you want me to succeed, don't you…",
         "switch": true,
-        "condition": { "and": [ "asked_for_item", {"or": ["has_assigned_mission", "has_many_assigned_missions"] } ] },
+        "condition": { "and": [ "asked_for_item", { "or": [ "has_assigned_mission", "has_many_assigned_missions" ] } ] },
         "trial": { "type": "PERSUADE", "difficulty": 0, "mod": [ [ "TRUST", 1 ], [ "VALUE", 1 ] ] },
         "success": { "topic": "TALK_GIVE_EQUIPMENT", "effect": "give_equipment", "opinion": { "value": -1 } },
         "failure": { "topic": "TALK_DENY_EQUIPMENT", "opinion": { "value": -1 } }

--- a/data/json/npcs/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/TALK_COMMON_OTHER.json
@@ -435,9 +435,8 @@
     "type": "talk_topic",
     "dynamic_line": "<no>.",
     "responses": [
-      { "text": "Okay, okay, sorry.", "topic": "TALK_NONE" },
-      { "text": "Seriously, give me more stuff!", "topic": "TALK_SHARE_EQUIPMENT" },
-      { "text": "Okay, fine, bye.", "topic": "TALK_DONE" }
+      { "text": "Okay, okay, sorry.", "topic": "TALK_NONE", "effect": "deny_equipment" },
+      { "text": "Okay, fine, bye.", "topic": "TALK_DONE", "effect": "deny_equipment" }
     ]
   },
   {

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -692,7 +692,7 @@ void talk_function::deny_lead( npc &p )
 
 void talk_function::deny_equipment( npc &p )
 {
-    p.add_effect( effect_asked_for_item, 1_hours );
+    p.add_effect( effect_asked_for_item, 6_hours );
 }
 
 void talk_function::deny_train( npc &p )


### PR DESCRIPTION
## Purpose of change (The Why)

A player can continuously request an NPC for an item, which is a super grindy but stupid way to level up a skill.
This happens because the effect "asked_for_item" is never actually applied.

## Describe the solution (The How)

Properly add the effect and remove the chat option that disrespects consent and loops.

## Describe alternatives you've considered

## Testing

Tried pestering the starter npc with the lowest chance of success, then looked at it's status effects to confirm it had the proper effect and tried to ask for more stuff, which it denied.

## Additional context

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/6694

This still lets you request several items IF you succeeded, because it lowers that NPC's opinion of you.
Might be worth eventually having a limit on that too.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
