### PR TITLE
fix: NPC generating items are no longer reusable

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7924,7 +7924,8 @@ bool Character::consume_charges( item &used, int qty )
     }
 
     //Destroy items with specific flag
-    if( used.has_flag( flag_DESTROY_ON_DECHARGE ) || used.get_use( "place_monster" ) != nullptr ) {
+    if( used.has_flag( flag_DESTROY_ON_DECHARGE ) || used.get_use( "place_monster" ) != nullptr ||
+        used.get_use( "place_npc" ) != nullptr ) {
         used.detach();
         return true;
     }


### PR DESCRIPTION
fixes #6809

## Purpose of change (The Why)
It's should not be possible to mass produce NPCs

## Describe the solution (The How)
Like the "place_monster" action, "place_npc" now self combusts upon use.

## Describe alternatives you've considered
Fix the uses of place_npc to use DESTROY_ON_DISCHARGE, an unintuitive requirement
- Mainly to ease maintaining the Kenan modpack, if they mean for multi use hologram generators

## Testing
Spawn into a game with aftershock, debug in Frankenstein, place him down. The inactive Frankenstein disappears, a Frankenstein appears.

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior. 
  - It modifies the current seemingly bugged behavior of place_npc
