### PR TITLE
fix: NPCs can now use bionics which cancel their mutations

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2449,7 +2449,7 @@ bool Character::can_install_bionics( const itype &type, Character &installer, bo
     }
 
     if( !conflicting_muts.empty() &&
-        !query_yn(
+        !g->u.query_yn(
             _( "Installing this bionic will remove the conflicting traits: %s.  Continue anyway?" ),
             enumerate_as_string( conflicting_muts ) ) ) {
         return false;


### PR DESCRIPTION
fixes #6183 

## Purpose of change (The Why)
I hate the asthmatic mutation, my NPCs must have it purged

## Describe the solution (The How)
Give the player, not the NPC the Y/N checkbox

## Describe alternatives you've considered
Give up.
Make it clearer what g->u means.
- Though it is used below for the other "There are Risks!" checkbox

## Testing
Installed Air Purification System onto my asthmatic NPC

## Additional context
Can you tell I enjoy playing with NPCs yet? Sorry that I'm energetic today.

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
