### PR TITLE
fix: Fix cones having weird blindspots at certain angles and rotations

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -206,7 +206,7 @@ static std::set<tripoint> spell_effect_cone_range_override( const tripoint &sour
     const units::angle start_angle = initial_angle - half_width;
     const units::angle end_angle = initial_angle + half_width;
     std::set<tripoint> end_points;
-    for( units::angle angle = start_angle; angle <= end_angle; angle += 1_degrees ) {
+    for( units::angle angle = start_angle; angle <= end_angle; angle += 0.5_degrees ) {
         tripoint potential;
         calc_ray_end( angle, range, source, potential );
         end_points.emplace( potential );


### PR DESCRIPTION
## Purpose of change (The Why)

Cones currently have blind spots of random tiles that don't get hit by them for some reason

## Describe the solution (The How)

Reduce the increment of drawing the rays to construct the cone to half a degree instead of a full degree (meaning we draw twice as many rays to construct the cone)

## Describe alternatives you've considered

- Figure out how to make a cone without doing all this silly ray stuff

## Testing

Fixed a smol one in my own testing, but RoyalFox likely has better test candidates
Before:
<img width="309" height="533" alt="image" src="https://github.com/user-attachments/assets/773ce328-dbfb-4529-bb9b-ab33ff8796e0" />
After:
<img width="289" height="517" alt="image" src="https://github.com/user-attachments/assets/c70ebfe7-edb3-49fa-8ebd-3e8d9dd4a33c" />


## Additional context

We don't draw that many cones, so I could see going to even more fine-grained angles if this doesn't quite fix the issue entirely

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
