### PR TITLE
feat: Add debug teleport to overmap special

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -450,7 +450,6 @@ void teleport_overmap( bool specific_coordinates )
 }
 
 static void teleport_to_overmap_special() {
-    // Vector of name, id so that we can sort by name
     std::vector<const overmap_special *> vec_os;
     std::vector<std::pair<std::string, vproto_id>> area_strings;
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Could not see any quick and easy way to teleport to a specific overmap special for debugging.

## Describe the solution (The How)

This shows a list of overmap specials, then reuses code related to missions to find and create the special if necessary.
The list of specials can be filtered as usual
<img width="544" height="258" alt="pr_1" src="https://github.com/user-attachments/assets/53eb4b07-aaa2-4fc4-af2a-fa3be969b8fa" />


## Describe alternatives you've considered

Nothing

## Testing

Used an existing world, used the debug to teleport to hub, then teleported to the evac center.
Created a new world and tried again.
<img width="343" height="458" alt="pr_2" src="https://github.com/user-attachments/assets/f9c0c309-17d8-4d0d-800b-fade1417c149" />
<img width="349" height="458" alt="pr_3" src="https://github.com/user-attachments/assets/473ccec1-89c6-4ed2-ab50-944af6475bbf" />


## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
