### PR TITLE
fix: stop recursively using remove_worn_items_with when removing gear

### DIFF
--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -192,7 +192,7 @@ item_location_type wield_item_location::where( ) const
 detached_ptr<item> worn_item_location::detach( item *it )
 {
     detached_ptr<item> res;
-    res=holder->worn.remove(it);
+    res = holder->worn.remove( it );
     if( !res ) {
         debugmsg( "Failed to find worn item in detach" );
     }

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -192,14 +192,7 @@ item_location_type wield_item_location::where( ) const
 detached_ptr<item> worn_item_location::detach( item *it )
 {
     detached_ptr<item> res;
-    holder->remove_worn_items_with( [&it, &res]( detached_ptr<item> &&ch ) {
-        if( &*ch == it ) {
-            res = std::move( ch );
-            return detached_ptr<item>();
-        } else {
-            return std::move( ch );
-        }
-    } );
+    res=holder->worn.remove(it);
     if( !res ) {
         debugmsg( "Failed to find worn item in detach" );
     }


### PR DESCRIPTION
## Purpose of change (The Why)

Fixes #6433 #6584 No more crashes if you lose clothing from a mutation. 

## Describe the solution (The How)

Removes the items directly on detach rather than recurring into remove_worn_items_with. 

## Describe alternatives you've considered

I need to look more into some of the safety stuff around this. It's meant to give red text on bad recursion like this, but it went wrong here because it never actually got to removing an item and triggering that. 

## Testing

Giving myself freakishly huge doesn't crash anymore. 