### PR TITLE
feat: NPCs can use CBMs using Solar or Wind Power

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1283,7 +1283,7 @@
     "fuel_options": [ "sunlight" ],
     "fuel_efficiency": 1,
     "time": 1,
-    "flags": [ "BIONIC_POWER_SOURCE", "BIONIC_TOGGLED" ]
+    "flags": [ "BIONIC_POWER_SOURCE", "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ]
   },
   {
     "id": "afs_bio_missiles",

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -1309,7 +1309,7 @@
   },
   {
     "id": "bn_bio_solar",
-    "copy-from": "bionic_general",
+    "copy-from": "bionic_general_npc_usable",
     "type": "BIONIC_ITEM",
     "name": { "str": "Solar Panels CBM" },
     "description": "Installed on your back is a set of retractable solar panels.  When in direct sunlight, they will automatically deploy and slowly recharge your power level.",

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -123,6 +123,9 @@ static const itype_id itype_smoxygen_tank( "smoxygen_tank" );
 static const itype_id itype_thorazine( "thorazine" );
 static const itype_id itype_oxygen_tank( "oxygen_tank" );
 
+static const itype_id fuel_wind( "wind" );
+static const itype_id fuel_sunlight( "sunlight " );
+
 static constexpr float NPC_DANGER_VERY_LOW = 5.0f;
 static constexpr float NPC_DANGER_MAX = 150.0f;
 static constexpr float MAX_FLOAT = 5000000000.0f;
@@ -1744,11 +1747,17 @@ bool npc::recharge_cbm()
                     fuel_op.end() ||
                     std::find( fuel_op.begin(), fuel_op.end(), itype_denat_alcohol ) !=
                     fuel_op.end();
+                const bool need_environment =
+                    std::find( fuel_op.begin(), fuel_op.end(), fuel_sunlight ) != fuel_op.end() ||
+                    std::find( fuel_op.begin(), fuel_op.end(), fuel_wind ) != fuel_op.end();
 
                 if( std::find( fuel_op.begin(), fuel_op.end(), itype_battery ) != fuel_op.end() ) {
                     complain_about( "need_batteries", 3_hours, "<need_batteries>", false );
                 } else if( need_alcohol ) {
                     complain_about( "need_booze", 3_hours, "<need_booze>", false );
+                } else if( need_environment ) {
+                    // No Need for NPCs to complain about the weather and time of day...
+                    continue;
                 } else {
                     complain_about( "need_fuel", 3_hours, "<need_fuel>", false );
                 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -124,7 +124,7 @@ static const itype_id itype_thorazine( "thorazine" );
 static const itype_id itype_oxygen_tank( "oxygen_tank" );
 
 static const itype_id fuel_wind( "wind" );
-static const itype_id fuel_sunlight( "sunlight " );
+static const itype_id fuel_sunlight( "sunlight" );
 
 static constexpr float NPC_DANGER_VERY_LOW = 5.0f;
 static constexpr float NPC_DANGER_MAX = 150.0f;


### PR DESCRIPTION
## Purpose of change (The Why)
Solar Panels are very good CBMs for powering things during the day.
NPCs should be able to use it
Additionally NPCs should not complain about lacking sunlight or wind. That is just odd.

## Describe the solution (The How)
Add the BIONIC_NPC_USABLE flags to the bionic items
Where NPCs complain about lacking fuel, skip if the fuel is sunlight or wind.

## Describe alternatives you've considered
Lament that I can't not use the Metabolic CBM... Feels cheaty with unlimited food NPCs.

## Testing
Spawn NPC, give it solar panel CBM, you can install it.
During the night, they don't complain about lacking sunlight

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

