### PR TITLE
docs: fix documentation around astyle

### DIFF
--- a/docs/en/dev/explanation/code_style.md
+++ b/docs/en/dev/explanation/code_style.md
@@ -3,13 +3,12 @@
 All of the C++ code in the project is styled, you should run any changes you make through astyle
 before pushing a pull request.
 
-We are using astyle version 3.0.1. Version 3.1 should also work, though there are a few cases where
-they disagree and require annotation.
+We are using astyle version 3.1. Version 3.0.1 will disagree in only a few places, while Version 3.6.6 will disagree in nearly every file.
 
 Blocks of code can be passed through astyle to ensure that their formatting is correct:
 
 ```sh
-astyle --style=1tbs --attach-inlines --indent=spaces=4 --align-pointer=name --max-code-length=100 --break-after-logical --indent-classes --indent-preprocessor --indent-switches --indent-col1-comments --min-conditional-indent=0 --pad-oper --unpad-paren --pad-paren-in --add-brackets --convert-tabs
+astyle --style=1tbs --attach-inlines --indent=spaces=4 --align-pointer=name --max-code-length=100 --break-after-logical --indent-classes --indent-switches --indent-preproc-define --indent-col1-comments --min-conditional-indent=0 --pad-oper --add-braces --convet-tabs --unpad-paren --pad-paren-in --keep-one-line-blocks
 ```
 
 These options are mirrored in `.astylerc`, `doc/CODE_STYLE.txt` and
@@ -18,7 +17,7 @@ These options are mirrored in `.astylerc`, `doc/CODE_STYLE.txt` and
 For example, from `vi`, set marks a and b around the block, then:
 
 ```sh
-:'a,'b ! astyle  --style=1tbs --attach-inlines --indent=spaces=4 --align-pointer=name --max-code-length=100 --break-after-logical --indent-classes --indent-preprocessor --indent-switches --indent-col1-comments --min-conditional-indent=0 --pad-oper --unpad-paren --pad-paren-in --add-brackets --convert-tabs
+:'a,'b ! astyle --style=1tbs --attach-inlines --indent=spaces=4 --align-pointer=name --max-code-length=100 --break-after-logical --indent-classes --indent-switches --indent-preproc-define --indent-col1-comments --min-conditional-indent=0 --pad-oper --add-braces --convet-tabs --unpad-paren --pad-paren-in --keep-one-line-blocks
 ```
 
 See [DEVELOPER_TOOLING.md](../reference/tooling) for other environments.


### PR DESCRIPTION
## Purpose of change (The Why)
Chaosvolt will remember me accedentially changing nearly every file, that was because I was using astyle 3.6.6
Then I installed 3.0.1, which had only a few issues.
When looking into the github action of the fix-bot, I found it installed astyle from Debian repos each time it ran.
That astyle version is 3.1 see [debian docs](https://manpages.debian.org/trixie/astyle/astyle.1.en.html)

## Solution to Issue
So the docs needed to be updated to the new versioning, along with adding a warning regarding much newer versions.
Also the Doc commands and .astylerc do not match, make the doc commands match .astylerc as that is used by the autofix bot.
Also orders the Documentation commands in the same order as .astylerc for clarity.

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.