### PR TITLE
fix(mods/teleportation_tech): make teleport furnitures deploy/collectable

### DIFF
--- a/data/mods/teleportation_mod/item.json
+++ b/data/mods/teleportation_mod/item.json
@@ -50,7 +50,8 @@
     "to_hit": -4,
     "bashing": 1,
     "use_action": "teleporter_anchor_use",
-    "looks_like": "telepad"
+    "looks_like": "telepad",
+    "flags": [ "DESTROY_ON_DECHARGE" ]
   },
   {
     "id": "teleporter_station_undeployed",
@@ -68,7 +69,8 @@
     "to_hit": -4,
     "bashing": 1,
     "use_action": "teleporter_station_use",
-    "looks_like": "f_MRI"
+    "looks_like": "f_MRI",
+    "flags": [ "DESTROY_ON_DECHARGE" ]
   },
   {
     "id": "schematics_teleportation",

--- a/data/mods/teleportation_mod/main.lua
+++ b/data/mods/teleportation_mod/main.lua
@@ -547,7 +547,7 @@ mod.scan_omt_remove_furn = function(abs_omt, ftype)
     --print(furniture_name)
   elseif ftype == "anchor" then
     furniture_name = tostring(FurnId.new("teleporter_anchor_deployed"):int_id())
-    spawn_item = "teleporter_station_undeployed"
+    spawn_item = "teleporter_anchor_undeployed"
     --print(furniture_name)
   end
   local x, y = 0, 0
@@ -568,13 +568,7 @@ mod.scan_omt_remove_furn = function(abs_omt, ftype)
       --gapi.get_map():set_furn_at( xyz, FurnId.new("f_fridge"):int_id() )
       if furn_at_tile == furniture_name then
         gapi.get_map():set_furn_at(xyz, FurnId.new("f_null"):int_id())
-        gapi.add_msg(
-          locale.gettext(
-            "You should get the"
-              .. tostring(spawn_item)
-              .. "item back at this point, but not yet available in LUA, sorry! Feel free to debug spawn the appropriate item."
-          )
-        )
+        gapi.get_map():create_item_at(xyz, ItypeId.new(spawn_item), 1)
         return 0
       elseif i == const.OMT_MS_SIZE and j == const.OMT_MS_SIZE then
         gapi.add_msg(locale.gettext("Appropriate furniture not found. Something went terribly wrong!"))


### PR DESCRIPTION
## Purpose of change (The Why)
The teleportation mod while functional currently has two issues.
- Teleport anchors and stations are not consumed upon placement
- Teleport anchors and stations are not returned upon deconstruction

## Describe the solution (The How)
Adds the "DESTROY_ON_DECHARGE" flag to the undeployed teleport station and anchor
Upon deconstruction of deployed version, place an undeployed item in it's place.

## Describe alternatives you've considered
None

## Testing
Spawn in a teleporter anchor, place it down, the item disappears.
Use the teleporter remote to deconstruct it, the teleporter anchor item reappears
Repeat for the teleporter station.

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.