### PR TITLE
feat(mods): add lua game_started_hook and gapi.place_monster_around

### DIFF
--- a/lua_annotations.lua
+++ b/lua_annotations.lua
@@ -1720,6 +1720,7 @@ coords = {}
 ---@field get_npc_at fun(arg1: Tripoint, arg2: bool?): Npc
 ---@field look_around fun(): Tripoint?
 ---@field place_monster_at fun(arg1: MtypeId, arg2: Tripoint): Monster
+---@field place_monster_around fun(arg1: MtypeId, arg2: Tripoint, arg3: integer): Monster @Example: gapi.place_monster_around(MtypeId.new("mon_dog_bcollie"), gapi.get_avatar():get_pos_ms(), 5)
 ---@field place_player_overmap_at fun(arg1: Tripoint)
 ---@field play_ambient_variant_sound fun(arg1: string, arg2: string, arg3: integer, arg4: SfxChannel, arg5: integer, arg6: number, arg7: integer)
 ---@field play_variant_sound fun(arg1: string, arg2: string, arg3: integer) | fun(arg1: string, arg2: string, arg3: integer, arg4: Angle, arg5: number, arg6: number)
@@ -1746,6 +1747,7 @@ gdebug = {}
 ---@field on_every_x fun() @Called every in-game period
 ---@field on_game_load fun() @Called right after game has loaded
 ---@field on_game_save fun() @Called when game is about to save
+---@field on_game_started fun() @Called when game is started the first time
 ---@field on_mapgen_postprocess fun(arg1: Map, arg2: Tripoint, arg3: TimePoint) @Called right after mapgen has completed. Map argument is the tinymap that represents 24x24 area (2x2 submaps, or 1x1 omt), tripoint is the absolute omt pos, and time_point is the current time (for time-based effects).
 ---@field on_mon_death fun() @Called when a monster is dead
 hooks = {}

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -376,6 +376,11 @@ void run_on_game_load_hooks( lua_state &state )
     run_hooks( state, "on_game_load" );
 }
 
+void run_on_game_started_hooks( lua_state &state )
+{
+    run_hooks( state, "on_game_started" );
+}
+
 void run_on_mapgen_postprocess_hooks( lua_state &state, map &m, const tripoint &p,
                                       const time_point &when )
 {

--- a/src/catalua.h
+++ b/src/catalua.h
@@ -41,6 +41,7 @@ void run_mod_finalize_script( lua_state &state, const mod_id &mod );
 void run_mod_main_script( lua_state &state, const mod_id &mod );
 void run_on_game_load_hooks( lua_state &state );
 void run_on_game_save_hooks( lua_state &state );
+void run_on_game_started_hooks( lua_state &state );
 void run_on_every_x_hooks( lua_state &state );
 void run_on_mapgen_postprocess_hooks( lua_state &state, map &m, const tripoint &p,
                                       const time_point &when );

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -643,6 +643,8 @@ void cata::detail::reg_hooks_examples( sol::state &lua )
     DOC( "Called right after game has loaded" );
     luna::set_fx( lib, "on_game_load", []() {} );
     DOC( "Called when character stat gets reset" );
+    luna::set_fx( lib, "on_game_started", []() {} );
+    DOC( "Called when the game has first started" );
     luna::set_fx( lib, "on_character_reset_stats", []() {} );
     DOC( "Called when a monster is dead" );
     luna::set_fx( lib, "on_mon_death", []() {} );

--- a/src/catalua_bindings_game.cpp
+++ b/src/catalua_bindings_game.cpp
@@ -66,6 +66,7 @@ void cata::detail::reg_game_api( sol::state &lua )
     luna::set_fx( lib, "get_monster_at",
                   []( const tripoint & p, sol::optional<bool> allow_hallucination ) -> monster * { return g->critter_at<monster>( p, allow_hallucination.value_or( false ) ); } );
     luna::set_fx( lib, "place_monster_at", []( const mtype_id & id, const tripoint & p ) { return g->place_critter_at( id, p ); } );
+    luna::set_fx( lib, "place_monster_around", []( const mtype_id & id, const tripoint & p, const int radius ) { return g->place_critter_around( id, p, radius ); } );
     luna::set_fx( lib, "get_character_at",
                   []( const tripoint & p, sol::optional<bool> allow_hallucination ) -> Character * { return g->critter_at<Character>( p, allow_hallucination.value_or( false ) ); } );
     luna::set_fx( lib, "get_npc_at",

--- a/src/catalua_hooks.cpp
+++ b/src/catalua_hooks.cpp
@@ -9,6 +9,7 @@ constexpr auto hook_names = std::array
 {
     "on_game_load",
     "on_game_save",
+    "on_game_started",
     "on_character_reset_stats",
     "on_mon_death",
     "on_mapgen_postprocess",


### PR DESCRIPTION
## Purpose of change (The Why)

For the hook, imho the lua init context (at the body/root level) should be kept for preparing the lua code only.
Having a proper context such as game started means we can do proper error handling on it but also differentiate errors related to lua initializing  and the actual mod initialization.

For the gapi function, being able to place a monster at a specific location is good when a player chooses the spot, or we have a pre-defined spot we want to use. In other use cases we may want to spawn a monster in the general area instead.

For the game load change, I noticed that placing a monster during the load hook was never able to produce a proper where coordinate in the cpp spawning function, but calling it later DURING gameplay worked.
While testing the game_start hook, I noticed the spawn function would work flawlessly, so I tried to find
what was missing in the load function, it seemed to be those two lines and it seems to fix the issue.

## Describe the solution (The How)

Add a `game_started_hook` and the `gapi.place_monster_around` function.
Invalidate and build the map cache when loading the game.

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

This brings the question of how to handle adding a mod when the game is already started.
This needs to be handled by each mod, as it will vary a lot from use case to use case.
It should be possible to call the on_game_started function from the loading hook in most cases.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
