### PR TITLE
fix: Drugs no longer have double the effect time

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -746,12 +746,10 @@
     "addiction_type": "sleeping pill",
     "flags": [ "UNSAFE_CONSUME" ],
     "phase": "liquid",
-    "//": "should be four hours, but we have a bug right now yay",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You measure out a dose of GHB with the syringe.",
       "tools_needed": { "syringe": 1 },
-      "effects": [ { "id": "took_antinarcoleptic", "duration": "2 h" } ],
+      "effects": [ { "id": "took_antinarcoleptic", "duration": "4 h" } ],
       "moves": 250
     }
   },

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -955,11 +955,6 @@ int consume_drug_iuse::use( player &p, item &it, bool, const tripoint & ) const
         if( eff.permanent ) {
             p.get_effect( eff.id, convert_bp( eff.bp ) ).set_permanent();
         }
-
-        p.add_effect( eff.id, eff.duration, convert_bp( eff.bp ) );
-        if( eff.permanent ) {
-            p.get_effect( eff.id, convert_bp( eff.bp ) ).set_permanent();
-        }
     }
 
     for( const auto &stat_adjustment : stat_adjustments ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Drugs should follow their set JSON time like any other sane effect, like magic (does that even use json?).
@chaosvolt You said "Someone open an issue for it plz", I hope skipping that step is fine.


## Describe the solution (The How)
Removed the duplicated section of code around applying the effect.
If only Github would show one more line so you didn't need to dig through the file to see...

## Describe alternatives you've considered
- Double the effect time of all in game drugs so that I don't destroy anyone's playstyle
- Keep the current double call, but half each applied time, so that you don't need to use double the painkillers at one time
  - It seems to be an issue at least, but either way drugs would be halved in effectiveness.

## Testing
Spawn in a drug and it should have half the length it used to, and is at the JSON length.

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - Specifically Drugs now have half of the effect time due to a mistake in doubling it.