### PR TITLE
feat(balance): reduce number of cannons and powderkegs on pirate ship, fix canoes

### DIFF
--- a/data/json/vehicles/boats.json
+++ b/data/json/vehicles/boats.json
@@ -6,7 +6,7 @@
     "blueprint": [ [ "<OO>" ] ],
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_wood_horizontal", "seat_wood_light", "hand_paddles", "boat_board" ] },
-      { "x": 1, "y": 0, "parts": [ "frame_wood_horizontal", "boat_board", "seat" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_wood_horizontal", "boat_board", "seat_wood_light" ] },
       { "x": 2, "y": 0, "parts": [ "frame_wood_horizontal", "boat_board" ] },
       { "x": -1, "y": 0, "parts": [ "frame_wood_horizontal", "boat_board" ] }
     ]
@@ -426,11 +426,11 @@
     "name": "Pirate Ship",
     "blueprint": [
       [ " ||||||||++|||   " ],
-      [ "||heeh|t____t||  " ],
+      [ "||heeh|_____t||  " ],
       [ "|=_hh_|_______|| " ],
       [ "|=____+__S===_F|>" ],
       [ "|=____|_______|| " ],
-      [ "||##__|t____t||  " ],
+      [ "||##__|_____t||  " ],
       [ " ||||||||++|||   " ]
     ],
     "parts": [
@@ -482,22 +482,7 @@
       { "x": -5, "y": 2, "parts": [ "frame_wood_vertical", "wooden_aisle_vertical", "roof_wood", "boat_board" ] },
       { "x": -4, "y": 2, "parts": [ "frame_wood_vertical", "wooden_aisle_vertical", "roof_wood", "boat_board" ] },
       { "x": -3, "y": 2, "parts": [ "frame_wood_horizontal", "woodboard_horizontal", "boat_board" ] },
-      {
-        "x": -2,
-        "y": 2,
-        "parts": [
-          "frame_wood_vertical",
-          "wood box",
-          "turret_mount_manual_wood",
-          {
-            "ammo_types": [ "cannon_round_ball", "cannon_canister_shot" ],
-            "part": "mounted_3in_ordnance_rifle",
-            "ammo": 50,
-            "ammo_qty": [ 1, 1 ]
-          },
-          "boat_board"
-        ]
-      },
+      { "x": -2, "y": 2, "parts": [ "frame_wood_horizontal", "wooden_aisle_vertical", "boat_board" ] },
       { "x": -1, "y": 2, "parts": [ "frame_wood_vertical", "wooden_aisle_vertical", "boat_board" ] },
       { "x": 0, "y": 2, "parts": [ "frame_wood_vertical", "wooden_aisle_vertical", "boat_board" ] },
       { "x": 1, "y": 2, "parts": [ "frame_wood_vertical", "wooden_aisle_vertical", "boat_board" ] },
@@ -556,22 +541,7 @@
       { "x": -5, "y": -2, "parts": [ "frame_wood_vertical", "veh_table_wood", "roof_wood", "boat_board" ] },
       { "x": -4, "y": -2, "parts": [ "frame_wood_vertical", "seat_wood", "roof_wood", "boat_board" ] },
       { "x": -3, "y": -2, "parts": [ "frame_wood_horizontal", "woodboard_horizontal", "boat_board" ] },
-      {
-        "x": -2,
-        "y": -2,
-        "parts": [
-          "frame_wood_vertical",
-          "wood box",
-          "turret_mount_manual_wood",
-          {
-            "ammo_types": [ "cannon_round_ball", "cannon_canister_shot" ],
-            "part": "mounted_3in_ordnance_rifle",
-            "ammo": 50,
-            "ammo_qty": [ 1, 1 ]
-          },
-          "boat_board"
-        ]
-      },
+      { "x": -2, "y": -2, "parts": [ "frame_wood_horizontal", "wooden_aisle_vertical", "boat_board" ] },
       { "x": -1, "y": -2, "parts": [ "frame_wood_vertical", "wooden_aisle_vertical", "boat_board" ] },
       { "x": 0, "y": -2, "parts": [ "frame_wood_vertical", "wooden_aisle_vertical", "boat_board" ] },
       { "x": 1, "y": -2, "parts": [ "frame_wood_vertical", "wooden_aisle_vertical", "boat_board" ] },
@@ -609,16 +579,12 @@
       { "x": 4, "y": -3, "parts": [ "frame_wood_nw", "woodhalfboard_nw", "plating_wood", "boat_board" ] }
     ],
     "items": [
-      { "x": -2, "y": 2, "chance": 50, "item_groups": [ "supplies_cannonball" ] },
       { "x": 3, "y": 2, "chance": 50, "item_groups": [ "supplies_cannonball" ] },
-      { "x": -2, "y": -2, "chance": 50, "item_groups": [ "supplies_cannonball" ] },
       { "x": 3, "y": -2, "chance": 50, "item_groups": [ "supplies_cannonball" ] },
       { "x": 1, "y": 0, "chance": 100, "item_groups": [ "supplies_ship_rigging" ] },
       { "x": 2, "y": 0, "chance": 100, "item_groups": [ "supplies_ship_rigging" ] },
       { "x": 3, "y": 0, "chance": 100, "item_groups": [ "supplies_ship_rigging" ] },
-      { "x": 1, "y": 0, "chance": 50, "item_groups": [ "supplies_powder_mag" ] },
-      { "x": 2, "y": 0, "chance": 50, "item_groups": [ "supplies_powder_mag" ] },
-      { "x": 3, "y": 0, "chance": 50, "item_groups": [ "supplies_powder_mag" ] },
+      { "x": 3, "y": 0, "chance": 100, "item_groups": [ "supplies_powder_mag" ] },
       { "x": -8, "y": 0, "chance": 100, "item_groups": [ "supplies_naval_cache" ] },
       { "x": -8, "y": 1, "chance": 100, "item_groups": [ "supplies_naval_cache" ] },
       { "x": -8, "y": -1, "chance": 100, "item_groups": [ "supplies_naval_cache" ] },

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -294,7 +294,7 @@ TEST_CASE( "vehicle_drag", "[vehicle] [engine]" )
     test_vehicle_drag( "schoolbus", 0.411188, 3.331642, 1491.510227, 12930, 15101 );
     test_vehicle_drag( "security_van", 0.541800, 7.617575, 6252.103125, 11074, 13079 );
     test_vehicle_drag( "wienermobile", 1.063697, 2.385608, 1957.981250, 11253, 13409 );
-    test_vehicle_drag( "canoe", 0.609525, 7.551118, 2.138157, 337, 707 );
+    test_vehicle_drag( "canoe", 0.609525, 6.970263, 1.973684, 337, 707 );
     test_vehicle_drag( "kayak", 0.609525, 4.036067, 1.523792, 544, 1067 );
     test_vehicle_drag( "kayak_racing", 0.609525, 3.704980, 1.398792, 586, 1133 );
     test_vehicle_drag( "DUKW", 0.776903, 3.8956, 84.26, 9993, 12063 );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This makes a couple tweaks to two of the boats.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Removed two of that cannons on pirate ships, as even when completely empty its minimum weight as spawned was getting kinda close to the edge of what a single large sail could reliably power.
2. Reduced powder keg spawns from 3 calls of `supplies_powder_mag` to just one, in exchange for making it a 100% chance instead of 50%. Basically means each ship goes from spawning 0-6 powderkegs to a more consistent 1-2.
2. Misc: Fixed only half the seats on canoes being replaced with wooden varient.

## Describe alternatives you've considered

Removing the restriction on installing multiple sails on a vehicle so that players can build big-ass galleons loaded with multiple cannons.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Ported file change to playthrough build and load-tested.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
