### PR TITLE
feat: add more tamable animals

### DIFF
--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -705,7 +705,8 @@
     "material": [ "flesh" ],
     "symbol": ";",
     "color": "red",
-    "flags": [ "INEDIBLE" ],
+    "calories": 100,
+    "flags": [ "INEDIBLE", "NUTRIENT_OVERRIDE" ],
     "use_action": [ "PETFOOD" ],
     "petfood": [ "BATFOOD" ]
   },

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -691,6 +691,25 @@
     "petfood": [ "CATFOOD", "DINOFOOD_B" ]
   },
   {
+    "id": "jellied_insects_petfood",
+    "type": "COMESTIBLE",
+    "category": "tools_farming",
+    "comestible_type": "FOOD",
+    "name": { "str_sp": "jellied insects" },
+    "description": "Preserved insect organs, perfect for animals who like extra proteins.",
+    "weight": "60 g",
+    "volume": "50 ml",
+    "price": "20 cent",
+    "price_postapoc": "25 cent",
+    "to_hit": -5,
+    "material": [ "flesh" ],
+    "symbol": ";",
+    "color": "red",
+    "flags": [ "INEDIBLE" ],
+    "use_action": [ "PETFOOD" ],
+    "petfood": [ "BATFOOD" ]
+  },
+  {
     "type": "COMESTIBLE",
     "id": "grass",
     "name": { "str": "grass", "str_pl": "grasses" },

--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -72,7 +72,12 @@
     "death_function": [ "NORMAL" ],
     "reproduction": { "baby_egg": "egg_crow", "baby_count": 3, "baby_timer": 8 },
     "baby_flags": [ "SPRING" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES" ],
+    "petfood": {
+      "food": [ "BIRDFOOD" ],
+      "feed": "The %s seems to like you!",
+      "pet": "The %s flies around you and briefly perches on your arm."
+    }
   },
   {
     "id": "mon_duck",
@@ -101,7 +106,12 @@
     "death_function": [ "NORMAL" ],
     "reproduction": { "baby_egg": "egg_duck", "baby_count": 3, "baby_timer": 5 },
     "baby_flags": [ "SPRING" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES" ],
+    "petfood": {
+      "food": [ "BIRDFOOD" ],
+      "feed": "The %s seems to like you!",
+      "pet": "The %s quacks happily at you as you pat its head."
+    }
   },
   {
     "id": "mon_goose_canadian",
@@ -149,7 +159,12 @@
     "death_function": [ "NORMAL" ],
     "reproduction": { "baby_egg": "egg_turkey", "baby_count": 3, "baby_timer": 12 },
     "baby_flags": [ "SPRING", "SUMMER" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES" ],
+    "petfood": {
+      "food": [ "BIRDFOOD" ],
+      "feed": "The %s seems to like you!",
+      "pet": "The %s clucks happily at you as you pat its head."
+    }
   },
   {
     "id": "mon_pheasant",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -57,7 +57,7 @@
     "description": "One of the Desmodontinae bats, a family of winged blood-eating mammals.  It roosts in caves and other hollows, and uses a form of echolocation to aerially navigate through tricky terrain at rapid speeds.",
     "copy-from": "mon_bat",
     "aggression": 1,
-    "delete": {"petfood":  "food"}
+    "delete": { "petfood": "food" }
   },
   {
     "id": "mon_bat_vampire_mutant",
@@ -106,7 +106,7 @@
       "food": [ "DOGFOOD" ],
       "feed": "The %s seems to like you!",
       "pet": "The %s looks at you with big puppy eyes.",
-      "tamer_traits": [[ "ANIMALEMPATH", "THRESH_URSINE" ]]
+      "tamer_traits": [ [ "ANIMALEMPATH", "THRESH_URSINE" ] ]
     }
   },
   {

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -57,7 +57,7 @@
     "description": "One of the Desmodontinae bats, a family of winged blood-eating mammals.  It roosts in caves and other hollows, and uses a form of echolocation to aerially navigate through tricky terrain at rapid speeds.",
     "copy-from": "mon_bat",
     "aggression": 1,
-    "delete": "petfood"
+    "delete": {"petfood":  "food"}
   },
   {
     "id": "mon_bat_vampire_mutant",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -28,7 +28,12 @@
     "special_attacks": [ { "type": "bite", "cooldown": 15 } ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "GOODHEARING", "WARM", "FLIES", "ANIMAL", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "GOODHEARING", "WARM", "FLIES", "ANIMAL", "PATH_AVOID_DANGER_1" ],
+    "petfood": {
+      "food": [ "BATFOOD" ],
+      "feed": "The %s seems to like you!",
+      "pet": "The %s flies around you, screeching a song of friendship."
+    }
   },
   {
     "id": "mon_bat",
@@ -51,7 +56,8 @@
     "name": { "str": "vampire bat" },
     "description": "One of the Desmodontinae bats, a family of winged blood-eating mammals.  It roosts in caves and other hollows, and uses a form of echolocation to aerially navigate through tricky terrain at rapid speeds.",
     "copy-from": "mon_bat",
-    "aggression": 1
+    "aggression": 1,
+    "delete": "petfood"
   },
   {
     "id": "mon_bat_vampire_mutant",
@@ -95,7 +101,13 @@
     "dodge": 2,
     "harvest": "mammal_fur",
     "special_attacks": [ [ "EAT_FOOD", 60 ] ],
-    "upgrades": { "age_grow": 480, "into": "mon_bear" }
+    "upgrades": { "age_grow": 480, "into": "mon_bear" },
+    "petfood": {
+      "food": [ "DOGFOOD" ],
+      "feed": "The %s seems to like you!",
+      "pet": "The %s looks at you with big puppy eyes.",
+      "tamer_traits": [[ "ANIMALEMPATH", "THRESH_URSINE" ]]
+    }
   },
   {
     "id": "mon_bear",
@@ -233,7 +245,8 @@
     "death_function": [ "NORMAL" ],
     "upgrades": { "age_grow": 38, "into": "mon_boar_wild" },
     "special_attacks": [ [ "EAT_FOOD", 40 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "BLEED" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "BLEED" ],
+    "petfood": { "food": [ "DOGFOOD" ], "feed": "The %s seems to like you!", "pet": "The %s squeals happily at you." }
   },
   {
     "id": "mon_boar_wild",
@@ -272,7 +285,8 @@
     "placate_triggers": [ "MEAT" ],
     "death_function": [ "NORMAL" ],
     "special_attacks": [ [ "EAT_FOOD", 20 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "BLEED" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "BLEED" ],
+    "petfood": { "food": [ "DOGFOOD" ], "feed": "The %s seems to like you!", "pet": "The %s squeals happily at you." }
   },
   {
     "id": "mon_bobcat",
@@ -835,7 +849,12 @@
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "death_function": [ "NORMAL" ],
     "upgrades": { "age_grow": 330, "into": "mon_deer" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ],
+    "petfood": {
+      "food": [ "CATTLEFOOD" ],
+      "feed": "The %s seems to like you!",
+      "pet": "The %s kicks its leg happily as you scratch it."
+    }
   },
   {
     "id": "mon_deer",
@@ -869,7 +888,12 @@
     "//": " 201 days gestation period. The fawn will stay with its mother for approximately one year, suckling for three to four months.",
     "baby_flags": [ "SPRING", "SUMMER" ],
     "special_attacks": [ [ "EAT_CROP", 60 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ],
+    "petfood": {
+      "food": [ "CATTLEFOOD" ],
+      "feed": "The %s seems to like you!",
+      "pet": "The %s kicks its leg happily as you scratch it."
+    }
   },
   {
     "id": "mon_dog",
@@ -2265,7 +2289,8 @@
     "vision_night": 5,
     "anger_triggers": [ "FRIEND_ATTACKED", "HURT" ],
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CLIMBS", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "BLEED" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CLIMBS", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "BLEED" ],
+    "petfood": { "food": [ "CATFOOD", "DOGFOOD" ], "feed": "The %s seems to like you!", "pet": "The %s looks at you lovingly." }
   },
   {
     "id": "mon_rat_king",
@@ -2353,7 +2378,8 @@
     "death_function": [ "NORMAL" ],
     "upgrades": { "age_grow": 240, "into": "mon_sheep" },
     "//": "Puberty reached in 6-9 months.",
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ],
+    "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you! It lets you pat its head and seems friendly." }
   },
   {
     "id": "mon_sheep",

--- a/data/json/recipes/food/other.json
+++ b/data/json/recipes/food/other.json
@@ -279,6 +279,18 @@
     ]
   },
   {
+    "result": "jellied_insects_petfood",
+    "type": "recipe",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_OTHER",
+    "skill_used": "cooking",
+    "difficulty": 1,
+    "skills_required": [ "survival", 1 ],
+    "time": "2 m",
+    "autolearn": true,
+    "components": [ [ [ "edible_tallow_lard", 1, "LIST" ] ], [ [ "mutant_bug_lungs", 1 ], [ "mutant_bug_organs", 1 ] ] ]
+  },
+  {
     "type": "recipe",
     "result": "morel_cooked",
     "category": "CC_FOOD",


### PR DESCRIPTION
## Purpose of change (The Why)

Taming animals is fun, we need to have more fun, so we need more tamable animals!

## Describe the solution (The How)

Added petfood to many animals who are peaceful enough to do so.
Added a new type of petfood for bats, and made them tamable (except vampire bats for now).
Added the possibility to tame a bear cub IF you are post-thresh ursine or have ANIMALEMPATH, like elf-a

## Describe alternatives you've considered

## Testing

Spawned a new empty world, spawned monsters, gave them food.
Mutated to Ursine, spawned a bear cub, gave it food.

## Additional context

<img width="904" height="574" alt="image" src="https://github.com/user-attachments/assets/17c2a407-fc5a-4be5-8744-bc953d649e8c" />


Relates to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7049 , https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7070 , https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6996
## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
