### PR TITLE
fix: Turrets will no longer return fire when using EMP weapons

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -468,9 +468,6 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
             if( is_emp ) {
                 apply_ammo_effects( tp, proj.get_ammo_effects(), origin );
                 explosion_handler::get_explosion_queue().execute();
-                /*if( !g->critter_tracker->find( tp ) ) {
-                    continue;
-                }*/
             }
             critter->deal_projectile_attack( null_source ? nullptr : origin, source_weapon, attack );
             // Critter can still dodge the projectile

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -13,6 +13,7 @@
 #include "calendar.h"
 #include "cata_utility.h" // for normal_cdf
 #include "creature.h"
+#include "creature_tracker.h"
 #include "damage.h"
 #include "debug.h"
 #include "dispersion.h"
@@ -39,6 +40,7 @@ static const ammo_effect_str_id ammo_effect_ACT_ON_RANGED_HIT( "ACT_ON_RANGED_HI
 static const ammo_effect_str_id ammo_effect_BOUNCE( "BOUNCE" );
 static const ammo_effect_str_id ammo_effect_BURST( "BURST" );
 static const ammo_effect_str_id ammo_effect_DRAW_AS_LINE( "DRAW_AS_LINE" );
+static const ammo_effect_str_id ammo_effect_EMP( "EMP" );
 static const ammo_effect_str_id ammo_effect_HEAVY_HIT( "HEAVY_HIT" );
 static const ammo_effect_str_id ammo_effect_JET( "JET" );
 static const ammo_effect_str_id ammo_effect_MUZZLE_SMOKE( "MUZZLE_SMOKE" );
@@ -240,6 +242,9 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
     // Determines whether it can penetrate obstacles
     const bool is_bullet = proj_arg.speed >= 200 &&
                            !proj.has_effect( ammo_effect_NO_PENETRATE_OBSTACLES );
+
+    // EMP Blasts must come BEFORE attacks to avoid return fire, unlike other explosions (I Think at least)
+    const bool is_emp = proj.has_effect( ammo_effect_EMP );
 
     // If we were targetting a tile rather than a monster, don't overshoot
     // Unless the target was a wall, then we are aiming high enough to overshoot
@@ -460,6 +465,13 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
                 continue;
             }
             attack.missed_by = cur_missed_by;
+            if( is_emp ) {
+                apply_ammo_effects( tp, proj.get_ammo_effects(), origin );
+                explosion_handler::get_explosion_queue().execute();
+                if( !g->critter_tracker->find( tp ) ) {
+                    continue;
+                }
+            }
             critter->deal_projectile_attack( null_source ? nullptr : origin, source_weapon, attack );
             // Critter can still dodge the projectile
             // In this case hit_critter won't be set
@@ -510,7 +522,9 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
 
     drop_or_embed_projectile( attack );
 
-    apply_ammo_effects( tp, proj.get_ammo_effects(), origin );
+    if( !is_emp ) {
+        apply_ammo_effects( tp, proj.get_ammo_effects(), origin );
+    }
     const auto &expl = proj.get_custom_explosion();
     if( expl ) {
         explosion_handler::explosion( tp, expl, origin );

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -468,9 +468,9 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
             if( is_emp ) {
                 apply_ammo_effects( tp, proj.get_ammo_effects(), origin );
                 explosion_handler::get_explosion_queue().execute();
-                if( !g->critter_tracker->find( tp ) ) {
+                /*if( !g->critter_tracker->find( tp ) ) {
                     continue;
-                }
+                }*/
             }
             critter->deal_projectile_attack( null_source ? nullptr : origin, source_weapon, attack );
             // Critter can still dodge the projectile

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -14,6 +14,7 @@
 #include "ballistics.h"
 #include "bodypart.h"
 #include "creature.h"
+#include "creature_tracker.h"
 #include "damage.h"
 #include "effect.h"
 #include "game.h"
@@ -159,7 +160,7 @@ void mdefense::return_fire( monster &m, Creature *source, const dealt_projectile
     }
 
     // No return fire from dead monsters.
-    if( m.is_dead_state() ) {
+    if( m.is_dead_state() || !g->critter_tracker->find( m.pos() ) ) {
         return;
     }
 


### PR DESCRIPTION
fixes #6869 
## Purpose of change (The Why)
Turrets should not return fire when attacked by EMP weapons, due to the property of them causing explosions.

## Describe the solution (The How)
Currently the chain goes as such:
- Player attacks with EMP
- EMP bullet attacks light turret
- Turret returns fire
- EMP explosion occurs
- Turret Dies

Changes it so that the chain is:
- Player attacks with EMP
- EMP explosion occurs
- Turret Dies OR EMP bullet attacks light turret
- If bullet attacks and is still alive, turret would return fire

Additionally before return fire, the creature will make sure it is still tracked in "creature_tracker"
- As that is how the EMP explosion "kills" the creature, not by losing health.

## Describe alternatives you've considered
Remove the damage of the EMP projector's bullet, as it is designed for anti-turret alone
Move all explosions to occur before the bullet, so other explosive ammo would not have the same ordering issue.

## Testing
Spawn Light turret, fire with EMP projector, it dies, does not return fire
Spawn Light turret, fire other gun, it return fires

## Additional context
If overpenetration occurs with an EMP weapon, then there may be issues where multiple explosions occur. No base game weapon has this issue though, the PPA-5 does not penetrate after an explosion, and all the EMP projectors have the "NO_PENETRATE_OBSTACLES" flag. So may only be an issue for modded weapons.

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.