### PR TITLE
feat(mods): Custom UPSes can now be implemented + UPS fixes

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1631,6 +1631,11 @@
     "context": [  ]
   },
   {
+    "id": "IS_EFF_UPS",
+    "type": "json_flag",
+    "context": [  ]
+  },
+  {
     "id": "LEAK_DAM",
     "type": "json_flag",
     "context": [  ]

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -16,7 +16,7 @@
     "color": "light_green",
     "ammo": "plutonium",
     "max_charges": 2500,
-    "flags": [ "IS_UPS" ]
+    "flags": [ "IS_UPS", "IS_EFF_UPS" ]
   },
   {
     "id": "camera",

--- a/data/json/items/tool/fire.json
+++ b/data/json/items/tool/fire.json
@@ -29,7 +29,7 @@
         ]
       ]
     ],
-    "flags": [ "FIRESTARTER" ],
+    "flags": [ "FIRESTARTER", "CAN_HAVE_CHARGES" ],
     "category": "tools_cooking"
   },
   {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2070,6 +2070,9 @@ void activity_handlers::start_fire_finish( player_activity *act, player *p )
     }
 
     if( it.type->can_have_charges() ) {
+        if( it.has_flag( flag_USE_UPS ) ) {
+            p->use_charges( itype_UPS, it.type->charges_to_use() );
+        }
         p->consume_charges( it, it.type->charges_to_use() );
     }
     p->practice( skill_survival, act->index, 5 );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -138,6 +138,7 @@ static const itype_id itype_burnt_out_bionic( "burnt_out_bionic" );
 static const itype_id itype_radiocontrol( "radiocontrol" );
 static const itype_id itype_remotevehcontrol( "remotevehcontrol" );
 static const itype_id itype_UPS_off( "UPS_off" );
+static const itype_id itype_UPS( "UPS" );
 static const itype_id itype_water_clean( "water_clean" );
 
 static const fault_id fault_bionic_nonsterile( "fault_bionic_nonsterile" );
@@ -1525,11 +1526,8 @@ itype_id Character::find_remote_fuel( bool look_only )
                     return itm.get_var( "cable" ) == "plugged_in";
                 };
                 if( !look_only ) {
-                    if( has_charges( itype_UPS_off, 1, used_ups ) ) {
-                        set_value( "rem_battery", std::to_string( charges_of( itype_UPS_off,
-                                   units::to_kilojoule( max_power_level ), used_ups ) ) );
-                    } else if( has_charges( itype_adv_UPS_off, 1, used_ups ) ) {
-                        set_value( "rem_battery", std::to_string( charges_of( itype_adv_UPS_off,
+                    if( has_charges( itype_UPS, 1, used_ups ) ) {
+                        set_value( "rem_battery", std::to_string( charges_of( itype_UPS,
                                    units::to_kilojoule( max_power_level ), used_ups ) ) );
                     } else {
                         set_value( "rem_battery", std::to_string( 0 ) );
@@ -1587,8 +1585,8 @@ units::energy Character::consume_remote_fuel( units::energy amount )
                 static const item_filter used_ups = [&]( const item & itm ) {
                     return itm.get_var( "cable" ) == "plugged_in";
                 };
-                if( has_charges( itype_UPS_off, amount_kj, used_ups ) ) {
-                    use_charges( itype_UPS_off, amount_kj, used_ups );
+                if( has_charges( itype_UPS, amount_kj, used_ups ) ) {
+                    use_charges( itype_UPS, amount_kj, used_ups );
                     unconsumed_amount = 0_J;
                 } else if( has_charges( itype_adv_UPS_off, amount_kj, used_ups ) ) {
                     use_charges( itype_adv_UPS_off, roll_remainder( amount_kj * 0.5 ), used_ups );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -132,12 +132,10 @@ static const itype_id fuel_type_muscle( "muscle" );
 static const itype_id fuel_type_sun_light( "sunlight" );
 static const itype_id fuel_type_wind( "wind" );
 
-static const itype_id itype_adv_UPS_off( "adv_UPS_off" );
 static const itype_id itype_anesthetic( "anesthetic" );
 static const itype_id itype_burnt_out_bionic( "burnt_out_bionic" );
 static const itype_id itype_radiocontrol( "radiocontrol" );
 static const itype_id itype_remotevehcontrol( "remotevehcontrol" );
-static const itype_id itype_UPS_off( "UPS_off" );
 static const itype_id itype_UPS( "UPS" );
 static const itype_id itype_water_clean( "water_clean" );
 
@@ -1587,9 +1585,6 @@ units::energy Character::consume_remote_fuel( units::energy amount )
                 };
                 if( has_charges( itype_UPS, amount_kj, used_ups ) ) {
                     use_charges( itype_UPS, amount_kj, used_ups );
-                    unconsumed_amount = 0_J;
-                } else if( has_charges( itype_adv_UPS_off, amount_kj, used_ups ) ) {
-                    use_charges( itype_adv_UPS_off, roll_remainder( amount_kj * 0.5 ), used_ups );
                     unconsumed_amount = 0_J;
                 }
                 break;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -12,6 +12,7 @@
 #include <ostream>
 #include <ranges>
 #include <type_traits>
+#include <vector>
 
 #include "action.h"
 #include "activity_actor_definitions.h"
@@ -36,6 +37,7 @@
 #include "creature.h"
 #include "damage.h"
 #include "debug.h"
+#include "detached_ptr.h"
 #include "disease.h"
 #include "effect.h"
 #include "event.h"
@@ -10365,24 +10367,18 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
             qty -= std::min( qty, bio );
         }
 
-        int adv = charges_of( itype_adv_UPS_off, static_cast<int>( std::ceil( qty * 0.5 ) ) );
-        if( adv > 0 ) {
-            int adv_odd = x_in_y( qty % 2, 2 );
-            // qty % 2 returns 1 if odd and 0 if even, giving a 50% chance of consuming one less charge if odd, 0 otherwise.
-            // (eg: if 5, consumes either 2 or 3)
-            std::vector<detached_ptr<item>> found = use_charges( itype_adv_UPS_off, adv - adv_odd );
-            res.insert( res.end(), std::make_move_iterator( found.begin() ),
-                        std::make_move_iterator( found.end() ) );
-            qty -= std::min( qty, static_cast<int>( adv / 0.5 ) );
-        }
+        remove_items_with( [&, &qty, &res]( detached_ptr<item> &&e ) {
+            if( e->has_flag( flag_IS_UPS ) && e->ammo_remaining() > 0 ) {
+                detached_ptr<item> split = item::spawn( *e );
+                split->ammo_set( e->ammo_current(), e->ammo_remaining() );
+                int used = std::min( qty, e->ammo_remaining() );
+                qty -= used;
+                e->ammo_consume( used, pos() );
+                res.push_back( std::move( split ) );
+            }
+            return qty != 0 ? VisitResponse::NEXT : VisitResponse::ABORT;
+        } );
 
-        int ups = charges_of( itype_UPS_off, qty );
-        if( ups > 0 ) {
-            std::vector<detached_ptr<item>> found = use_charges( itype_UPS_off, ups );
-            res.insert( res.end(), std::make_move_iterator( found.begin() ),
-                        std::make_move_iterator( found.end() ) );
-            qty -= std::min( qty, ups );
-        }
         return res;
 
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10371,9 +10371,20 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
             if( e->has_flag( flag_IS_UPS ) && e->ammo_remaining() > 0 ) {
                 detached_ptr<item> split = item::spawn( *e );
                 split->ammo_set( e->ammo_current(), e->ammo_remaining() );
-                int used = std::min( qty, e->ammo_remaining() );
-                qty -= used;
-                e->ammo_consume( used, pos() );
+                if( e->has_flag( flag_IS_EFF_UPS ) ){
+                    // qty % 2 returns 1, if odd, or 0, if even.
+                    // So if odd 1 / 2 chance to consume 1 less charge
+                    // If even 0 / 2 chance to consume 1 less charge
+                    int rand_round = x_in_y( qty % 2, 2 );
+                    int used = std::min( qty, e->ammo_remaining() * 2);
+                    qty -= used;
+                    e->ammo_consume( std::max((used / 2) - rand_round, 1), pos() );
+                }
+                else{
+                    int used = std::min( qty, e->ammo_remaining() );
+                    qty -= used;
+                    e->ammo_consume( used, pos() );
+                }
                 res.push_back( std::move( split ) );
             }
             return qty != 0 ? VisitResponse::NEXT : VisitResponse::ABORT;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10365,20 +10365,19 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
             qty -= std::min( qty, bio );
         }
 
-        remove_items_with( [&, &qty, &res]( detached_ptr<item> &&e ) {
+        remove_items_with( [ &, &qty, &res]( detached_ptr<item> &&e ) {
             if( e->has_flag( flag_IS_UPS ) && e->ammo_remaining() > 0 ) {
                 detached_ptr<item> split = item::spawn( *e );
                 split->ammo_set( e->ammo_current(), e->ammo_remaining() );
-                if( e->has_flag( flag_IS_EFF_UPS ) ){
+                if( e->has_flag( flag_IS_EFF_UPS ) ) {
                     // qty % 2 returns 1, if odd, or 0, if even.
                     // So if odd 1 / 2 chance to consume 1 less charge
                     // If even 0 / 2 chance to consume 1 less charge
                     int rand_round = x_in_y( qty % 2, 2 );
-                    int used = std::min( qty, e->ammo_remaining() * 2);
+                    int used = std::min( qty, e->ammo_remaining() * 2 );
                     qty -= used;
-                    e->ammo_consume( std::max((used / 2) - rand_round, 1), pos() );
-                }
-                else{
+                    e->ammo_consume( std::max( ( used / 2 ) - rand_round, 1 ), pos() );
+                } else {
                     int used = std::min( qty, e->ammo_remaining() );
                     qty -= used;
                     e->ammo_consume( used, pos() );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -198,7 +198,6 @@ static const efftype_id effect_took_prozac( "took_prozac" );
 static const efftype_id effect_took_xanax( "took_xanax" );
 static const efftype_id effect_webbed( "webbed" );
 
-static const itype_id itype_adv_UPS_off( "adv_UPS_off" );
 static const itype_id itype_apparatus( "apparatus" );
 static const itype_id itype_beartrap( "beartrap" );
 static const itype_id itype_e_handcuffs( "e_handcuffs" );
@@ -210,7 +209,6 @@ static const itype_id itype_string_36( "string_36" );
 static const itype_id itype_toolset( "toolset" );
 static const itype_id itype_voltmeter_bionic( "voltmeter_bionic" );
 static const itype_id itype_UPS( "UPS" );
-static const itype_id itype_UPS_off( "UPS_off" );
 static const itype_id itype_power_storage( "bio_power_storage" );
 static const itype_id itype_power_storage_mkII( "bio_power_storage_mkII" );
 static const itype_id itype_bio_armor( "bio_armor" );

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -864,11 +864,7 @@ void Character::process_items()
     for( size_t index = 0; index < inv.size(); index++ ) {
         item &it = inv.find_item( index );
         itype_id identifier = it.type->get_id();
-        if( identifier == itype_UPS_off ) {
-            ch_UPS += it.ammo_remaining();
-        } else if( identifier == itype_adv_UPS_off ) {
-            ch_UPS += it.ammo_remaining() / 0.5;
-        }
+        ch_UPS += inv.charges_of( itype_UPS );
         if( it.has_flag( flag_USE_UPS ) && it.charges < it.type->maximum_charges() ) {
             active_held_items.push_back( index );
         }

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -98,8 +98,6 @@ static const bionic_id bio_ground_sonar( "bio_ground_sonar" );
 static const bionic_id bio_hydraulics( "bio_hydraulics" );
 static const bionic_id bio_speed( "bio_speed" );
 
-static const itype_id itype_adv_UPS_off( "adv_UPS_off" );
-static const itype_id itype_UPS_off( "UPS_off" );
 static const itype_id itype_UPS( "UPS" );
 
 void Character::recalc_speed_bonus()

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -875,8 +875,8 @@ void Character::process_items()
         }
         // Necessary for UPS in Aftershock - check worn items for charge
         const itype_id &identifier = w->typeId();
-        if( w->has_flag( flag_IS_UPS) ) {
-            if( w->has_flag( flag_IS_EFF_UPS ) ){
+        if( w->has_flag( flag_IS_UPS ) ) {
+            if( w->has_flag( flag_IS_EFF_UPS ) ) {
                 ch_UPS += w->ammo_remaining() / 0.5;
             } else {
                 ch_UPS += w->ammo_remaining();

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -877,10 +877,12 @@ void Character::process_items()
         }
         // Necessary for UPS in Aftershock - check worn items for charge
         const itype_id &identifier = w->typeId();
-        if( identifier == itype_UPS_off ) {
-            ch_UPS += w->ammo_remaining();
-        } else if( identifier == itype_adv_UPS_off ) {
-            ch_UPS += w->ammo_remaining() / 0.5;
+        if( w->has_flag( flag_IS_UPS) ) {
+            if( w->has_flag( flag_IS_EFF_UPS ) ){
+                ch_UPS += w->ammo_remaining() / 0.5;
+            } else {
+                ch_UPS += w->ammo_remaining();
+            }
         }
         if( !update_required && w->encumbrance_update_ ) {
             update_required = true;

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -170,6 +170,7 @@ const flag_id flag_IS_BLOOD( "IS_BLOOD" );
 const flag_id flag_IS_EXPLOSION_PROPELLED( "IS_EXPLOSION_PROPELLED" );
 const flag_id flag_IS_PET_ARMOR( "IS_PET_ARMOR" );
 const flag_id flag_IS_UPS( "IS_UPS" );
+const flag_id flag_IS_EFF_UPS( "IS_EFF_UPS" );
 const flag_id flag_LEAK_ALWAYS( "LEAK_ALWAYS" );
 const flag_id flag_LEAK_DAM( "LEAK_DAM" );
 const flag_id flag_LIGHT_IMMUNE( "LIGHT_IMMUNE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -171,6 +171,7 @@ extern const flag_id flag_IS_BLOOD;
 extern const flag_id flag_IS_EXPLOSION_PROPELLED;
 extern const flag_id flag_IS_PET_ARMOR;
 extern const flag_id flag_IS_UPS;
+extern const flag_id flag_IS_EFF_UPS;
 extern const flag_id flag_LEAK_ALWAYS;
 extern const flag_id flag_LEAK_DAM;
 extern const flag_id flag_LIGHT_IMMUNE;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9297,27 +9297,25 @@ detached_ptr<item> item::use_charges( detached_ptr<item> &&self, const itype_id 
 
                 if( n == e->ammo_remaining() ) {
                     used.push_back( item::spawn( *e ) );
-                    if( e->has_flag( flag_IS_EFF_UPS ) ){
+                    if( e->has_flag( flag_IS_EFF_UPS ) ) {
                         e->ammo_consume( n / 2, pos );
-                    }
-                    else{
-                        e->ammo_consume( n, pos);
+                    } else {
+                        e->ammo_consume( n, pos );
                     }
                 } else {
                     detached_ptr<item> split = item::spawn( *e );
                     split->ammo_set( e->ammo_current(), n );
-                    if( e->has_flag( flag_IS_EFF_UPS ) ){
+                    if( e->has_flag( flag_IS_EFF_UPS ) ) {
                         e->ammo_consume( n / 2, pos );
-                    }
-                    else{
-                        e->ammo_consume( n, pos);
+                    } else {
+                        e->ammo_consume( n, pos );
                     }
                     used.push_back( std::move( split ) );
                 }
             }
         } else if( e->count_by_charges() ) {
             if( e->typeId() == what || ( what == itype_UPS && e->has_flag( flag_IS_UPS ) ) ) {
-                if( e->has_flag( flag_IS_EFF_UPS ) ){
+                if( e->has_flag( flag_IS_EFF_UPS ) ) {
                     if( e->charges * 2 > qty ) {
                         e->charges -= qty / 2;
                         detached_ptr<item> split = item::spawn( *e );
@@ -9329,8 +9327,7 @@ detached_ptr<item> item::use_charges( detached_ptr<item> &&self, const itype_id 
                         used.push_back( std::move( e ) );
                         return detached_ptr<item>();
                     }
-                }
-                else {
+                } else {
                     if( e->charges > qty ) {
                         e->charges -= qty;
                         detached_ptr<item> split = item::spawn( *e );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9297,26 +9297,51 @@ detached_ptr<item> item::use_charges( detached_ptr<item> &&self, const itype_id 
 
                 if( n == e->ammo_remaining() ) {
                     used.push_back( item::spawn( *e ) );
-                    e->ammo_consume( n, pos );
+                    if( e->has_flag( flag_IS_EFF_UPS ) ){
+                        e->ammo_consume( n / 2, pos );
+                    }
+                    else{
+                        e->ammo_consume( n, pos);
+                    }
                 } else {
                     detached_ptr<item> split = item::spawn( *e );
                     split->ammo_set( e->ammo_current(), n );
-                    e->ammo_consume( n, pos );
+                    if( e->has_flag( flag_IS_EFF_UPS ) ){
+                        e->ammo_consume( n / 2, pos );
+                    }
+                    else{
+                        e->ammo_consume( n, pos);
+                    }
                     used.push_back( std::move( split ) );
                 }
             }
         } else if( e->count_by_charges() ) {
             if( e->typeId() == what || ( what == itype_UPS && e->has_flag( flag_IS_UPS ) ) ) {
-                if( e->charges > qty ) {
-                    e->charges -= qty;
-                    detached_ptr<item> split = item::spawn( *e );
-                    split->charges = qty;
-                    used.push_back( std::move( split ) );
-                    qty = 0;
-                } else {
-                    qty -= e->charges;
-                    used.push_back( std::move( e ) );
-                    return detached_ptr<item>();
+                if( e->has_flag( flag_IS_EFF_UPS ) ){
+                    if( e->charges * 2 > qty ) {
+                        e->charges -= qty / 2;
+                        detached_ptr<item> split = item::spawn( *e );
+                        split->charges = qty / 2;
+                        used.push_back( std::move( split ) );
+                        qty = 0;
+                    } else {
+                        qty -= e->charges;
+                        used.push_back( std::move( e ) );
+                        return detached_ptr<item>();
+                    }
+                }
+                else {
+                    if( e->charges > qty ) {
+                        e->charges -= qty;
+                        detached_ptr<item> split = item::spawn( *e );
+                        split->charges = qty;
+                        used.push_back( std::move( split ) );
+                        qty = 0;
+                    } else {
+                        qty -= e->charges;
+                        used.push_back( std::move( e ) );
+                        return detached_ptr<item>();
+                    }
                 }
             }
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9291,7 +9291,7 @@ detached_ptr<item> item::use_charges( detached_ptr<item> &&self, const itype_id 
 
     auto handle_item = [&qty, &used, &pos, &what]( detached_ptr<item> &&e ) {
         if( e->is_tool() ) {
-            if( e->typeId() == what ) {
+            if( e->typeId() == what || ( what == itype_UPS && e->has_flag( flag_IS_UPS ) ) ) {
                 int n = std::min( e->ammo_remaining(), qty );
                 qty -= n;
 
@@ -9306,7 +9306,7 @@ detached_ptr<item> item::use_charges( detached_ptr<item> &&self, const itype_id 
                 }
             }
         } else if( e->count_by_charges() ) {
-            if( e->typeId() == what ) {
+            if( e->typeId() == what || ( what == itype_UPS && e->has_flag( flag_IS_UPS ) ) ) {
                 if( e->charges > qty ) {
                     e->charges -= qty;
                     detached_ptr<item> split = item::spawn( *e );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8246,8 +8246,7 @@ static cable_state cable_menu( Character *who, cable_state &state, cable_state &
     // const bool has_solar_pack = who->worn_with_flag( flag_SOLARPACK );
     const bool has_solar_pack_on = who->worn_with_flag( flag_SOLARPACK_ON );
     //const bool wearing_solar_pack = has_solar_pack || has_solar_pack_on;
-    const bool has_ups = who->has_charges( itype_UPS_off, 1 ) ||
-                         who->has_charges( itype_adv_UPS_off, 1 );
+    const bool has_ups = who->has_charges( itype_UPS, 1 );
 
     const bool allow_self = state != state_self && state_other != state_self;
     const bool allow_ups =  state_other == state_self ||

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -221,7 +221,6 @@ static const efftype_id effect_weak_antibiotic( "weak_antibiotic" );
 static const efftype_id effect_webbed( "webbed" );
 static const efftype_id effect_weed_high( "weed_high" );
 
-static const itype_id itype_adv_UPS_off( "adv_UPS_off" );
 static const itype_id itype_advanced_ecig( "advanced_ecig" );
 static const itype_id itype_afs_atomic_smartphone( "afs_atomic_smartphone" );
 static const itype_id itype_afs_atomic_smartphone_music( "afs_atomic_smartphone_music" );
@@ -276,7 +275,6 @@ static const itype_id itype_towel( "towel" );
 static const itype_id itype_towel_soiled( "towel_soiled" );
 static const itype_id itype_towel_wet( "towel_wet" );
 static const itype_id itype_UPS( "UPS" );
-static const itype_id itype_UPS_off( "UPS_off" );
 static const itype_id itype_water( "water" );
 static const itype_id itype_water_clean( "water_clean" );
 static const itype_id itype_wax( "wax" );
@@ -5456,8 +5454,7 @@ int iuse::toolmod_attach( player *p, item *it, bool, const tripoint & )
     auto filter = [&it]( const item & e ) {
         // don't allow ups battery mods on a UPS or UPS-powered tools
         if( it->has_flag( flag_USE_UPS ) &&
-            ( e.typeId() == itype_UPS_off || e.typeId() == itype_adv_UPS_off ||
-              e.has_flag( flag_USE_UPS ) ) ) {
+            ( e.has_flag( flag_IS_UPS ) || e.has_flag( flag_USE_UPS ) ) ) {
             return false;
         }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -97,7 +97,6 @@ static const efftype_id effect_pkill3( "pkill3" );
 static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_riding( "riding" );
 
-static const itype_id itype_UPS_off( "UPS_off" );
 static const itype_id itype_UPS( "UPS" );
 
 static const skill_id skill_archery( "archery" );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -98,6 +98,7 @@ static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_riding( "riding" );
 
 static const itype_id itype_UPS_off( "UPS_off" );
+static const itype_id itype_UPS( "UPS" );
 
 static const skill_id skill_archery( "archery" );
 static const skill_id skill_barter( "barter" );
@@ -1547,8 +1548,7 @@ void npc::decide_needs()
     if( primary_weapon().is_gun() ) {
         int ups_drain = primary_weapon().get_gun_ups_drain();
         if( ups_drain > 0 ) {
-            int ups_charges = charges_of( itype_UPS_off, ups_drain ) +
-                              charges_of( itype_UPS_off, ups_drain );
+            int ups_charges = charges_of( itype_UPS );
             needrank[need_ammo] = static_cast<double>( ups_charges ) / ups_drain;
         } else {
             needrank[need_ammo] = character_funcs::get_ammo_items(

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -117,9 +117,7 @@ static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_hit_by_player( "hit_by_player" );
 static const efftype_id effect_on_roof( "on_roof" );
 
-static const itype_id itype_adv_UPS_off( "adv_UPS_off" );
 static const itype_id itype_UPS( "UPS" );
-static const itype_id itype_UPS_off( "UPS_off" );
 
 static const trap_str_id tr_practice_target( "tr_practice_target" );
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3977,8 +3977,7 @@ auto ranged::gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::
             }
         }
         if( !is_mech_weapon ) {
-            if( !( you.has_charges( itype_UPS_off, ups_drain ) ||
-                   you.has_charges( itype_adv_UPS_off, adv_ups_drain ) ||
+            if( !( you.has_charges( itype_UPS, ups_drain )  ||
                    ( you.has_active_bionic( bio_ups ) &&
                      you.get_power_level() >= units::from_kilojoule( ups_drain ) ) ) ) {
                 messages.push_back( string_format(

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -33,11 +33,9 @@
 #include "vehicle_selector.h"
 
 static const itype_id itype_apparatus( "apparatus" );
-static const itype_id itype_adv_UPS_off( "adv_UPS_off" );
 static const itype_id itype_toolset( "toolset" );
 static const itype_id itype_voltmeter_bionic( "voltmeter_bionic" );
 static const itype_id itype_UPS( "UPS" );
-static const itype_id itype_UPS_off( "UPS_off" );
 static const itype_id itype_bio_armor( "bio_armor" );
 
 static const quality_id qual_BUTCHER( "BUTCHER" );

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -48,6 +48,7 @@ static const bionic_id bio_ups( "bio_ups" );
 
 static const flag_id flag_BIONIC_ARMOR_INTERFACE( "BIONIC_ARMOR_INTERFACE" );
 static const flag_id flag_IS_UPS( "IS_UPS" );
+static const flag_id flag_IS_EFF_UPS( "IS_EFF_UPS" );
 
 /** @relates visitable */
 template <typename T>
@@ -960,7 +961,8 @@ static int charges_of_ups( const T &self, int limit,
     int qty = 0;
     self->visit_items( [&]( const item *e ) {
         if( e->has_flag( flag_IS_UPS ) ) {
-            qty = sum_no_wrap(qty, e->ammo_remaining() );
+            int mult = e->has_flag( flag_IS_EFF_UPS ) ? 2 : 1;
+            qty = sum_no_wrap(qty, e->ammo_remaining() * mult);
         }
         return qty < limit ? VisitResponse::NEXT : VisitResponse::ABORT;
     } );

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -957,10 +957,10 @@ static int charges_of_ups( const T &self, int limit,
                            std::function<void( int )> visitor )
 {
     int qty = 0;
-    self->visit_items( [&]( const item *e ) {
+    self->visit_items( [&]( const item * e ) {
         if( e->has_flag( flag_IS_UPS ) ) {
             int mult = e->has_flag( flag_IS_EFF_UPS ) ? 2 : 1;
-            qty = sum_no_wrap(qty, e->ammo_remaining() * mult);
+            qty = sum_no_wrap( qty, e->ammo_remaining() * mult );
         }
         return qty < limit ? VisitResponse::NEXT : VisitResponse::ABORT;
     } );
@@ -1099,7 +1099,7 @@ int visitable<Character>::charges_of( const itype_id &what, int limit,
 
     if( what == itype_UPS ) {
         int qty = 0;
-        qty = charges_of_ups( this, limit, filter, visitor);
+        qty = charges_of_ups( this, limit, filter, visitor );
         if( p && p->has_active_bionic( bio_ups ) ) {
             qty = sum_no_wrap( qty, units::to_kilojoule( p->get_power_level() ) );
         }

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -47,6 +47,7 @@ static const bionic_id bio_electrosense_voltmeter( "bio_electrosense_voltmeter" 
 static const bionic_id bio_ups( "bio_ups" );
 
 static const flag_id flag_BIONIC_ARMOR_INTERFACE( "BIONIC_ARMOR_INTERFACE" );
+static const flag_id flag_IS_UPS( "IS_UPS" );
 
 /** @relates visitable */
 template <typename T>
@@ -949,6 +950,22 @@ void location_visitable<monster>::remove_items_with( const
         mon->get_tied_item()->attempt_detach( check_item );
     }
 }
+/** @relates visitable */
+
+template <typename T>
+static int charges_of_ups( const T &self, int limit,
+                           const std::function<bool( const item & )> &filter,
+                           std::function<void( int )> visitor )
+{
+    int qty = 0;
+    self->visit_items( [&]( const item *e ) {
+        if( e->has_flag( flag_IS_UPS ) ) {
+            qty = sum_no_wrap(qty, e->ammo_remaining() );
+        }
+        return qty < limit ? VisitResponse::NEXT : VisitResponse::ABORT;
+    } );
+    return std::min( qty, limit );
+}
 
 template <typename T, typename M>
 static int charges_of_internal( const T &self, const M &main, const itype_id &id, int limit,
@@ -1009,8 +1026,7 @@ int visitable<inventory>::charges_of( const itype_id &what, int limit,
 {
     if( what == itype_UPS ) {
         int qty = 0;
-        qty = sum_no_wrap( qty, charges_of( itype_UPS_off ) );
-        qty = sum_no_wrap( qty, static_cast<int>( charges_of( itype_adv_UPS_off ) / 0.5 ) );
+        qty = charges_of_ups( this, limit, filter, visitor );
         return std::min( qty, limit );
     }
     const auto &binned = static_cast<const inventory *>( this )->get_binned_items();
@@ -1083,8 +1099,7 @@ int visitable<Character>::charges_of( const itype_id &what, int limit,
 
     if( what == itype_UPS ) {
         int qty = 0;
-        qty = sum_no_wrap( qty, charges_of( itype_UPS_off ) );
-        qty = sum_no_wrap( qty, static_cast<int>( charges_of( itype_adv_UPS_off ) / 0.5 ) );
+        qty = charges_of_ups( this, limit, filter, visitor);
         if( p && p->has_active_bionic( bio_ups ) ) {
             qty = sum_no_wrap( qty, units::to_kilojoule( p->get_power_level() ) );
         }


### PR DESCRIPTION
fixes: #6704 
fixes: #6259 
## Purpose of change (The Why)
I am impatient and finally got this polished enough to be used outside of my own games :)
It fixes the lack of custom UPSes, prior to the energy rework.

## Describe the solution (The How)
Changes checks to be based on the IS_UPS flag, and itype_UPS (as it does not exist), to be what is sent to charges_of and such to get UPS charges.
Additionally adds the IS_EFF_UPS flag to determine if the UPS is efficient like the advanced UPS
## Describe alternatives you've considered
Wait for #5259 to be merged and just merge the fixes for #6704 and #6259.

## Testing
Spawn in, load thyself with an advanced UPS, power armor, mess tin, firestarter, GPS pinpointer, and three UPS mods
- The firestarter should consume UPS power
- The GPS pinpointer should work under UPS power
- You can craft using the mess tin
- The power armor is using the UPS
- The charge of the advanced UPS is reducing at half the power cost.
- All related checks (I.E. Crafting checks using UPSes) pass 

## Additional context
I understand that when #5259 is merged, this PR will be reverted.

I will also revert all not-fix related changes if requested.

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later. 
