### PR TITLE
fix: steel rail should be ammo for the ferromag launchers

### DIFF
--- a/data/json/items/ammo/metal_rail.json
+++ b/data/json/items/ammo/metal_rail.json
@@ -37,6 +37,7 @@
     "color": "light_gray",
     "dispersion": 100,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING" ],
+    "ammo_type": "metal_rail",
     "range": 30,
     "loudness": 0,
     "damage": { "damage_type": "stab", "amount": 50, "armor_penetration": 30 }


### PR DESCRIPTION
## Purpose of change (The Why)
Looks like an oversight

## Describe the solution (The How)
Add the ammo category to steel_rail

## Describe alternatives you've considered
None

## Testing
Used eyes

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.