### PR TITLE
feat: Hearing and Stethoscopes now contribute to safe cracking speeds

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -12,6 +12,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "action.h"
 #include "activity_actor.h"
 #include "activity_actor_definitions.h"
 // TODO (https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1612):
@@ -1368,6 +1369,22 @@ static void apply_prying_tool( player &p, item *it, const tripoint &examp )
  * Time per attempt affected by perception and mechanics. 5 minutes per attempt minimum.
  * Small chance of just guessing the combo without listening device.
  */
+static time_duration safecracking_time( const player &p )
+{
+    time_duration time = 120_minutes;
+    time -= 10_minutes * p.get_skill_level( skill_mechanics );
+    if( p.get_per() > 10 ) {
+        time -= 5_minutes * ( p.get_per() - 10 );
+    }
+    // Count Safecracking tools (stethoscopes) as 2 perception
+    if( p.has_item_with_flag( flag_SAFECRACK ) ) {
+        time -= 10_minutes;
+    }
+    // Should take longer with poor hearing
+    time -= ( 5_minutes * ( p.hearing_ability() - 1 ) );
+    return std::max( time, 5_minutes );
+}
+
 void iexamine::safe( player &p, const tripoint &examp )
 {
 
@@ -1422,8 +1439,7 @@ void iexamine::safe( player &p, const tripoint &examp )
         add_msg( m_info, safecracking_message );
         // 120 minutes - 10 minutes per mechanics point, - 5 per perception point above 10;
         // capped at 5 minutes minimum.
-        const time_duration time = std::max( 120_minutes - 10_minutes * p.get_skill_level(
-                skill_mechanics ) - 5_minutes * ( std::max( p.get_per(), 10 ) - 10 ), 5_minutes );
+        const time_duration time = safecracking_time( p );
 
         p.assign_activity( ACT_CRACKING, to_moves<int>( time ) );
         p.activity->placement = examp;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1373,14 +1373,14 @@ static time_duration safecracking_time( const player &p )
 {
     time_duration time = 120_minutes;
     time -= 10_minutes * p.get_skill_level( skill_mechanics );
-    if( p.get_per() > 10 ) {
+    if( p.get_per() > 10){
         time -= 5_minutes * ( p.get_per() - 10 );
     }
     // Count Safecracking tools (stethoscopes) as 2 perception
-    if( p.has_item_with_flag( flag_SAFECRACK ) ) {
+    if( p.has_item_with_flag( flag_SAFECRACK ) ){
         time -= 10_minutes;
     }
-    // Should take longer with poor hearing
+    // Should take longer with poor hearing, hence the negative possibility
     time -= ( 5_minutes * ( p.hearing_ability() - 1 ) );
     return std::max( time, 5_minutes );
 }


### PR DESCRIPTION
## Purpose of change (The Why)
Counterintuitive for two requirements to not help safe cracking speeds at all
My hearing being good should still count for something even if I understand exactly how safes work and can see really well.

## Describe the solution (The How)
Moved it to a static function in order to simplify viewing and further edits.

Make Stethoscopes equivalent to 2 perception and every point of hearing over one equivalent to 1 perception for purposes of safe cracking.

Minimum time remains the same, and was reachable either way.

## Describe alternatives you've considered
None

## Testing
Spawn in bunch of safes
Try different combinations of perception, hearing, mechanics and stethoscopes and see that they all change the time taken to crack it.

## Additional context
Following suggested change from CrystalNole on discord.

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.