### PR TITLE
feat(balance): metal railing has higher bash resist than metal railing, correct `destroy_threshold` of wooden railing

### DIFF
--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -920,7 +920,6 @@
     "type": "terrain",
     "id": "t_metal_railing_underwater",
     "looks_like": "t_metal_railing",
-    "alias": [ "t_metal__railing_h", "t_metal__railing_v" ],
     "name": "underwater metal railing",
     "description": "A section of metal railing.",
     "symbol": "LINE_OXOX",

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -996,13 +996,13 @@
     "coverage": 25,
     "flags": [ "TRANSPARENT", "NOITEM", "REDUCE_SCENT", "MOUNTABLE", "SHORT", "THIN_OBSTACLE", "ROAD", "BURROWABLE" ],
     "bash": {
-      "str_min": 8,
+      "str_min": 25,
       "str_max": 150,
       "sound": "crunch!",
       "sound_fail": "clang!",
       "ter_set": "t_pavement_hw_air",
       "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ],
-      "ranged": { "reduction": [ 8, 8 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 25, 25 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -1016,13 +1016,13 @@
     "coverage": 25,
     "flags": [ "TRANSPARENT", "NOITEM", "REDUCE_SCENT", "MOUNTABLE", "SHORT", "THIN_OBSTACLE", "ROAD", "BURROWABLE" ],
     "bash": {
-      "str_min": 8,
+      "str_min": 25,
       "str_max": 150,
       "sound": "crunch!",
       "sound_fail": "clang!",
       "ter_set": "t_pavement_bg_dp",
       "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ],
-      "ranged": { "reduction": [ 8, 8 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 25, 25 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -1037,13 +1037,13 @@
     "flags": [ "TRANSPARENT", "NOITEM", "REDUCE_SCENT", "MOUNTABLE", "SHORT", "THIN_OBSTACLE", "ROAD", "BURROWABLE" ],
     "looks_like": "t_guardrail_bg_dp",
     "bash": {
-      "str_min": 8,
+      "str_min": 25,
       "str_max": 150,
       "sound": "crunch!",
       "sound_fail": "clang!",
       "ter_set": "t_pavement",
       "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ],
-      "ranged": { "reduction": [ 8, 8 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 25, 25 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -858,7 +858,7 @@
         { "item": "scrap", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 1, 3 ] }
       ],
-      "ranged": { "reduction": [ 20, 20 ], "destroy_threshold": 12, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 20, 20 ], "destroy_threshold": 80, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -902,8 +902,8 @@
     "connects_to": "RAILING",
     "deconstruct": { "ter_set": "t_rock_floor", "items": [ { "item": "sheet_metal", "count": 2 }, { "item": "pipe", "count": 4 } ] },
     "bash": {
-      "str_min": 20,
-      "str_max": 80,
+      "str_min": 25,
+      "str_max": 100,
       "sound": "clang!",
       "sound_fail": "whump.",
       "ter_set": "t_rock_floor",
@@ -913,7 +913,7 @@
         { "item": "sheet_metal_small", "charges": [ 1, 4 ] },
         { "item": "scrap", "count": [ 1, 3 ] }
       ],
-      "ranged": { "reduction": [ 20, 20 ], "destroy_threshold": 80, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 25, 25 ], "destroy_threshold": 100, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -944,8 +944,8 @@
     "connects_to": "RAILING",
     "deconstruct": { "ter_set": "t_water_cube", "items": [ { "item": "sheet_metal", "count": 2 }, { "item": "pipe", "count": 4 } ] },
     "bash": {
-      "str_min": 20,
-      "str_max": 80,
+      "str_min": 25,
+      "str_max": 100,
       "sound": "clang!",
       "sound_fail": "whump.",
       "ter_set": "t_water_cube",
@@ -955,7 +955,7 @@
         { "item": "sheet_metal_small", "charges": [ 1, 4 ] },
         { "item": "scrap", "count": [ 1, 3 ] }
       ],
-      "ranged": { "reduction": [ 20, 20 ], "destroy_threshold": 80, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 25, 25 ], "destroy_threshold": 100, "block_unaimed_chance": "25%" }
     }
   },
   {


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Smol thing I spotted while working on another PR, wooden railing had a weirdly low destroy threshold that didn't match its max bash roll, like terrain normally has. But then I further realized its bash resist was the same as metal railings.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Raised destroy thresh of wooden railing to 80, matching its `str_max`.
2. Bumped bash values of metal railing from 20-80 to 25-100.
3. Along the way I further realized that guard rails have 8 `str_min` which is wacky when glass rails have 10, bumped those up to 25 to match metal rails.

## Describe alternatives you've considered

Not buffing metal railings.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Confirmed my brain retains enough wrinkles to verify that the number 25 is higher than the numbers 10 and 20.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
