### PR TITLE
feat: UPS can recharge both internal and reloaded batteries

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1632,6 +1632,11 @@
     "context": [  ]
   },
   {
+    "id": "ADD_UPS_TOGGLE",
+    "type": "json_flag",
+    "context": [  ]
+  },
+  {
     "id": "IS_UPS",
     "type": "json_flag",
     "context": [  ]

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -17,6 +17,7 @@
     "ammo": "plutonium",
     "max_charges": 2500,
     "ups_eff_mult": 2,
+    "ups_recharge_rate": 10,
     "flags": [ "IS_UPS" ]
   },
   {

--- a/data/json/items/toolmod.json
+++ b/data/json/items/toolmod.json
@@ -17,6 +17,15 @@
     "category": "spare_parts",
     "name": { "str": "UPS conversion mod" },
     "description": "This device replaces conventional battery connections with a connector port that can plug into a UPS.  Any device modified with this can be used without a battery as long as you have a charged UPS with you.",
+    "flags": [ "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ]
+  },
+  {
+    "id": "battery_ups_toggle",
+    "copy-from": "battery_ups",
+    "type": "TOOLMOD",
+    "category": "spare_parts",
+    "name": { "str": "Toggled UPS conversion mod" },
+    "description": "This device extends the conventional battery connections with a connector port that can plug into a UPS.  Any device modified with this can draw from UPS power as long as you have a charged UPS with you.",
     "flags": [ "ADD_UPS_TOGGLE" ]
   },
   {

--- a/data/json/items/toolmod.json
+++ b/data/json/items/toolmod.json
@@ -24,8 +24,8 @@
     "copy-from": "battery_ups",
     "type": "TOOLMOD",
     "category": "spare_parts",
-    "name": { "str": "Toggled UPS conversion mod" },
-    "description": "This device extends the conventional battery connections with a connector port that can plug into a UPS.  Any device modified with this can draw from UPS power as long as you have a charged UPS with you.",
+    "name": { "str": "UPS battery conversion mod" },
+    "description": "This device extends the conventional battery connections with a connector port that can plug into a UPS.  Any device modified with this can toggle whether to charge its battery from UPS power.",
     "flags": [ "ADD_UPS_TOGGLE" ]
   },
   {

--- a/data/json/items/toolmod.json
+++ b/data/json/items/toolmod.json
@@ -17,7 +17,7 @@
     "category": "spare_parts",
     "name": { "str": "UPS conversion mod" },
     "description": "This device replaces conventional battery connections with a connector port that can plug into a UPS.  Any device modified with this can be used without a battery as long as you have a charged UPS with you.",
-    "flags": [ "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ]
+    "flags": [ "ADD_UPS_TOGGLE" ]
   },
   {
     "id": "magazine_battery_mod",

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -702,6 +702,25 @@
     "components": [ [ [ "power_supply", 1 ] ], [ [ "scrap", 4 ] ], [ [ "cable", 10 ] ] ]
   },
   {
+    "result": "battery_ups_toggle",
+    "type": "recipe",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_COMPONENTS",
+    "skill_used": "electronics",
+    "difficulty": 8,
+    "time": "15 m",
+    "reversible": true,
+    "decomp_learn": 4,
+    "autolearn": true,
+    "book_learn": [
+      [ "textbook_electronics", 6 ],
+      [ "recipe_lab_elec", 6 ],
+    ],
+    "using": [ [ "soldering_standard", 24 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [ [ [ "power_supply", 1 ] ], [ [ "scrap", 8 ] ], [ [ "cable", 15 ] ] ]
+  },
+  {
     "result": "magazine_battery_mod",
     "type": "recipe",
     "category": "CC_ELECTRONIC",

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -714,7 +714,7 @@
     "autolearn": true,
     "book_learn": [
       [ "textbook_electronics", 6 ],
-      [ "recipe_lab_elec", 6 ],
+      [ "recipe_lab_elec", 6 ]
     ],
     "using": [ [ "soldering_standard", 24 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -712,10 +712,7 @@
     "reversible": true,
     "decomp_learn": 4,
     "autolearn": true,
-    "book_learn": [
-      [ "textbook_electronics", 6 ],
-      [ "recipe_lab_elec", 6 ]
-    ],
+    "book_learn": [ [ "textbook_electronics", 6 ], [ "recipe_lab_elec", 6 ] ],
     "using": [ [ "soldering_standard", 24 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "power_supply", 1 ] ], [ [ "scrap", 8 ] ], [ [ "cable", 15 ] ] ]

--- a/docs/en/mod/json/reference/items/item_creation.md
+++ b/docs/en/mod/json/reference/items/item_creation.md
@@ -611,6 +611,7 @@ gunmod_data:
 "turns_per_charge": 20, // Charges consumed over time, deprecated in favor of power_draw
 "power_draw": 50,       // Energy consumption rate in mW
 "ups_eff_mult": 2,       // Multiplier for UPS efficiency
+"ups_recharge_rate": 10,       // The power output for UPS recharging of items
 "ammo": [ "NULL" ],       // Ammo types used for reloading
 "revert_to": "torch_done", // Transforms into item when charges are expended
 "use_action": "firestarter" // Action performed when tool is used, see special definition below

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -30,12 +30,14 @@
 #include "event.h"
 #include "event_bus.h"
 #include "faction.h"
+#include "flag.h"
 #include "game.h"
 #include "game_constants.h"
 #include "help.h"
 #include "inventory.h"
 #include "item.h"
 #include "item_contents.h"
+#include "item_factory.h"
 #include "itype.h"
 #include "iuse.h"
 #include "kill_tracker.h"
@@ -87,8 +89,6 @@ static const trait_id trait_CENOBITE( "CENOBITE" );
 static const trait_id trait_HYPEROPIC( "HYPEROPIC" );
 static const trait_id trait_ILLITERATE( "ILLITERATE" );
 static const trait_id trait_PROF_DICEMASTER( "PROF_DICEMASTER" );
-
-static const flag_id flag_FIX_FARSIGHT( "FIX_FARSIGHT" );
 
 static const morale_type MORALE_FOOD_COLD( "morale_food_cold" );
 static const morale_type MORALE_FOOD_VERY_COLD( "morale_food_very_cold" );
@@ -1330,8 +1330,11 @@ detached_ptr<item> avatar::wield( detached_ptr<item> &&target )
 
 bool avatar::invoke_item( item *used, const tripoint &pt )
 {
-    const std::map<std::string, use_function> &use_methods = used->type->use_methods;
-
+    std::map<std::string, use_function> use_methods;
+    use_methods.insert( used->type->use_methods.begin(), used->type->use_methods.end() );
+    if( used->has_flag( flag_ADD_UPS_TOGGLE ) ){
+        use_methods["TOGGLE_UPS_CHARGING"] = item_controller->usage_from_string( "TOGGLE_UPS_CHARGING" );
+    }
     if( use_methods.empty() ) {
         return false;
     } else if( use_methods.size() == 1 ) {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1332,7 +1332,7 @@ bool avatar::invoke_item( item *used, const tripoint &pt )
 {
     std::map<std::string, use_function> use_methods;
     use_methods.insert( used->type->use_methods.begin(), used->type->use_methods.end() );
-    if( used->has_flag( flag_ADD_UPS_TOGGLE ) ){
+    if( used->has_flag( flag_ADD_UPS_TOGGLE ) ) {
         use_methods["TOGGLE_UPS_CHARGING"] = item_controller->usage_from_string( "TOGGLE_UPS_CHARGING" );
     }
     if( use_methods.empty() ) {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1332,7 +1332,8 @@ bool avatar::invoke_item( item *used, const tripoint &pt )
 {
     std::map<std::string, use_function> use_methods;
     use_methods.insert( used->type->use_methods.begin(), used->type->use_methods.end() );
-    if( used->has_flag( flag_ADD_UPS_TOGGLE ) ) {
+    // Make sure the flag is that of the mod, not of the item being used :P
+    if( used->has_flag( flag_ADD_UPS_TOGGLE ) && !used->type->has_flag( flag_ADD_UPS_TOGGLE ) ) {
         use_methods["TOGGLE_UPS_CHARGING"] = item_controller->usage_from_string( "TOGGLE_UPS_CHARGING" );
     }
     if( use_methods.empty() ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7727,8 +7727,8 @@ bool Character::invoke_item( item *used, const std::string &method, const tripoi
     if( method != iuse_TOGGLE_UPS_CHARGING && !has_enough_charges( *used, true ) ) {
         return false;
     }
-    if( method == iuse_TOGGLE_UPS_CHARGING ){
-        iuse::toggle_ups_charging( this->as_player(), used, false, pt);
+    if( method == iuse_TOGGLE_UPS_CHARGING ) {
+        iuse::toggle_ups_charging( this->as_player(), used, false, pt );
         return true;
     }
     item *actually_used = used->get_usable_item( method );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7727,7 +7727,10 @@ bool Character::invoke_item( item *used, const std::string &method, const tripoi
     if( method != iuse_TOGGLE_UPS_CHARGING && !has_enough_charges( *used, true ) ) {
         return false;
     }
-
+    if( method == iuse_TOGGLE_UPS_CHARGING ){
+        iuse::toggle_ups_charging( this->as_player(), used, false, pt);
+        return true;
+    }
     item *actually_used = used->get_usable_item( method );
     if( actually_used == nullptr ) {
         debugmsg( "Tried to invoke a method %s on item %s, which doesn't have this method",

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -894,11 +894,11 @@ void Character::process_items()
     }
     int ch_UPS_used = 0;
     if( weapon_active && ch_UPS_used < ch_UPS ) {
-        auto weap = primary_weapon();
-        int used = std::min( ch_UPS, weap.ammo_capacity() - weap.ammo_remaining() );
+        auto weap = &primary_weapon();
+        int used = std::min( ch_UPS, weap->ammo_capacity() - weap->ammo_remaining() );
         ch_UPS -= used;
         ch_UPS_used += used;
-        weap.ammo_set( weap.ammo_current(), weap.ammo_remaining() + used );
+        weap->ammo_set( weap->ammo_current(), weap->ammo_remaining() + used );
     }
     // Load all items that use the UPS to their minimal functional charge,
     // The tool is not really useful if its charges are below charges_to_use

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -99,7 +99,6 @@ static const bionic_id bio_hydraulics( "bio_hydraulics" );
 static const bionic_id bio_speed( "bio_speed" );
 
 static const itype_id itype_UPS( "UPS" );
-static const itype_id itype_battery( "battery" );
 
 void Character::recalc_speed_bonus()
 {

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -99,6 +99,7 @@ static const bionic_id bio_hydraulics( "bio_hydraulics" );
 static const bionic_id bio_speed( "bio_speed" );
 
 static const itype_id itype_UPS( "UPS" );
+static const itype_id itype_battery( "battery" );
 
 void Character::recalc_speed_bonus()
 {
@@ -134,7 +135,7 @@ void Character::recalc_speed_bonus()
     mod_speed_bonus( mabuff_speed_bonus() );
 
     // Not sure why Sunlight Dependent is here, but OK
-    // Ectothermic/COLDBLOOD4 is intended to buff folks in the Summer
+    // Ectothermic/COLDBLOOD4 is intended to buff folks in the summer
     // Threshold-crossing has its charms ;-)
     if( g != nullptr ) {
         if( has_trait( trait_SUNLIGHT_DEPENDENT ) && !g->is_in_sunlight( pos() ) ) {
@@ -856,27 +857,30 @@ void Character::process_items()
     // Active item processing done, now we're recharging.
     std::vector<item *> active_worn_items;
     bool weapon_active = primary_weapon().has_flag( flag_USE_UPS ) &&
-                         primary_weapon().charges < primary_weapon().type->maximum_charges();
+                         primary_weapon().ammo_capacity() > primary_weapon().ammo_remaining();
     std::vector<size_t> active_held_items;
     int ch_UPS = 0;
     for( size_t index = 0; index < inv.size(); index++ ) {
         item &it = inv.find_item( index );
         itype_id identifier = it.type->get_id();
-        ch_UPS += inv.charges_of( itype_UPS );
-        if( it.has_flag( flag_USE_UPS ) && it.charges < it.type->maximum_charges() ) {
+        if( it.has_flag( flag_IS_UPS ) ) {
+            ch_UPS += std::min( it.ammo_remaining() * it.type->tool->ups_eff_mult,
+                                it.type->tool->ups_recharge_rate );
+        }
+        if( it.has_flag( flag_USE_UPS ) && it.ammo_capacity() > it.ammo_remaining() ) {
             active_held_items.push_back( index );
         }
     }
     bool update_required = get_check_encumbrance();
     for( item *&w : worn ) {
-        if( w->has_flag( flag_USE_UPS ) &&
-            w->charges < w->type->maximum_charges() ) {
+        if( w->has_flag( flag_USE_UPS ) && w->ammo_capacity() > w->ammo_remaining() ) {
             active_worn_items.push_back( w );
         }
         // Necessary for UPS in Aftershock - check worn items for charge
         const itype_id &identifier = w->typeId();
         if( w->has_flag( flag_IS_UPS ) ) {
-            ch_UPS += w->ammo_remaining() * w->type->tool->ups_eff_mult;
+            ch_UPS += std::min( w->ammo_remaining() * w->type->tool->ups_eff_mult,
+                                w->type->tool->ups_recharge_rate );
         }
         if( !update_required && w->encumbrance_update_ ) {
             update_required = true;
@@ -887,30 +891,36 @@ void Character::process_items()
         reset_encumbrance();
     }
     if( has_active_bionic( bionic_id( "bio_ups" ) ) ) {
-        ch_UPS += units::to_kilojoule( get_power_level() );
+        ch_UPS += std::min( units::to_kilojoule( get_power_level() ), 10 );
     }
     int ch_UPS_used = 0;
-
+    if( weapon_active && ch_UPS_used < ch_UPS ) {
+        auto weap = primary_weapon();
+        int used = std::min( ch_UPS, weap.ammo_capacity() - weap.ammo_remaining() );
+        ch_UPS -= used;
+        ch_UPS_used += used;
+        weap.ammo_set( weap.ammo_current(), weap.ammo_remaining() + used );
+    }
     // Load all items that use the UPS to their minimal functional charge,
     // The tool is not really useful if its charges are below charges_to_use
     for( size_t index : active_held_items ) {
-        if( ch_UPS_used >= ch_UPS ) {
+        if( ch_UPS <= 0 ) {
             break;
         }
         item &it = inv.find_item( index );
-        ch_UPS_used++;
-        it.charges++;
-    }
-    if( weapon_active && ch_UPS_used < ch_UPS ) {
-        ch_UPS_used++;
-        primary_weapon().charges++;
+        int used = std::min( ch_UPS, it.ammo_capacity() - it.ammo_remaining() );
+        ch_UPS -= used;
+        ch_UPS_used += used;
+        it.ammo_set( it.ammo_current(), it.ammo_remaining() + used );
     }
     for( item *worn_item : active_worn_items ) {
-        if( ch_UPS_used >= ch_UPS ) {
+        if( ch_UPS <= 0 ) {
             break;
         }
-        ch_UPS_used++;
-        worn_item->charges++;
+        int used = std::min( ch_UPS, worn_item->ammo_capacity() - worn_item->ammo_remaining() );
+        ch_UPS -= used;
+        ch_UPS_used += used;
+        worn_item->ammo_set( worn_item->ammo_current(), worn_item->ammo_remaining() + used );
     }
     if( ch_UPS_used > 0 ) {
         use_charges( itype_UPS, ch_UPS_used );

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -839,7 +839,7 @@ static bool needs_elec_charges( item *it )
     const item *mag = it->magazine_current();
     if( mag ) {
         return mag->has_flag( flag_RECHARGE );
-    } else{
+    } else {
         return true;
     }
 }
@@ -871,7 +871,7 @@ void Character::process_items()
     // Active item processing done, now we're recharging.
     std::vector<item *> active_worn_items;
     bool weapon_active = primary_weapon().has_flag( flag_USE_UPS ) &&
-                         needs_elec_charges(&primary_weapon());
+                         needs_elec_charges( &primary_weapon() );
     std::vector<size_t> active_held_items;
     int ch_UPS = 0;
     for( size_t index = 0; index < inv.size(); index++ ) {
@@ -881,13 +881,13 @@ void Character::process_items()
             ch_UPS += std::min( it.ammo_remaining() * it.type->tool->ups_eff_mult,
                                 it.type->tool->ups_recharge_rate );
         }
-        if( it.has_flag( flag_USE_UPS ) && needs_elec_charges(&it) ) {
+        if( it.has_flag( flag_USE_UPS ) && needs_elec_charges( &it ) ) {
             active_held_items.push_back( index );
         }
     }
     bool update_required = get_check_encumbrance();
     for( item *&w : worn ) {
-        if( w->has_flag( flag_USE_UPS ) && needs_elec_charges(w) ) {
+        if( w->has_flag( flag_USE_UPS ) && needs_elec_charges( w ) ) {
             active_worn_items.push_back( w );
         }
         // Necessary for UPS in Aftershock - check worn items for charge

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -135,7 +135,7 @@ void Character::recalc_speed_bonus()
     mod_speed_bonus( mabuff_speed_bonus() );
 
     // Not sure why Sunlight Dependent is here, but OK
-    // Ectothermic/COLDBLOOD4 is intended to buff folks in the summer
+    // Ectothermic/COLDBLOOD4 is intended to buff folks in the Summer
     // Threshold-crossing has its charms ;-)
     if( g != nullptr ) {
         if( has_trait( trait_SUNLIGHT_DEPENDENT ) && !g->is_in_sunlight( pos() ) ) {

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -14,6 +14,7 @@ const flag_id flag_ACID_IMMUNE( "ACID_IMMUNE" );
 const flag_id flag_ACTIVE_CLOAKING( "ACTIVE_CLOAKING" );
 const flag_id flag_ACT_IN_FIRE( "ACT_IN_FIRE" );
 const flag_id flag_ACT_ON_RANGED_HIT( "ACT_ON_RANGED_HIT" );
+const flag_id flag_ADD_UPS_TOGGLE( "ADD_UPS_TOGGLE" );
 const flag_id flag_ALARMCLOCK( "ALARMCLOCK" );
 const flag_id flag_ALLERGEN_EGG( "ALLERGEN_EGG" );
 const flag_id flag_ALLERGEN_FRUIT( "ALLERGEN_FRUIT" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -16,6 +16,7 @@ extern const flag_id flag_ACID_IMMUNE;
 extern const flag_id flag_ACTIVE_CLOAKING;
 extern const flag_id flag_ACT_IN_FIRE;
 extern const flag_id flag_ACT_ON_RANGED_HIT;
+extern const flag_id flag_ADD_UPS_TOGGLE;
 extern const flag_id flag_ALARMCLOCK;
 extern const flag_id flag_ALLERGEN_EGG;
 extern const flag_id flag_ALLERGEN_FRUIT;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2093,6 +2093,7 @@ void Item_factory::load( islot_tool &slot, const JsonObject &jo, const std::stri
     assign( jo, "revert_msg", slot.revert_msg, strict );
     assign( jo, "sub", slot.subtype, strict );
     assign( jo, "ups_eff_mult", slot.ups_eff_mult, strict );
+    assign( jo, "ups_recharge_rate", slot.ups_recharge_rate, strict );
 
     if( jo.has_array( "rand_charges" ) ) {
         if( jo.has_member( "initial_charges" ) ) {

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -235,6 +235,9 @@ class Item_factory
 
         std::list<itype_id> subtype_replacement( const itype_id & ) const;
 
+        // For very rare cases
+        use_function usage_from_string( const std::string &type ) const;
+
     private:
         /** Set at finalization and prevents alterations to the static item templates */
         bool frozen = false;
@@ -309,8 +312,6 @@ class Item_factory
                                         std::map<std::string, use_function> &use_methods );
         void set_use_methods_from_array( const JsonArray &array,
                                          std::map<std::string, use_function> &use_methods );
-
-        use_function usage_from_string( const std::string &type ) const;
 
         std::pair<std::string, use_function> usage_from_object( const JsonObject &obj );
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -110,6 +110,7 @@ struct islot_tool {
     int turns_active = 0;
     int power_draw = 0;
     int ups_eff_mult = 1;
+    int ups_recharge_rate = 5;
 
     std::vector<int> rand_charges;
 };


### PR DESCRIPTION
## Purpose of change (The Why)
@RoyalFox2140 wanted to be able to recharge items with a replaceable battery using a UPS, this would provide that.
In addition, it makes a UPS recharge all objects at a set rate, so connecting more objects does not increase total recharge rate.

## Describe the solution (The How)
Coverts code from using charges and maximum_charges() to ammo_capacity(), ammo_remaining() and ammo_set()
Adds a new field "ups_recharge_rate" which sets how many charges the UPS recharges each turn IN TOTAL.
Adds a new flag "ADD_UPS_TOGGLE", which adds the UPS_TOGGLE action to an item.
This new thing replaces the previous UPS mod
## Describe alternatives you've considered
Change the flag for recharging from ups from USE_UPS to UPS_RECHARGE or even the RECHARGE flag to differentiate using the UPS as an ammo source or recharging internal batteries.
- Note: this provides very little difference, due to use time > charges used for nearly all purposes.
- Note 2: The recharge using UPS action just adds the USE_UPS flag, so it maintains previous logic.

Additionally, the values for recharge speed may need to be tweaked/lowered due to the current speed.
But it's designed for people who previously could use 5+ items recharging from one UPS.

## Testing
Add USE_UPS to any removing battery containing item beforehand.
Spawn said item and a smartphone.
Reduce both of their batteries.
Spawn in either a UPS or an Advanced UPS
Watch as both of their charges go up.
- Note: Like a recharging station, one goes to full, then the next then the next

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.