### PR TITLE
fix: sanity-check item weight and recipe for gas sac buoyancy cells

### DIFF
--- a/data/json/items/vehicle/boat.json
+++ b/data/json/items/vehicle/boat.json
@@ -41,7 +41,7 @@
     "price": 100,
     "price_postapoc": 10,
     "material": [ "flesh", "plastic" ],
-    "weight": "35 kg",
+    "weight": "1250 g",
     "volume": "12500 ml",
     "bashing": 8,
     "to_hit": -3,

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -169,14 +169,13 @@
     "skill_used": "fabrication",
     "difficulty": 2,
     "time": "1 h",
-    "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
-      [ [ "mutant_bug_hydrogen_sacs", 288 ] ],
+      [ [ "mutant_bug_hydrogen_sacs", 250 ] ],
       [ [ "bag_plastic", 12 ] ],
-      [ [ "rope_natural", 1, "LIST" ] ],
-      [ [ "rigid_plastic_sheet", 1 ] ]
+      [ [ "rope_natural_short", 1, "LIST" ] ],
+      [ [ "plastic_sheet", 1 ] ]
     ]
   },
   {


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Ekarus pointed out that hydrogen gas sacs have an absolutely unreasonable weight of 35 kilos which makes it de-facto the worst boat hull in the entire game.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Lowered weight of hydrogen boat hulls down to 1250 grams, just below the weight of most of its components (see below) minus the hydrogen, assuming we're cutting the hydrogen out of the bug guts.
2. Swapped the rigid plastic sheet for a regular one since that's presumably being used to contain the individual plastic bags, lowered the amount of gas sacs needed to a more even 250 (equal in volume to the resulting part), lowered the rope requirement a bit and lastly made the recipe non-reversible, under the assumption that you're probably taking the hydrogen out of the cells and trapping them in the makeshift gas cell. Otherwise the item weight would only make sense if I tacked on the extra 12.5 kilos of weight the bug guts take up and then it'd STILL be way shittier weight-wise than any other boat hull.

## Describe alternatives you've considered

1. Making the recipe demand hydrogen directly since you can extract them from bug bits anyway.
2. Making it not take hydrogen at all and just be a player-made version of the inflatable boat parts.

Log boat hulls are also kinda fucky, you turn 120 kilos into 6 kilos of boat board but the recipe is still reversible...

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
