### PR TITLE
feat(balance): Laser finger CBM requires v29 to craft

### DIFF
--- a/data/json/recipes/electronic/cbms.json
+++ b/data/json/recipes/electronic/cbms.json
@@ -370,9 +370,7 @@
     "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
     "tools": [ [ [ "autoclave", 5000 ], [ "fake_autoclave", -1 ] ], [ [ "small_repairkit", 10 ], [ "large_repairkit", 5 ] ] ],
     "components": [
-      [ [ "lens", 2 ] ],
-      [ [ "power_supply", 2 ] ],
-      [ [ "amplifier", 1 ] ],
+      [ [ "v29", 1 ] ],
       [ [ "processor", 1 ] ],
       [ [ "targeting_module", 1 ] ],
       [ [ "cable", 12 ] ],

--- a/data/json/recipes/electronic/cbms.json
+++ b/data/json/recipes/electronic/cbms.json
@@ -366,7 +366,7 @@
     "difficulty": 7,
     "time": "6 h",
     "book_learn": [ [ "recipe_lab_elec", 6 ], [ "recipe_mil_augs", 6 ] ],
-    "using": [ [ "soldering_standard", 80 ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
     "tools": [ [ [ "autoclave", 5000 ], [ "fake_autoclave", -1 ] ], [ [ "small_repairkit", 10 ], [ "large_repairkit", 5 ] ] ],
     "components": [


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

The v29 Laser Pistol is made of special proprietary stuffs and cannot possibly be crafted. Meanwhile, a Laser Finger CBM with the same stats and better accuracy can be assembled from things lying around the garage.

## Describe the solution (The How)

- Replace the lenses and power supply requirements in the recipe with a v29.
- Reduce the solder requirements since the player isn't assembling a laser from scratch anymore.

## Describe alternatives you've considered

- Require industrial laser.
- Buff v29 to differentiate it from the finger.
- Reintroduce homemade laser pistols
- Make v29 craftable (please don't).

## Testing

1. Spawned in
2. Crafting recipe showed new required materials
3. Nothing weird happened when crafting it

## Additional context

The idea is that you are disassembling and reorienting the core components of a v29 into a bionic.

## Checklist


### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
