### PR TITLE
fix: add `ALLOWS_TAIL_SNAKE` to overlooked containers and tool armors

### DIFF
--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -597,7 +597,7 @@
     "seals": true,
     "watertight": true,
     "armor_data": { "covers": [ "leg_either" ], "coverage": 5, "encumbrance": 2, "material_thickness": 2 },
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
   },
   {
     "id": "power_armor_canteen",
@@ -834,7 +834,7 @@
     "watertight": true,
     "armor_data": { "covers": [ "leg_either" ], "coverage": 2, "material_thickness": 1 },
     "qualities": [ [ "BOIL", 1 ] ],
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
   },
   {
     "id": "jar_3l_glass",
@@ -1153,7 +1153,7 @@
     "seals": true,
     "watertight": true,
     "armor_data": { "covers": [ "leg_either" ], "coverage": 5, "material_thickness": 2 },
-    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
   },
   {
     "id": "waterskin2",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -363,7 +363,7 @@
     "material_thickness": 1,
     "environmental_protection": 4,
     "use_action": "DIRECTIONAL_HOLOGRAM",
-    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER" ]
+    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "ALLOWS_TAIL_SNAKE" ]
   },
   {
     "type": "TOOL_ARMOR",
@@ -1700,7 +1700,7 @@
     "revert_to": "emer_blanket",
     "use_action": "PACK_ITEM",
     "covers": [ "torso", "arms", "hands", "legs", "feet" ],
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ],
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TAIL_SNAKE" ],
     "warmth": 50,
     "environmental_protection": 1,
     "encumbrance": 50,
@@ -1776,7 +1776,7 @@
     "warmth": 10,
     "coverage": 50,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE" ]
+    "flags": [ "OVERSIZE", "ALLOWS_TAIL_SNAKE" ]
   },
   {
     "id": "towel_wet",
@@ -1796,7 +1796,7 @@
     "to_hit": -1,
     "revert_to": "towel",
     "use_action": "TOWEL",
-    "flags": [ "WET", "OVERSIZE" ],
+    "flags": [ "WET", "OVERSIZE", "ALLOWS_TAIL_SNAKE" ],
     "coverage": 50,
     "material_thickness": 1
   },
@@ -1818,7 +1818,7 @@
     "to_hit": -1,
     "revert_to": "towel",
     "use_action": "TOWEL",
-    "flags": [ "WET", "OVERSIZE" ],
+    "flags": [ "WET", "OVERSIZE", "ALLOWS_TAIL_SNAKE" ],
     "coverage": 50,
     "material_thickness": 1
   },
@@ -2936,7 +2936,7 @@
       "need_charges": 1,
       "need_charges_msg": "The blanket's batteries are dead."
     },
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ],
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TAIL_SNAKE" ],
     "magazines": [
       [
         "battery",


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Fixes some items I overlooked that would make sense to be wearable with snake tails.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Added the flag to:
1. Canteens/waterskins that go on the leg slot.
2. Holo cloak.
3. Emergency blanket.
4. Towels.
5. Electric blanket.

## Describe alternatives you've considered

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Used my eyes. :D

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
