### PR TITLE
fix(UI): pouring liquid directly into an adjacent keg after crafting it wont lock you in a menu

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3509,7 +3509,7 @@ detached_ptr<item> iexamine::pour_into_keg( const tripoint &pos, detached_ptr<it
             liquid->charges--;
         }
         add_msg( _( "You pour %1$s into the %2$s." ), obj.tname(), keg_name );
-        if ( liquid->charges == 0 ) {
+        if( liquid->charges == 0 ) {
             return detached_ptr<item>();
         }
     }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3509,6 +3509,9 @@ detached_ptr<item> iexamine::pour_into_keg( const tripoint &pos, detached_ptr<it
             liquid->charges--;
         }
         add_msg( _( "You pour %1$s into the %2$s." ), obj.tname(), keg_name );
+        if ( liquid->charges == 0 ) {
+            return detached_ptr<item>();
+        }
     }
 
     return std::move( liquid );


### PR DESCRIPTION

<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

Crafting a liquid while adjacent to a keg/standing tank will give you a prompt to pour it directly into the keg. 
Selecting the option to pour liquid into a keg will correctly add the liquid to the tank, 
However if the tank already has that same liquid in it, the menu will not close after transferring all liquid charges
This appears to be because all other code paths return detached_ptr<item>() when all liquid charges have been transferred except for this one

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Correctly return detached_ptr<item>() when all liquid charges have been transferred into a partially full keg

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Uhh, not fixing this I guess?

## Testing

Placed a oven next to a standing tank and partially filled it with clean water
Batch crafted some clean water (with the hammerspace mutation turned off)
Checked that the menu now correctly closes when selecting the "Pour into adjacent keg" option

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
<img width="1920" height="1080" alt="2025-09-01-10:10:13" src="https://github.com/user-attachments/assets/f36a5a8e-2dac-4359-bec5-60227471096e" />
This is what menu jail looks like I guess

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
