### PR TITLE
fix: flotation device doesnt give a swim bonus underwater

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1118,7 +1118,7 @@ int Character::swim_speed() const
 
     /** @EFFECT_DEX increases swim speed */
     ret -= str_cur * 6 + dex_cur * 4;
-    if( worn_with_flag( flag_FLOTATION ) ) {
+    if( worn_with_flag( flag_FLOTATION ) && !is_underwater() ) {
         ret = std::min( ret, 400 );
         ret = std::max( ret, 200 );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3215,7 +3215,8 @@ ret_val<bool> Character::can_wear( const item &it, bool with_equip_change ) cons
     }
 
     if( it.has_flag( flag_FLOTATION ) && get_map().has_flag( TFLAG_WATER_CUBE, pos() ) ) {
-        return ret_val<bool>::make_failure( ( is_player() ? _( "You can't put on a flotation device below the surface." )
+        return ret_val<bool>::make_failure( ( is_player() ?
+                                              _( "You can't put on a flotation device below the surface." )
                                               : string_format( _( "%s can't put on a flotation device below the surface." ), name ) ) );
     }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1118,7 +1118,7 @@ int Character::swim_speed() const
 
     /** @EFFECT_DEX increases swim speed */
     ret -= str_cur * 6 + dex_cur * 4;
-    if( worn_with_flag( flag_FLOTATION ) && !is_underwater() ) {
+    if( worn_with_flag( flag_FLOTATION ) && !get_map().has_flag( TFLAG_WATER_CUBE, pos() ) ) {
         ret = std::min( ret, 400 );
         ret = std::max( ret, 200 );
     }
@@ -3212,6 +3212,11 @@ ret_val<bool> Character::can_wear( const item &it, bool with_equip_change ) cons
     if( it.has_flag( flag_RESTRICT_HANDS ) && !has_two_arms() ) {
         return ret_val<bool>::make_failure( ( is_player() ? _( "You don't have enough arms to wear that." )
                                               : string_format( _( "%s doesn't have enough arms to wear that." ), name ) ) );
+    }
+
+    if( it.has_flag( flag_FLOTATION ) && get_map().has_flag( TFLAG_WATER_CUBE, pos() ) ) {
+        return ret_val<bool>::make_failure( ( is_player() ? _( "You can't put on a flotation device below the surface." )
+                                              : string_format( _( "%s can't put on a flotation device below the surface." ), name ) ) );
     }
 
     //Everything checked after here should be something that could be solved by changing equipment


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
fixes #7095 
Diving underwater and then equipping a flotation vest increases your swim speed enough that your stamina does not drop while swimming. 
This is presumably unintended given items with the flotation flag prevent you from diving
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Simply disable the swim speed bonus from flotation devices when underwater
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Additionally preventing a player from wearing a flotation vest while underwater
Making the flotation vest drag the player back to the surface somehow?

## Testing

Located the nearest lake and swam to the bottom of it
Wore a flotation vest and swam around to confirm stamina depleted normally

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
