### PR TITLE
fix: multicooker no longer has a chance of disappearing when cooking food

### DIFF
--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -827,7 +827,7 @@
     "symbol": ";",
     "color": "red",
     "ammo": "battery",
-    "power_draw": 1500000,
+    "power_draw": 1000000,
     "qualities": [ [ "CONTAIN", 1 ] ],
     "use_action": "MULTICOOKER",
     "magazines": [


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
fixes #6637 
Currently, there is a decent chance a multicooker will disappear when cooking recipes that are around 3-4 minutes long (when unupgraded). 
This is because the multicooker has a 50% chance of using 1 charge per turn and a 50% chance of using 2 charges
Subsequently a recipe may then take more charges then the multicooker has which sends it to the void
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adjust power draw to 1 charge per turn so its consistent
That does mean this is also a buff but theres not exactly a lot of other options to fix this issue so
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Adjusting it to 2 charges per turn instead?

## Testing
Spawned several multicookers and cooked rice with them
Verified it took 410 charges consistently every time
(3 minute recipe * 2 = 360 charges + the initial 50 charge cost = 410) 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
