### PR TITLE
feat: jsonize packmule, crafting multiplier, audit setting names

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -319,7 +319,8 @@
     "description": "You can manage to find space for anything!  You can carry 40% more volume.",
     "starting_trait": true,
     "valid": false,
-    "cancels": [ "DISORGANIZED" ]
+    "cancels": [ "DISORGANIZED" ],
+    "packmule_modifier": 1.4
   },
   {
     "type": "mutation",
@@ -813,7 +814,8 @@
     "description": "You are terrible at organizing and storing your possessions.  You can carry 40% less volume.",
     "starting_trait": true,
     "valid": false,
-    "cancels": [ "PACKMULE" ]
+    "cancels": [ "PACKMULE" ],
+    "packmule_modifier": 0.6
   },
   {
     "type": "mutation",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -314,7 +314,6 @@ static const trait_id trait_NOMAD2( "NOMAD2" );
 static const trait_id trait_NOMAD3( "NOMAD3" );
 static const trait_id trait_NOPAIN( "NOPAIN" );
 static const trait_id trait_PACIFIST( "PACIFIST" );
-static const trait_id trait_PACKMULE( "PACKMULE" );
 static const trait_id trait_PADDED_FEET( "PADDED_FEET" );
 static const trait_id trait_PAINRESIST_TROGLO( "PAINRESIST_TROGLO" );
 static const trait_id trait_PAINRESIST( "PAINRESIST" );
@@ -3096,12 +3095,9 @@ units::volume Character::volume_capacity_reduced_by(
     if( has_trait( trait_SHELL2 ) && !has_active_mutation( trait_SHELL2 ) ) {
         ret += 6_liter;
     }
-    if( has_trait( trait_PACKMULE ) ) {
-        ret = ret * 1.4;
-    }
-    if( has_trait( trait_DISORGANIZED ) ) {
-        ret = ret * 0.6;
-    }
+
+    ret = ret * mutation_value( "packmule_modifier" );
+
     return std::max( ret, 0_ml );
 }
 
@@ -7102,6 +7098,7 @@ mutation_value_map = {
     { "movecost_modifier", calc_mutation_value_multiplicative<&mutation_branch::movecost_modifier> },
     { "movecost_flatground_modifier", calc_mutation_value_multiplicative<&mutation_branch::movecost_flatground_modifier> },
     { "movecost_obstacle_modifier", calc_mutation_value_multiplicative<&mutation_branch::movecost_obstacle_modifier> },
+    { "packmule_modifier", calc_mutation_value_multiplicative<&mutation_branch::packmule_modifier> },
     { "attackcost_modifier", calc_mutation_value_multiplicative<&mutation_branch::attackcost_modifier> },
     { "falling_damage_multiplier", calc_mutation_value_multiplicative<&mutation_branch::falling_damage_multiplier> },
     { "max_stamina_modifier", calc_mutation_value_multiplicative<&mutation_branch::max_stamina_modifier> },

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -283,7 +283,6 @@ static const trait_id trait_DEBUG_LS( "DEBUG_LS" );
 static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );
 static const trait_id trait_DEBUG_NOTEMP( "DEBUG_NOTEMP" );
 static const trait_id trait_DEBUG_STORAGE( "DEBUG_STORAGE" );
-static const trait_id trait_DISORGANIZED( "DISORGANIZED" );
 static const trait_id trait_DOWN( "DOWN" );
 static const trait_id trait_ELECTRORECEPTORS( "ELECTRORECEPTORS" );
 static const trait_id trait_FASTLEARNER( "FASTLEARNER" );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -274,7 +274,7 @@ float crafting_speed_multiplier( const Character &who, const item &craft,
     const float light_multi = lighting_crafting_speed_multiplier( who, rec );
     const float bench_multi = workbench_crafting_speed_multiplier( craft, bench );
     const float morale_multi = morale_crafting_speed_multiplier( who, rec );
-    const float game_opt_multi = get_option<float>( "CRAFTING_SPEED_MULT" );
+    const float game_opt_multi = get_option<int>( "CRAFTING_SPEED_MULT" ) / 100.0f;
 
     const float total_multi = light_multi * bench_multi * morale_multi * game_opt_multi;
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -274,8 +274,9 @@ float crafting_speed_multiplier( const Character &who, const item &craft,
     const float light_multi = lighting_crafting_speed_multiplier( who, rec );
     const float bench_multi = workbench_crafting_speed_multiplier( craft, bench );
     const float morale_multi = morale_crafting_speed_multiplier( who, rec );
+    const float game_opt_multi = get_option<float>( "CRAFTING_SPEED_MULT" );
 
-    const float total_multi = light_multi * bench_multi * morale_multi;
+    const float total_multi = light_multi * bench_multi * morale_multi * game_opt_multi;
 
     if( light_multi <= 0.0f ) {
         who.add_msg_if_player( m_bad, _( "You can no longer see well enough to keep crafting." ) );

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -154,6 +154,7 @@ struct mutation_branch {
         float noise_modifier = 1.0f;
         float scent_modifier = 1.0f;
         float bleed_resist = 0;
+        float packmule_modifier = 1.0f;
         std::optional<int> scent_intensity;
         std::optional<int> scent_mask;
 

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -390,6 +390,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "night_vision_range", night_vision_range, 0.0f );
     optional( jo, was_loaded, "reading_speed_multiplier", reading_speed_multiplier, 1.0f );
     optional( jo, was_loaded, "skill_rust_multiplier", skill_rust_multiplier, 1.0f );
+    optional( jo, was_loaded, "packmule_modifier", packmule_modifier, 1.0f );
     optional( jo, was_loaded, "scent_modifier", scent_modifier, 1.0f );
     optional( jo, was_loaded, "scent_intensity", scent_intensity, std::nullopt );
     optional( jo, was_loaded, "scent_mask", scent_mask, std::nullopt );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2393,7 +2393,7 @@ void options_manager::add_options_world_default()
          0, 8, 4
        );
 
-    add( "SPECIALS_DENSITY", world_default, translate_marker( "Overmap specials density" ),
+    add( "SPECIALS_DENSITY", world_default, translate_marker( "Overmap specials density factor" ),
          translate_marker( "A scaling factor that determines density of overmap specials." ),
          0.01, 10.0, 1, 0.1
        );
@@ -2403,7 +2403,7 @@ void options_manager::add_options_world_default()
          -1, 72, 6
        );
 
-    add( "VEHICLE_DAMAGE", world_default, translate_marker( "Vehicle damage modifier" ),
+    add( "VEHICLE_DAMAGE", world_default, translate_marker( "Vehicle damage scaling factor" ),
          translate_marker( "A scaling factor that determines how damaged vehicles are." ),
          0.0, 10.0, 1, 0.1
        );
@@ -2433,11 +2433,6 @@ void options_manager::add_options_world_default()
          0.0, 100, 2.0, 0.01
        );
 
-    add( "CRAFTING_SPEED_MULT", world_default, translate_marker( "Crafting speed scaling factor" ),
-         translate_marker( "A scaling factor that determines crafting speed.  The player will give up if total speed multiplier is below 20%." ),
-         0.01, 10.0, 1.0, 0.01
-       );
-
     add_empty_line();
 
     add( "RESTOCK_DELAY_MULT", world_default, translate_marker( "Merchant restock scaling factor" ),
@@ -2453,7 +2448,7 @@ void options_manager::add_options_world_default()
          0.01, 10.0, 1.0, 0.01 );
 
     add_option_group( world_default, Group( "item_category_spawn_rate",
-                                            to_translation( "Item category spawn rate" ),
+                                            to_translation( "Item category scaling factors" ),
                                             to_translation( "Spawn rate for item categories. Values ≤ 1.0 represent a chance to spawn. >1.0 means extra spawns. Set to 0.0 to disable spawning items from that category." ) ),
     [&]( const std::string & page_id ) {
 
@@ -2647,12 +2642,13 @@ void options_manager::add_options_world_default()
 
     add_empty_line();
 
-    add( "MONSTER_SPEED", world_default, translate_marker( "Monster speed" ),
+    add( "MONSTER_SPEED", world_default, translate_marker( "Monster speed percentage" ),
          translate_marker( "Determines the movement rate of monsters.  A higher value increases monster speed and a lower reduces it.  Requires world reset." ),
          1, 1000, 100, COPT_NO_HIDE, "%i%%"
        );
 
-    add( "MONSTER_RESILIENCE", world_default, translate_marker( "Monster resilience" ),
+    add( "MONSTER_RESILIENCE", world_default,
+         translate_marker( "Monster resilience percentage" ),
          translate_marker( "Determines how much damage monsters can take.  A higher value makes monsters more resilient and a lower makes them more flimsy.  Requires world reset." ),
          1, 1000, 100, COPT_NO_HIDE, "%i%%"
        );
@@ -2686,12 +2682,19 @@ void options_manager::add_options_world_default()
          14, 127, 30
        );
 
-    add( "CONSTRUCTION_SCALING", world_default, translate_marker( "Construction scaling" ),
+    add( "CONSTRUCTION_SCALING", world_default,
+         translate_marker( "Construction speed percentage" ),
          translate_marker( "Sets the time of construction in percents.  '50' is two times faster than default, '200' is two times longer.  '0' automatically scales construction time to match the world's season length." ),
-         0, 1000, 100
+         0, 1000, 100, COPT_NO_HIDE, "%i%%"
        );
 
-    add( "GROWTH_SCALING", world_default, translate_marker( "Growth scaling" ),
+
+    add( "CRAFTING_SPEED_MULT", world_default, translate_marker( "Crafting speed percentage" ),
+         translate_marker( "Sets default crafting speed in percents.  '50' is two times slower than default, '200' is two times faster." ),
+         0, 1000, 100, COPT_NO_HIDE, "%i%%"
+       );
+
+    add( "GROWTH_SCALING", world_default, translate_marker( "Growth scaling factor" ),
          translate_marker( "Sets the time of crop growth in percents.  '50' is two times faster than default, '200' is two times longer.  '0' automatically scales growth time to match the world's season length." ),
          0, 1000, 0
        );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2433,6 +2433,13 @@ void options_manager::add_options_world_default()
          0.0, 100, 2.0, 0.01
        );
 
+    add( "CRAFTING_SPEED_MULT", world_default, translate_marker( "Crafting speed scaling factor" ),
+         translate_marker( "A scaling factor that determines crafting speed.  The player will give up if total speed multiplier is below 20%." ),
+         0.01, 10.0, 1.0, 0.01
+       );
+
+    add_empty_line();
+
     add( "RESTOCK_DELAY_MULT", world_default, translate_marker( "Merchant restock scaling factor" ),
          translate_marker( "A scaling factor that determines restock rate of merchants." ),
          0.01, 10.0, 1.0, 0.01

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -217,7 +217,7 @@ static std::string craft_progress_message( const avatar &u, const player_activit
     const float assist_total_moves = std::max( 1, rec.batch_time( craft->charges, 1.0f, assistants ) );
     const float assist_mult = base_total_moves / assist_total_moves;
     const float speed_mult = u.get_speed() / 100.0f;
-    const float game_opt_mult = get_option<float>( "CRAFTING_SPEED_MULT" );
+    const float game_opt_mult = get_option<int>( "CRAFTING_SPEED_MULT" ) / 100.0f;
     const float total_mult = light_mult * bench_mult * morale_mult * assist_mult * speed_mult *
                              game_opt_mult;
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -24,6 +24,7 @@
 #include "itype.h"
 #include "map.h"
 #include "npc.h"
+#include "options.h"
 #include "player.h"
 #include "profile.h"
 #include "recipe.h"
@@ -216,7 +217,9 @@ static std::string craft_progress_message( const avatar &u, const player_activit
     const float assist_total_moves = std::max( 1, rec.batch_time( craft->charges, 1.0f, assistants ) );
     const float assist_mult = base_total_moves / assist_total_moves;
     const float speed_mult = u.get_speed() / 100.0f;
-    const float total_mult = light_mult * bench_mult * morale_mult * assist_mult * speed_mult;
+    const float game_opt_mult = get_option<float>( "CRAFTING_SPEED_MULT" );
+    const float total_mult = light_mult * bench_mult * morale_mult * assist_mult * speed_mult *
+                             game_opt_mult;
 
     const double remaining_percentage = 1.0 - craft->item_counter / 10'000'000.0;
     int remaining_turns = remaining_percentage * base_total_moves / 100 / std::max( 0.01f, total_mult );


### PR DESCRIPTION
## Purpose of change (The Why)
Resolves https://github.com/cataclysmbnteam/Cataclysm-BN/issues/7041
World setting names are all over the place and can be confusing
## Describe the solution (The How)
Remove hardcoding related to `PACKMULE` and `DISORGANIZED` and replace it with `packmule_modifier` which modifies how effectively the player can use space in a storage container. Replace the definitions of these to use this new modifier value.

Add a world setting for crafting speed. Note that this functions a bit awkwardly when paired with construction speed, as setting both to 500% causes construction speed to be slower and crafting speed to be faster.

Standardize the world settings tab so the names include "percentage" if its a percent, or "factor" if it's a scaling factor. This allows players to more intuitively use these options without reading the specific examples for each.
## Describe alternatives you've considered

Not including "percentage"? It's obviously a given considering it displays a percent next to the number, but it seems reasonable enough to distinguish the two still by name.

## Testing

Set crafting speed to 25% and then to 200%. Ensured it slowed me down, and then sped me up respectively.

Gave myself `PACKMULE` with debug, and ensured it worked as expected and seems to function the same as before. Ditto with `DISORGANIZED`.

Didn't seem to get any load errors with the changed setting names. Not that I expected this to happen anyways, as we are just changing the display string and not the actual ID.

## Additional context
I need to document the `packmule_modifier` still, and lua may also need a change related to resetting the value? Similar to how hp_modifier does? Should probably wait to figure this out before merging.

<img width="968" height="780" alt="image" src="https://github.com/user-attachments/assets/c1d9821e-1784-4fde-8bce-47258e4cf879" />
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


### Optional
- [X] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
<!--
- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
