### PR TITLE
feat: port `starting_cash`, money piles and tub, ATM improvement

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -5735,5 +5735,29 @@
     "components": [ [ [ "concrete", 8 ] ], [ [ "wood_structural", 12, "LIST" ] ], [ [ "water", 8 ], [ "water_clean", 8 ] ] ],
     "pre_terrain": "t_rock",
     "post_terrain": "t_sconc_wall"
+  },
+  {
+    "type": "construction",
+    "id": "constr_bathtub_money",
+    "group": "build_bathtub_money",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "5 m",
+    "components": [ [ [ "money_pile", 1 ] ] ],
+    "dark_craftable": true,
+    "pre_furniture": "f_bathtub",
+    "post_furniture": "f_bathtub_money"
+  },
+  {
+    "type": "construction",
+    "id": "constr_revert_bathtub_money",
+    "group": "remove_bathtub_money",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "2 m",
+    "dark_craftable": true,
+    "pre_furniture": "f_bathtub_money",
+    "byproducts": [ { "item": "money_pile" } ],
+    "post_furniture": "f_bathtub"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1578,5 +1578,15 @@
     "type": "construction_group",
     "id": "build_adobe_roof",
     "name": "Build Roof Over Adobe Floor"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_bathtub_money",
+    "name": "Fill Bathtub with Money"
+  },
+  {
+    "type": "construction_group",
+    "id": "remove_bathtub_money",
+    "name": "Remove Money from Bathtub"
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-sleep.json
+++ b/data/json/furniture_and_terrain/furniture-sleep.json
@@ -256,5 +256,34 @@
       "sound_fail": "whump.",
       "items": [ { "item": "felt_patch", "count": [ 40, 55 ] }, { "item": "yarn", "count": [ 500, 650 ] } ]
     }
+  },
+  {
+    "type": "furniture",
+    "id": "f_bathtub_money",
+    "name": "bathtub full of money",
+    "symbol": "~",
+    "description": "You could lay in and take a soothing bath, if there were running water.  Instead, you have a bathtub full of cash.  Now you can lay in it and take a scrooge mcduck-style slumber.",
+    "color": "white",
+    "move_cost_mod": 3,
+    "coverage": 40,
+    "comfort": 5,
+    "floor_bedding_warmth": 700,
+    "required_str": -1,
+    "looks_like": "f_bathtub",
+    "flags": [ "TRANSPARENT", "BLOCKSDOOR", "MOUNTABLE" ],
+    "bash": {
+      "str_min": 12,
+      "str_max": 50,
+      "sound": "porcelain breaking!",
+      "sound_fail": "whunk!",
+      "items": [
+        { "item": "cu_pipe", "prob": 50 },
+        { "item": "water_faucet", "prob": 50 },
+        { "item": "money_bundle", "count": [ 4, 10 ] },
+        { "item": "ceramic_shard", "count": [ 6, 18 ] }
+      ],
+      "//": "ceramic obstacles have destroy_threshold equal to str_min since more fragile",
+      "ranged": { "reduction": [ 12, 12 ], "destroy_threshold": 12, "block_unaimed_chance": "25%" }
+    }
   }
 ]

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2229,6 +2229,7 @@
       [ "gold_small", 10 ],
       [ "silver_small", 30 ],
       [ "money_bundle", 50 ],
+      [ "money_pile", 25 ],
       [ "pocketwatch", 11 ],
       [ "gold_watch", 12 ],
       [ "sf_watch", 10 ],

--- a/data/json/itemgroups/Locations_MapExtras/mansion.json
+++ b/data/json/itemgroups/Locations_MapExtras/mansion.json
@@ -193,6 +193,7 @@
       [ "file", 70 ],
       { "group": "jewelry_front", "prob": 40 },
       [ "money_bundle", 50 ],
+      [ "money_pile", 10 ],
       { "group": "mansion_guns", "prob": 95 },
       { "group": "mansion_guns", "prob": 80 }
     ]
@@ -203,6 +204,7 @@
     "subtype": "collection",
     "items": [
       [ "money_bundle", 20 ],
+      [ "money_pile", 4 ],
       { "group": "mansion_ammo", "prob": 100 },
       { "group": "mansion_guns", "prob": 40 },
       { "group": "mansion_guns", "prob": 80 },

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -927,6 +927,7 @@
       { "item": "creepy_doll", "prob": 1 },
       { "item": "straw_doll", "prob": 1 },
       { "item": "money_bundle", "prob": 30 },
+      { "item": "money_pile", "prob": 1 },
       { "item": "wristwatch", "prob": 15 },
       { "item": "balloon", "prob": 5 },
       { "item": "diving_watch", "prob": 5 },

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -90,7 +90,8 @@
         ],
         "prob": 50
       },
-      { "item": "money_bundle", "count": [ 5, 50 ], "prob": 50 }
+      { "item": "money_bundle", "count": [ 5, 50 ], "prob": 50 },
+      { "item": "money_pile", "count": [ 1, 3 ], "prob": 10 }
     ]
   }
 ]

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2370,6 +2370,21 @@
   },
   {
     "type": "GENERIC",
+    "id": "money_pile",
+    "symbol": ",",
+    "color": "light_green",
+    "name": { "str": "pile of money", "str_pl": "piles of money" },
+    "looks_like": "money_bundle",
+    "category": "valuables",
+    "description": "A pile of cash.  Can be used to fill a bathtub with cash or as a comforting reminder of the past.",
+    "material": [ "paper" ],
+    "flags": ["TRADER_AVOID", "SLEEP_AID" ],
+    "weight": "200 g",
+    "volume": "2500 ml",
+    "to_hit": -2
+  },
+  {
+    "type": "GENERIC",
     "id": "straw_doll",
     "symbol": "o",
     "color": "light_gray",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2378,7 +2378,7 @@
     "category": "valuables",
     "description": "A pile of cash.  Can be used to fill a bathtub with cash or as a comforting reminder of the past.",
     "material": [ "paper" ],
-    "flags": ["TRADER_AVOID", "SLEEP_AID" ],
+    "flags": [ "TRADER_AVOID", "SLEEP_AID" ],
     "weight": "200 g",
     "volume": "2500 ml",
     "to_hit": -2

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -5630,6 +5630,7 @@
     "points": 4,
     "skills": [ { "level": 4, "name": "barter" }, { "level": 6, "name": "speech" } ],
     "traits": [ "LIAR" ],
+    "starting_cash": 2000000,
     "items": {
       "both": [
         "suit",
@@ -5844,6 +5845,7 @@
     "name": { "male": "Hitman", "female": "Hitwoman" },
     "description": "You were a killer for hire, trained and equipped to efficiently eliminate your target while keeping a low profile.  No one's hiring now that the world's ended, but your skills may prove useful for staying alive.",
     "points": 5,
+    "starting_cash": 2000000,
     "skills": [
       { "level": 3, "name": "dodge" },
       { "level": 1, "name": "melee" },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1086,6 +1086,7 @@
     "id": "davy_jones",
     "name": "Davy Jones",
     "description": "You were robbed, shot in the head and thrown into the sea just before the Cataclysm. Now you have risen undead from the depths, with a thirst for vengeance against those who wronged you, and a desire to reclaim your lost treasures.",
+    "starting_cash": 0,
     "points": 2,
     "traits": [
       "SCHIZOPHRENIC",
@@ -1118,6 +1119,7 @@
     "id": "lagoon_creature",
     "name": "Creature of the Lagoon",
     "description": "Ascending from the muck, you've been granted a new life by the Cataclysm. A far cry from your previous existence, you now find yourself a creature of the deep, struggling to understand your new form and purpose.",
+    "starting_cash": 0,
     "points": 1,
     "traits": [ "UNSTABLE", "SLIME_HANDS", "PER_SLIME", "VISCOUS", "AMORPHOUS", "FRESHWATEROSMOSIS", "THRESH_SLIME" ],
     "skills": [ { "level": 2, "name": "swimming" }, { "level": 2, "name": "dodge" } ],
@@ -1845,6 +1847,7 @@
           "switchblade",
           "mag_porn",
           "sunglasses",
+          "money_bundle",
           "diving_watch"
         ],
         "entries": [
@@ -2007,6 +2010,7 @@
     "name": "Hobo",
     "description": "Society drove you to the fringes and set you wandering, with no home, no family, no friends, until you could only find solace in the bottom of a bottle.  But society doesn't mean a thing anymore, and for all the crap thrown your way, you're still standing.  God damn, you need a drink.",
     "points": -1,
+    "starting_cash": 0,
     "items": {
       "both": [
         "pants",
@@ -2884,6 +2888,7 @@
     "id": "mutant_patient",
     "name": "Unwilling Mutant",
     "description": "You were a human guinea pig, used by laboratory technicians to understand the immense power of mutation.",
+    "starting_cash": 0,
     "points": -1,
     "items": { "both": [ "subsuit_xl" ], "male": [ "briefs" ], "female": [ "bra", "panties" ] },
     "flags": [ "SCEN_ONLY" ]
@@ -3840,6 +3845,7 @@
     "description": "Now instead of complaining about your fees, your clients try to eat your brain.  You can't tell which one is worse though.",
     "points": 1,
     "skills": [ { "level": 1, "name": "barter" }, { "level": 2, "name": "speech" } ],
+    "starting_cash": 1000000,
     "items": {
       "both": [
         "suit",
@@ -3851,7 +3857,6 @@
         "wristwatch",
         "smart_phone",
         "briefcase",
-        "money_bundle",
         "file"
       ],
       "male": [ "briefs" ],
@@ -5845,7 +5850,6 @@
     "name": { "male": "Hitman", "female": "Hitwoman" },
     "description": "You were a killer for hire, trained and equipped to efficiently eliminate your target while keeping a low profile.  No one's hiring now that the world's ended, but your skills may prove useful for staying alive.",
     "points": 5,
-    "starting_cash": 2000000,
     "skills": [
       { "level": 3, "name": "dodge" },
       { "level": 1, "name": "melee" },
@@ -5854,7 +5858,7 @@
     ],
     "items": {
       "both": {
-        "items": [ "fancy_sunglasses", "platinum_watch" ],
+        "items": [ "fancy_sunglasses", "platinum_watch", "money_bundle" ],
         "entries": [
           { "item": "shoulder_holster", "contents-group": "hitman_pistol" },
           { "item": "legpouch_large", "contents-group": "hitman_mags_ppq" }
@@ -5892,6 +5896,7 @@
     "name": "Assassin",
     "description": "You were the best undercover agent they had, sent on missions so vital that you had to take it even with the riots going on.  You've lost contact with your handler, you are all alone now.",
     "points": 5,
+    "starting_cash": 2000000,
     "skills": [
       { "level": 3, "name": "dodge" },
       { "level": 3, "name": "melee" },

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -869,5 +869,17 @@
     "result": "carbondioxide_tank",
     "time": "30 s",
     "components": [ [ [ "metal_tank_little", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "money_pile",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 0,
+    "time": "1 m",
+    "reversible": true,
+    "autolearn": true,
+    "components": [ [ [ "money_bundle", 10 ] ] ]
   }
 ]

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -131,9 +131,7 @@
     "items": {
       "both": {
         "items": [ "tux", "dress_shoes", "socks", "gold_watch", "undershirt", "smart_phone", "gasdiscount_platinum" ],
-        "entries": [
-          { "item": "afs_wraitheon_smartphone" }
-        ]
+        "entries": [ { "item": "afs_wraitheon_smartphone" } ]
       },
       "male": [ "briefs", "collarpin", "diamond_ring" ],
       "female": [ "panties", "hairpin", "pearl_collar" ]

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -98,6 +98,7 @@
     "description": "You worked as a technician in a sterile, high-security facility concerned with the fabrication of bionic implants.  The final evacuation order caught you in the middle of your 16 hour extended shift, and you barely managed to escape the building, tools in hand.",
     "points": 2,
     "skills": [ { "level": 4, "name": "electronics" } ],
+    "starting_cash": 50000,
     "items": {
       "both": {
         "items": [
@@ -110,8 +111,7 @@
           "boots",
           "backpack",
           "jeans"
-        ],
-        "entries": [ { "item": "cash_card", "charges": 50000 } ]
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -127,12 +127,11 @@
     "traits": [ "FLIMSY3", "SLOWHEALER3" ],
     "pets": [ { "name": "afs_mon_sentinel_lx", "amount": 2 } ],
     "skills": [ { "level": 6, "name": "speech" }, { "level": 6, "name": "computer" } ],
+    "starting_cash": 400000000,
     "items": {
       "both": {
         "items": [ "tux", "dress_shoes", "socks", "gold_watch", "undershirt", "smart_phone", "gasdiscount_platinum" ],
         "entries": [
-          { "item": "cash_card", "charges": 200000000 },
-          { "item": "cash_card", "charges": 200000000 },
           { "item": "afs_wraitheon_smartphone" }
         ]
       },
@@ -188,6 +187,7 @@
     "name": "Assistant Sub-Executive",
     "description": "Through a lifetime of hard work, dedication, boot-licking and immense luck, you achieved the almost impossible, and were promoted from an indentured clerk to a minor managerial position.  Although you were still an expendable peon among the ranks of the corporation, you earned numbers most people could only dream of, and you savored it.",
     "points": 2,
+    "starting_cash": 200000000,
     "items": {
       "both": {
         "items": [ "tux", "dress_shoes", "socks", "gold_watch", "undershirt", "smart_phone", "gasdiscount_platinum" ],

--- a/docs/en/mod/json/reference/professions.md
+++ b/docs/en/mod/json/reference/professions.md
@@ -243,3 +243,9 @@ Mods can modify this via `add:CBMs` and `remove:CBMs`.
 A list of trait/mutation ids that are applied to the character.
 
 Mods can modify this via `add:traits` and `remove:traits`.
+
+#### `starting_cash`
+
+(optional, int)
+
+The amount of money this profession will start with upon the beginning of the cataclysm.

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -447,6 +447,9 @@ class atm_menu
             }
         }
     private:
+        int value_of_money_bundle = item::spawn_temporary( itype_money_bundle,
+                                    calendar::start_of_cataclysm )->price( false );
+
         void add_choice( const int i, const char *const title ) {
             amenu.addentry( i, true, -1, title );
         }
@@ -484,14 +487,14 @@ class atm_menu
                 add_info( purchase_card, _( "You need $10.00 in your account to purchase a card." ) );
             }
 
-            if( u.cash > 40000 ) {
+            if( u.cash > value_of_money_bundle ) {
                 add_choice( withdraw_cash, _( "Withdraw cash" ) );
             } else if( u.cash < 0 ) {
                 add_info( withdraw_cash,
                           _( "You need to pay down your debt before withdrawing cash!" ) );
             } else {
                 add_info( withdraw_cash,
-                          _( "You don't have enough to withdraw a bundle!" ) );
+                          _( "You don't have enough to withdraw a money bundle!" ) );
             }
 
             if( cash_amount > 0 ) {
@@ -589,7 +592,7 @@ class atm_menu
             }
 
             u.use_charges( itype_money_bundle, amount );
-            u.cash += amount * 40000;
+            u.cash += amount * value_of_money_bundle;
             u.moves -= to_turns<int>( 10_seconds );
             finish_interaction();
 
@@ -660,7 +663,8 @@ class atm_menu
         bool do_withdraw_cash() {
             const int amount = prompt_for_amount( vgettext(
                     "Withdraw how much?  Max: %d bundles.  (0 to cancel) ",
-                    "Withdraw how much?  Max: %d bundles.  (0 to cancel) ", u.cash / 40000 ), u.cash / 40000 );
+                    "Withdraw how much?  Max: %d bundles.  (0 to cancel) ", u.cash / value_of_money_bundle ),
+                                                  u.cash / value_of_money_bundle );
 
             if( !amount ) {
                 return false;
@@ -670,7 +674,7 @@ class atm_menu
                 detached_ptr<item> card = item::spawn( "money_bundle", calendar::turn );
 
                 u.i_add( std::move( card ) );
-                u.cash -= 40000;
+                u.cash -= value_of_money_bundle;
             }
 
             u.moves -= to_turns<int>( 5_seconds );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -131,6 +131,7 @@ static const itype_id itype_battery( "battery" );
 static const itype_id itype_bot_broken_cyborg( "bot_broken_cyborg" );
 static const itype_id itype_bot_prototype_cyborg( "bot_prototype_cyborg" );
 static const itype_id itype_cash_card( "cash_card" );
+static const itype_id itype_money_bundle( "money_bundle" );
 static const itype_id itype_charcoal( "charcoal" );
 static const itype_id itype_chem_carbide( "chem_carbide" );
 static const itype_id itype_corpse( "corpse" );
@@ -403,7 +404,7 @@ class atm_menu
     public:
         // menu choices
         enum options : int {
-            cancel, purchase_card, deposit_money, withdraw_money, transfer_all_money
+            cancel, purchase_card, deposit_money, withdraw_money, deposit_cash, withdraw_cash, transfer_all_money
         };
 
         atm_menu()                           = delete;
@@ -427,6 +428,12 @@ class atm_menu
                         break;
                     case withdraw_money:
                         result = do_withdraw_money();
+                        break;
+                    case deposit_cash:
+                        result = do_deposit_cash();
+                        break;
+                    case withdraw_cash:
+                        result = do_withdraw_cash();
                         break;
                     case transfer_all_money:
                         result = do_transfer_all_money();
@@ -458,6 +465,7 @@ class atm_menu
 
         //! Reset and repopulate the menu; with a fair bit of work this could be more efficient.
         void reset( const bool clear = true ) {
+            const int cash_amount   = u.amount_of( itype_money_bundle );
             const int card_count   = u.amount_of( itype_cash_card );
             const int charge_count = card_count ? u.charges_of( itype_cash_card ) : 0;
 
@@ -471,32 +479,49 @@ class atm_menu
                                         format_money( u.cash ) );
 
             if( u.cash >= 1000 ) {
-                add_choice( purchase_card, _( "Purchase cash card?" ) );
+                add_choice( purchase_card, _( "Purchase cash card" ) );
             } else {
                 add_info( purchase_card, _( "You need $10.00 in your account to purchase a card." ) );
             }
 
+            if( u.cash > 40000 ) {
+                add_choice( withdraw_cash, _( "Withdraw cash" ) );
+            } else if( u.cash < 0 ) {
+                add_info( withdraw_cash,
+                          _( "You need to pay down your debt before withdrawing cash!" ) );
+            } else {
+                add_info( withdraw_cash,
+                          _( "You don't have enough to withdraw a bundle!" ) );
+            }
+
+            if( cash_amount > 0 ) {
+                add_choice( deposit_cash, _( "Deposit cash" ) );
+            } else {
+                add_info( deposit_cash,
+                          _( "You need cash to deposit!" ) );
+            }
+
             if( card_count && u.cash > 0 ) {
-                add_choice( withdraw_money, _( "Withdraw Money" ) );
+                add_choice( withdraw_money, _( "Withdraw onto cash card" ) );
             } else if( u.cash > 0 ) {
                 add_info( withdraw_money, _( "You need a cash card before you can withdraw money!" ) );
             } else if( u.cash < 0 ) {
                 add_info( withdraw_money,
-                          _( "You need to pay down your debt first!" ) );
+                          _( "You need to pay down your debt before withdrawing money onto a card!" ) );
             } else {
                 add_info( withdraw_money,
                           _( "You need money in your account before you can withdraw money!" ) );
             }
 
             if( charge_count ) {
-                add_choice( deposit_money, _( "Deposit Money" ) );
+                add_choice( deposit_money, _( "Deposit from cash card" ) );
             } else {
                 add_info( deposit_money,
                           _( "You need a charged cash card before you can deposit money!" ) );
             }
 
             if( card_count >= 2 && charge_count ) {
-                add_choice( transfer_all_money, _( "Transfer All Money" ) );
+                add_choice( transfer_all_money, _( "Combine cash cards" ) );
             }
         }
 
@@ -540,6 +565,32 @@ class atm_menu
             u.i_add( std::move( card ) );
             u.cash -= 1000;
             u.moves -= to_turns<int>( 5_seconds );
+            finish_interaction();
+
+            return true;
+        }
+
+        //!Deposit money from cash card into bank account.
+        bool do_deposit_cash() {
+            int money = u.charges_of( itype_money_bundle );
+
+            if( !money ) {
+                popup( _( "You can only deposit money from charged cash cards!" ) );
+                return false;
+            }
+
+            const int amount = prompt_for_amount( vgettext(
+                    "Deposit how many bundles?  Max: %d bundles.  (0 to cancel) ",
+                    "Deposit how many bundles?  Max: %d bundles.  (0 to cancel) ", money ),
+                                                  money );
+
+            if( !amount ) {
+                return false;
+            }
+
+            u.use_charges( itype_money_bundle, amount );
+            u.cash += amount * 40000;
+            u.moves -= to_turns<int>( 10_seconds );
             finish_interaction();
 
             return true;
@@ -600,6 +651,30 @@ class atm_menu
             dst->charges += amount;
             u.cash -= amount;
             u.moves -= to_turns<int>( 10_seconds );
+            finish_interaction();
+
+            return true;
+        }
+
+        //!Move money from bank account onto cash card.
+        bool do_withdraw_cash() {
+            const int amount = prompt_for_amount( vgettext(
+                    "Withdraw how much?  Max: %d bundles.  (0 to cancel) ",
+                    "Withdraw how much?  Max: %d bundles.  (0 to cancel) ", u.cash / 40000 ), u.cash / 40000 );
+
+            if( !amount ) {
+                return false;
+            }
+
+            for( int i = 0; i < amount; i++ ) {
+                detached_ptr<item> card = item::spawn( "money_bundle", calendar::turn );
+
+                u.i_add( std::move( card ) );
+                u.cash -= 40000;
+            }
+
+            u.moves -= to_turns<int>( 5_seconds );
+
             finish_interaction();
 
             return true;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1733,7 +1733,7 @@ tab_direction set_profession( avatar &u, points_left &points,
             if( !sorted_profs[cur_id]->spells().empty() ) {
                 buffer += colorize( _( "Spells:" ), c_light_blue ) + "\n";
                 for( const std::pair<spell_id, int> spell_pair : sorted_profs[cur_id]->spells() ) {
-                    buffer += string_format( _( "%s level %d" ), spell_pair.first->name, spell_pair.second ) + "\n";
+                    buffer += string_format( _( "%s level %d" ), spell_pair.first->name, spell_pair.second );
                 }
             }
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -576,7 +576,7 @@ bool avatar::create( character_type type, const std::string &tempname )
     }
 
     // setup staring bank money
-    cash = rng( -200000, 200000 );
+    cash = prof->starting_cash().value_or( rng( -200000, 200000 ) );
 
     if( has_trait( trait_XS ) ) {
         set_stored_kcal( 10000 );
@@ -1736,6 +1736,15 @@ tab_direction set_profession( avatar &u, points_left &points,
                     buffer += string_format( _( "%s level %d" ), spell_pair.first->name, spell_pair.second ) + "\n";
                 }
             }
+
+            // Profession money
+            std::optional<int> cash = sorted_profs[cur_id]->starting_cash();
+
+            if( cash.has_value() ) {
+                buffer += colorize( _( "Profession money:" ), c_light_blue ) + "\n";
+                buffer += format_money( cash.value() ) + "\n";
+            }
+
             const auto scroll_msg = string_format(
                                         _( "Press <color_light_green>%1$s</color> or <color_light_green>%2$s</color> to scroll." ),
                                         ctxt.get_desc( "LEFT" ),

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -237,6 +237,8 @@ void profession::load( const JsonObject &jo, const std::string & )
     }
     optional( jo, was_loaded, "no_bonus", no_bonus );
 
+    optional( jo, was_loaded, "starting_cash", _starting_cash );
+
     optional( jo, was_loaded, "skills", _starting_skills, skilllevel_reader {} );
     optional( jo, was_loaded, "addictions", _starting_addictions, addiction_reader {} );
     // TODO: use string_id<bionic_type> or so
@@ -373,6 +375,11 @@ static time_point advanced_spawn_time()
 signed int profession::point_cost() const
 {
     return _point_cost;
+}
+
+std::optional<int> profession::starting_cash() const
+{
+    return _starting_cash;
 }
 
 static void clear_faults( item &it )

--- a/src/profession.h
+++ b/src/profession.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <list>
+#include <optional>
 #include <map>
 #include <set>
 #include <string>
@@ -99,6 +100,7 @@ class profession
         std::string gender_appropriate_name( bool male ) const;
         std::string description( bool male ) const;
         signed int point_cost() const;
+        std::optional<signed int> starting_cash() const;
         std::vector<detached_ptr<item>> items( bool male, const std::vector<trait_id> &traits ) const;
         std::vector<addiction> addictions() const;
         vproto_id vehicle() const;
@@ -107,6 +109,8 @@ class profession
         StartingSkillList skills() const;
 
         std::map<spell_id, int> spells() const;
+
+        std::optional<signed int> _starting_cash = std::nullopt;
 
         /**
          * Check if this type of profession has a certain flag set.


### PR DESCRIPTION
## Purpose of change (The Why)
ports DDA change https://github.com/CleverRaven/Cataclysm-DDA/pull/79450
ATM's should be able to accept and dispense cash
## Describe the solution (The How)
Add two new functions to the ATM, cash withdrawal and cash depositing. You can currently only deposit and withdraw whole money bundles (400 USD at a time).

Adds `starting_cash` for professions to define how much cash they should start with and added them to our assassin and politician professions. Hitman and smuggler get money bundles, as they likely wouldn't have that sort of money in a bank account. Hobo gets 0, as they likely wouldn't have a bank account.

Adds `bathtub full of money` and `pile of money` which can be used as a bed, and as a sleep aid respectively. The pile of money loses it's `TINDER` flag as it's unlikely the player will want to burn it in this form, but the original money bundle kept it.
## Describe alternatives you've considered
## Testing
Spawned as a hitman, noticed I had 20,000 USD in my bank.

Spawned in some cash, deposited and withdrew it from the ATM. Used it to buy a cash card.
## Additional context
Feel free to suggest changes to other professions that should have starting money or starting debt. Could also reimplement the cut "Millionaire" profession, but unsure how we would make it distinct from the politician or whatever without being useless except for the money.

It may be worth lowering the in-universe value of a money bundle or reducing their spawns. Cash in ATM's shouldn't be unreasonably hard to get, but 400 a bundle is a pretty decent amount and may cause some gear that is listed in vending machines to become too easy to access. (higher than most cash cards, wny would people be walking around with this instead, lol?) Also cash is really good tinder currently, as it's useless. Would be interesting to keep it lower so players can still burn money all they want.
<img width="530" height="186" alt="image" src="https://github.com/user-attachments/assets/1acca7ba-2e1f-41c3-8b3e-228361ca7368" />
<img width="409" height="489" alt="image" src="https://github.com/user-attachments/assets/b93f9322-c2f1-4b27-baf3-b34cf69388ad" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
### Optional
- [X] This PR ports commits from DDA or other cataclysm forks.
  - [X] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [X] I have linked the URL of original PR(s) in the description.
<!--
please remove sections irrelevant to this PR.

### Optional
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
