### PR TITLE
fix: make world settings for crafting work as intended

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1888,7 +1888,7 @@ float construction::time_scale() const
         return 0.000001;
     } else {
         // this is hacky, but the player or their followers should only be the ones to ever construct currently.
-        return ( 100.0f / get_option<int>( "CONSTRUCTION_SCALING" ) ) /
+        return ( get_option<int>( "CONSTRUCTION_SCALING" ) / 100.0f ) /
                get_player_character().mutation_value( "construction_speed_modifier" );
     }
 }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1888,7 +1888,7 @@ float construction::time_scale() const
         return 0.000001;
     } else {
         // this is hacky, but the player or their followers should only be the ones to ever construct currently.
-        return ( get_option<int>( "CONSTRUCTION_SCALING" ) / 100.0 ) /
+        return ( 100.0f / get_option<int>( "CONSTRUCTION_SCALING" ) ) /
                get_player_character().mutation_value( "construction_speed_modifier" );
     }
 }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -251,7 +251,7 @@ float crafting_speed_multiplier( const Character &who, const recipe &rec, bool i
                          lighting_crafting_speed_multiplier( who,
                                  rec ) * ( get_option<int>( "CRAFTING_SPEED_MULT" ) == 0
                                            ? 9999
-                                           : get_option<int>( "CRAFTING_SPEED_MULT" ) / 100.0f ) *
+                                           : 100.0f / get_option<int>( "CRAFTING_SPEED_MULT" ) ) *
                          who.mutation_value( "crafting_speed_modifier" );
 
     return result;
@@ -272,7 +272,7 @@ float crafting_speed_multiplier( const Character &who, const item &craft,
     const float morale_multi = morale_crafting_speed_multiplier( who, rec );
     const float mutation_multi = who.mutation_value( "crafting_speed_modifier" );
     const float game_opt_multi = get_option<int>( "CRAFTING_SPEED_MULT" ) == 0 ? 9999 :
-                                 get_option<int>( "CRAFTING_SPEED_MULT" ) / 100.0f;
+                                 100.0f / get_option<int>( "CRAFTING_SPEED_MULT" );
 
     const float total_multi = light_multi * bench_multi * morale_multi * mutation_multi *
                               game_opt_multi;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -251,7 +251,7 @@ float crafting_speed_multiplier( const Character &who, const recipe &rec, bool i
                          lighting_crafting_speed_multiplier( who,
                                  rec ) * ( get_option<int>( "CRAFTING_SPEED_MULT" ) == 0
                                            ? 9999
-                                           : 100.0f / get_option<int>( "CRAFTING_SPEED_MULT" ) ) *
+                                           : get_option<int>( "CRAFTING_SPEED_MULT" ) / 100.0f ) *
                          who.mutation_value( "crafting_speed_modifier" );
 
     return result;

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -224,6 +224,8 @@ static std::string craft_progress_message( const avatar &u, const player_activit
     const float total_mult = light_mult * bench_mult * morale_mult * assist_mult * speed_mult *
                              mutation_mult * game_opt_mult;
 
+    // CRAFTING PROGRESS FOR ACTIVITY INDICATOR. THIS IS ONLY FOR DISPLAYING TIME, NOT THE ACTUAL TIME.
+    // THIS AFFECTS THE **ACTUAL** CRAFTING SPEED.
     const double remaining_percentage = 1.0 - craft->item_counter / 10'000'000.0;
     int remaining_turns = remaining_percentage * base_total_moves / 100 / std::max( 0.01f, total_mult );
     std::string time_desc = string_format( _( "Time left: %s" ),

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -220,7 +220,7 @@ static std::string craft_progress_message( const avatar &u, const player_activit
     const float mutation_mult = u.mutation_value( "crafting_speed_modifier" );
     const float game_opt_mult = get_option<int>( "CRAFTING_SPEED_MULT" ) == 0
                                 ? 9999
-                                : get_option<int>( "CRAFTING_SPEED_MULT" ) / 100.0f;
+                                : 100.0f / get_option<int>( "CRAFTING_SPEED_MULT" );
     const float total_mult = light_mult * bench_mult * morale_mult * assist_mult * speed_mult *
                              mutation_mult * game_opt_mult;
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -224,8 +224,6 @@ static std::string craft_progress_message( const avatar &u, const player_activit
     const float total_mult = light_mult * bench_mult * morale_mult * assist_mult * speed_mult *
                              mutation_mult * game_opt_mult;
 
-    // CRAFTING PROGRESS FOR ACTIVITY INDICATOR. THIS IS ONLY FOR DISPLAYING TIME, NOT THE ACTUAL TIME.
-    // THIS AFFECTS THE **ACTUAL** CRAFTING SPEED.
     const double remaining_percentage = 1.0 - craft->item_counter / 10'000'000.0;
     int remaining_turns = remaining_percentage * base_total_moves / 100 / std::max( 0.01f, total_mult );
     std::string time_desc = string_format( _( "Time left: %s" ),

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -220,7 +220,7 @@ static std::string craft_progress_message( const avatar &u, const player_activit
     const float mutation_mult = u.mutation_value( "crafting_speed_modifier" );
     const float game_opt_mult = get_option<int>( "CRAFTING_SPEED_MULT" ) == 0
                                 ? 9999
-                                : 100.0f / get_option<int>( "CRAFTING_SPEED_MULT" );
+                                : get_option<int>( "CRAFTING_SPEED_MULT" ) / 100.0f;
     const float total_mult = light_mult * bench_mult * morale_mult * assist_mult * speed_mult *
                              mutation_mult * game_opt_mult;
 


### PR DESCRIPTION
## Purpose of change (The Why)
The previous intended followup PR to fix this issue did NOT fix it. followup to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7146
## Describe the solution (The How)
Flip a fraction again. And again. And again.
## Describe alternatives you've considered
Giving up
## Testing
// TEST 1 (CONTROL):
// 50% speed
// straw hat = 42 minutes total. UI displays: 10 minutes and 10 minutes respectively. (200 speed mult displayed)
// 100% speed
// straw hat = 21 minutes total. UI displays: 20 minutes and 21 minutes respectively.
// 200% speed
// straw hat = 10 minutes total. UI displays: 40 minutes and 40 minutes respectively. (50 speed mult displayed)

// TEST 2 (AFTER CHANGES):
// 50% speed
// straw hat = 12 minutes total. UI displays: 10 minutes and 10 minutes respectively. (50 speed mult displayed)
// 100% speed
// straw hat = 21 minutes total. UI displays: 20 minutes and 21 minutes respectively.
// 200% speed
// straw hat = 42 minutes total. UI displays: 40 minutes and 40 minutes respectively. (200 speed mult displayed)

I believe this should work now. To commence the test:
Debug the Life Support, Invisibility, and Invincibility mutations. Spawn around 100 enemies just on the edge of the reality bubble. Set world time to 43200, so it is exactly 12:00PM on the first day. Spawn in 100 piles of straw (or Hammerspace mutation), and begin crafting. Adjust settings, and repeat. Note the time to complete in the crafting GUI, the player activity indicator's "time left" and the actual final time it took to complete the craft.

Repeat with construction and Hammerspace mutation. Ensure that the description in the world options matches the functionality in game.
## Additional context
We can't merge this until we get like 2-3 others confirming the behavior is correct and as expected, so staying as a draft until then.
## Checklist
### Mandatory
- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
