### PR TITLE
feat(balance): allow holsters to accept launchers, increase volume of M79, add folding stock to MGL

### DIFF
--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -122,7 +122,7 @@
       "type": "holster",
       "max_volume": "1 L",
       "min_volume": "250 ml",
-      "skills": [ "pistol", "smg", "shotgun", "rifle" ],
+      "skills": [ "pistol", "smg", "shotgun", "rifle", "launcher" ],
       "flags": [ "HOLSTER_PISTOL" ]
     },
     "flags": [ "WAIST", "COMPACT", "OVERSIZE", "ALLOWS_TAIL_SNAKE" ]
@@ -200,7 +200,12 @@
     "encumbrance": 4,
     "storage": "3 L",
     "material_thickness": 2,
-    "use_action": { "type": "holster", "max_volume": "3750 ml", "min_volume": "1250 ml", "skills": [ "smg", "shotgun", "rifle" ] },
+    "use_action": {
+      "type": "holster",
+      "max_volume": "3750 ml",
+      "min_volume": "1250 ml",
+      "skills": [ "smg", "shotgun", "rifle", "launcher" ]
+    },
     "valid_mods": [ "steel_padded", "alloy_padded", "resized_large" ],
     "flags": [ "WATER_FRIENDLY", "STURDY", "WAIST", "COMPACT" ]
   },
@@ -253,7 +258,7 @@
       "type": "holster",
       "min_volume": "750 ml",
       "max_volume": "1500 ml",
-      "skills": [ "pistol", "smg", "shotgun", "rifle" ],
+      "skills": [ "pistol", "smg", "shotgun", "rifle", "launcher" ],
       "flags": [ "HOLSTER_PISTOL" ]
     },
     "flags": [ "WAIST", "COMPACT", "OVERSIZE", "ALLOWS_TAIL_SNAKE" ]

--- a/data/json/items/gun/40x46mm.json
+++ b/data/json/items/gun/40x46mm.json
@@ -6,7 +6,7 @@
     "name": { "str": "tube 40mm launcher" },
     "description": "A simple, home-made grenade launcher.  Basically a tube with a pin firing mechanism to activate the grenade.",
     "weight": "2267 g",
-    "volume": "1250 ml",
+    "volume": "1500 ml",
     "barrel_length": "250 ml",
     "price": "400 USD",
     "price_postapoc": "750 cent",

--- a/data/json/items/gun/40x46mm.json
+++ b/data/json/items/gun/40x46mm.json
@@ -53,7 +53,7 @@
     "name": { "str": "M79 launcher" },
     "description": "A widely-used grenade launcher that first saw use by American forces in the Vietnam War.  Though mostly replaced by more modern launchers, the M79 still sees use with many units worldwide.",
     "weight": "2930 g",
-    "volume": "1 L",
+    "volume": "1300 ml",
     "barrel_length": "250 ml",
     "price": "4 kUSD",
     "price_postapoc": "25 USD",
@@ -99,7 +99,8 @@
       [ "rail", 1 ],
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
-    ]
+    ],
+    "default_mods": [ "folding_stock" ]
   },
   {
     "id": "rm802",


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Some adjustments to launchers after discussion in the BN discord. Idea is make grenade launchers work in appropriate holsters, and adjust some things to fit better.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Allowed holsters, XL holsters, and survivor harness to hold launchers. This allows the XL holster to hold an M79 as-is or an MGL with the folding stock mod, and a regular holster to hold one that's had the stock cut off (see below).
2. Bumped volume of M79 from 1 liter to 1300 ml, idea being it stays in XL holster range by default but gets pushed back into holster range if you cut the stock off.
3. Adjusted makeshift launcher up to 1500 ml to remain beefier than the proper factory version, still makes the single-barrel version fit within an XL holster normally and a normal holster when stockless, while making the triple-barrel still require modification to fit in an XL holster.
4. Added folding stock to the MGL as a default gunmod, so that by default they can fit in a XL holster:
<img width="450" height="248" alt="image" src="https://github.com/user-attachments/assets/4e22d103-8d70-41f3-918c-082c5af269ff" />

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Checked that an M79 can fit in an XL holster but not a regular one.
5. Sawed its stock off, confirmed it can now fit in a regular holster.
6. Spawned an MGL, confirmed it fits in an XL holster.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
