### PR TITLE
ci: pin llvm to v20 for macOS

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel llvm astyle sqlite3 zlib
+          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel llvm@20 astyle sqlite3 zlib
           python3 -m venv ./venv
           source ./venv/bin/activate
           pip3 install mac_alias==2.2.0 dmgbuild==1.6.1 biplist polib luaparser


### PR DESCRIPTION
## Purpose of change (The Why)

v21 of Clang causes mac builds to fail due to a regression in obtaining libraries or something, causing it to think hash_memory in STD doesn't exist

v20 worked just fine in the past, and is already a VERY modern version of Clang. By the time we need anything it doesn't have, the regression should be fixed upstream in some way (or we can just work around it with some extra flags to clang)

## Describe the solution (The How)

Pin llvm for OSX builds to version 20 instead of 21 in CI

## Describe alternatives you've considered

- Do the workaround

This is less effort, and it'd be for the same result practically.

## Testing

CI, testing cannot be done locally.

## Additional context

At least it's MacOS instead of Linux or Windows, so it's only a smol (but still valued) portion of the playerbase.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

