### PR TITLE
build: update vcpkg package baselines

### DIFF
--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -6,9 +6,10 @@
     { "name": "sdl2-image", "features": [ "libjpeg-turbo" ] },
     { "name": "sdl2-mixer", "features": [ "libflac", "mpg123", "libmodplug" ] },
     "sdl2-ttf",
-    "sqlite3", "zlib"
+    "sqlite3",
+    "zlib"
   ],
-  "builtin-baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f",
+  "builtin-baseline": "b3e47eb102c805265d4cb0122cfecbb9b91a1337",
   "overrides": [
     { "name": "sdl2-mixer", "version": "2.6.3#1" }
   ],

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -9,7 +9,7 @@
     "sqlite3",
     "zlib"
   ],
-  "builtin-baseline": "b3e47eb102c805265d4cb0122cfecbb9b91a1337",
+  "builtin-baseline": "b1b19307e2d2ec1eefbdb7ea069de7d4bcd31f01",
   "overrides": [
     { "name": "sdl2-mixer", "version": "2.6.3#1" }
   ],


### PR DESCRIPTION
## Purpose of change (The Why)

The build is failing due to being unable to download libogg.

This appears to be because the gitlab for libogg is VERY unstable now, likely for AI-related essentially DDOS reasons.

A fix was merged a few days ago in vcpkg, but we won't catch it unless we update the package baselines.
I decided to just update the commit hash to the latest commit to the file, and if necessary will work backwards from there.

## Describe the solution (The How)

Updates the vcpkg baseline for packages to the latest commit to the JSON file.

## Describe alternatives you've considered

- Manually specify it
- Be more conservative with the commit hash to update to

## Testing

I'm not on Windows, so my testing will be done through Github building

## Additional context

What the fix actually is, is literally just changing the download source from the gitlab for OGG to the git*hub* for OGG

I learned of this fix from searching around vcpkg's closed issues a lil.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
