### PR TITLE
feat(port): port overmap tileset option from DDA

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7214,11 +7214,35 @@ void game::zoom_out()
 #endif
 }
 
+void game::zoom_out_overmap()
+{
+#if defined(TILES)
+    if( overmap_tileset_zoom > MAXIMUM_ZOOM_LEVEL ) {
+        overmap_tileset_zoom /= 2;
+    } else {
+        overmap_tileset_zoom = 64;
+    }
+    overmap_tilecontext->set_draw_scale( overmap_tileset_zoom );
+#endif
+}
+
 void game::zoom_in()
 {
 #if defined(TILES)
     tileset_zoom = calc_next_zoom( tileset_zoom, 1 );
     rescale_tileset( tileset_zoom );
+#endif
+}
+
+void game::zoom_in_overmap()
+{
+#if defined(TILES)
+    if( overmap_tileset_zoom == 64 ) {
+        overmap_tileset_zoom = MAXIMUM_ZOOM_LEVEL;
+    } else {
+        overmap_tileset_zoom *= 2;
+    }
+    overmap_tilecontext->set_draw_scale( overmap_tileset_zoom );
 #endif
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -449,7 +449,7 @@ void game::reload_tileset( [[maybe_unused]] const std::function<void( std::strin
     } catch( const std::exception &err ) {
         popup( _( "Loading the tileset failed: %s" ), err.what() );
     }
-	try {
+    try {
         overmap_tilecontext->reinit();
         std::vector<mod_id> dummy;
         overmap_tilecontext->load_tileset(

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -449,6 +449,20 @@ void game::reload_tileset( [[maybe_unused]] const std::function<void( std::strin
     } catch( const std::exception &err ) {
         popup( _( "Loading the tileset failed: %s" ), err.what() );
     }
+	try {
+        overmap_tilecontext->reinit();
+        std::vector<mod_id> dummy;
+        overmap_tilecontext->load_tileset(
+            get_option<std::string>( "OVERMAP_TILES" ),
+            world_generator->active_world ? world_generator->active_world->info->active_mod_order : dummy,
+            /*precheck=*/false,
+            /*force=*/true,
+            /*pump_events=*/true
+        );
+        overmap_tilecontext->do_tile_loading_report( out );
+    } catch( const std::exception &err ) {
+        popup( _( "Loading the overmap tileset failed: %s" ), err.what() );
+    }
     g->reset_zoom();
     g->mark_main_ui_adaptor_resize();
 #endif // TILES

--- a/src/game.h
+++ b/src/game.h
@@ -586,6 +586,8 @@ class game
         void reload_tileset( const std::function<void( std::string )> &out );
         void temp_exit_fullscreen();
         void reenter_fullscreen();
+        void zoom_in_overmap();
+        void zoom_out_overmap();
         void zoom_in();
         void zoom_out();
         void reset_zoom();
@@ -1044,6 +1046,7 @@ class game
 
         /** How far the tileset should be zoomed out, 16 is default. 32 is zoomed in by x2, 8 is zoomed out by x0.5 */
         float tileset_zoom = 0;
+        int overmap_tileset_zoom = DEFAULT_TILESET_ZOOM;
 
         /** Seed for all the random numbers that should have consistent randomness (weather). */
         unsigned int seed = 0;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2024,7 +2024,7 @@ void options_manager::add_options_graphics()
 	
 	add( "OVERMAP_TILES", graphics, translate_marker( "Choose overmap tileset" ),
          translate_marker( "Choose the overmap tileset you want to use." ),
-         build_tilesets_list(), "retrodays", COPT_CURSES_HIDE
+         build_tilesets_list(), "UNDEAD_PEOPLE_BASE", COPT_CURSES_HIDE
        ); // populate the options dynamically
 
     get_option( "OVERMAP_TILES" ).setPrerequisite( "USE_TILES_OVERMAP" );
@@ -3059,7 +3059,7 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
                 get_option<std::string>( "OVERMAP_TILES" ),
                 ingame ? world_generator->active_world->info->active_mod_order : dummy,
                 /*precheck=*/false,
-                /*force=*/false,
+                /*force=*/force_tile_change,
                 /*pump_events=*/true
             );
             //game_ui::init_ui is called when zoom is changed

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2021,8 +2021,8 @@ void options_manager::add_options_graphics()
        );
 
     get_option( "USE_TILES_OVERMAP" ).setPrerequisite( "USE_TILES" );
-	
-	add( "OVERMAP_TILES", graphics, translate_marker( "Choose overmap tileset" ),
+
+    add( "OVERMAP_TILES", graphics, translate_marker( "Choose overmap tileset" ),
          translate_marker( "Choose the overmap tileset you want to use." ),
          build_tilesets_list(), "UNDEAD_PEOPLE_BASE", COPT_CURSES_HIDE
        ); // populate the options dynamically
@@ -3051,10 +3051,10 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
             use_tiles = false;
             use_tiles_overmap = false;
         }
-		try {
+        try {
             overmap_tilecontext->reinit();
             std::vector<mod_id> dummy;
-            
+
             overmap_tilecontext->load_tileset(
                 get_option<std::string>( "OVERMAP_TILES" ),
                 ingame ? world_generator->active_world->info->active_mod_order : dummy,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3588,7 +3588,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                 || iter.first == "PIXEL_MINIMAP_SCALE_TO_FIT" ) {
                 pixel_minimap_changed = true;
             } else if( iter.first == "TILES" || iter.first == "USE_TILES" || iter.first == "STATICZEFFECT" ||
-                       iter.first == "MEMORY_MAP_MODE" || iter.first == "OVERMAP_TILES") {
+                       iter.first == "MEMORY_MAP_MODE" || iter.first == "OVERMAP_TILES" ) {
                 used_tiles_changed = true;
                 if( iter.first == "STATICZEFFECT" || iter.first == "MEMORY_MAP_MODE" ) {
                     force_tile_change = true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3587,6 +3587,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                 || iter.first == "PIXEL_MINIMAP_MODE"
                 || iter.first == "PIXEL_MINIMAP_SCALE_TO_FIT" ) {
                 pixel_minimap_changed = true;
+
             } else if( iter.first == "TILES" || iter.first == "USE_TILES" || iter.first == "STATICZEFFECT" ||
                        iter.first == "MEMORY_MAP_MODE" || iter.first == "OVERMAP_TILES" ) {
                 used_tiles_changed = true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3587,9 +3587,8 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                 || iter.first == "PIXEL_MINIMAP_MODE"
                 || iter.first == "PIXEL_MINIMAP_SCALE_TO_FIT" ) {
                 pixel_minimap_changed = true;
-
             } else if( iter.first == "TILES" || iter.first == "USE_TILES" || iter.first == "STATICZEFFECT" ||
-                       iter.first == "MEMORY_MAP_MODE" ) {
+                       iter.first == "MEMORY_MAP_MODE" || iter.first == "OVERMAP_TILES") {
                 used_tiles_changed = true;
                 if( iter.first == "STATICZEFFECT" || iter.first == "MEMORY_MAP_MODE" ) {
                     force_tile_change = true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2021,6 +2021,13 @@ void options_manager::add_options_graphics()
        );
 
     get_option( "USE_TILES_OVERMAP" ).setPrerequisite( "USE_TILES" );
+	
+	add( "OVERMAP_TILES", graphics, translate_marker( "Choose overmap tileset" ),
+         translate_marker( "Choose the overmap tileset you want to use." ),
+         build_tilesets_list(), "retrodays", COPT_CURSES_HIDE
+       ); // populate the options dynamically
+
+    get_option( "OVERMAP_TILES" ).setPrerequisite( "USE_TILES_OVERMAP" );
 
     add( "USE_CHARACTER_PREVIEW", graphics, translate_marker( "Enable character preview window" ),
          translate_marker( "If true, shows character preview window in traits tab on character creation.  "
@@ -3041,6 +3048,28 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
             } );
         } catch( const std::exception &err ) {
             popup( _( "Loading the tileset failed: %s" ), err.what() );
+            use_tiles = false;
+            use_tiles_overmap = false;
+        }
+		try {
+            overmap_tilecontext->reinit();
+            std::vector<mod_id> dummy;
+            
+            overmap_tilecontext->load_tileset(
+                get_option<std::string>( "OVERMAP_TILES" ),
+                ingame ? world_generator->active_world->info->active_mod_order : dummy,
+                /*precheck=*/false,
+                /*force=*/false,
+                /*pump_events=*/true
+            );
+            //game_ui::init_ui is called when zoom is changed
+            g->reset_zoom();
+            g->mark_main_ui_adaptor_resize();
+            overmap_tilecontext->do_tile_loading_report( []( const std::string & str ) {
+                DebugLog( DL::Info, DC::Main ) << str;
+            } );
+        } catch( const std::exception &err ) {
+            popup( _( "Loading the overmap tileset failed: %s" ), err.what() );
             use_tiles = false;
             use_tiles_overmap = false;
         }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -2054,10 +2054,10 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
         } else if( action == "LEVEL_UP" && curs.z() < OVERMAP_HEIGHT ) {
             curs.z() += 1;
         } else if( action == "ZOOM_OUT" ) {
-            g->zoom_out();
+            g->zoom_out_overmap();
             ui.mark_resize();
         } else  if( action == "ZOOM_IN" ) {
-            g->zoom_in();
+            g->zoom_in_overmap();
             ui.mark_resize();
         } else if( action == "CONFIRM" ) {
             ret = curs;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -866,22 +866,22 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
         geometry->rect( renderer, clipRect, SDL_Color() );
     }
 
+    point s;
+    get_window_tile_counts( width, height, s.x, s.y );
+
     op = point( dest.x * fontwidth, dest.y * fontheight );
     // Rounding up to include incomplete tiles at the bottom/right edges
     screentile_width = divide_round_up( width, tile_width );
     screentile_height = divide_round_up( height, tile_height );
 
-    window_dimensions wnd_dim = get_window_dimensions( g->w_overmap );
-
     const int min_col = 0;
-    const int max_col = screentile_width;
+    const int max_col = s.x;
     const int min_row = 0;
-    const int max_row = screentile_height;
+    const int max_row = s.y;
     int height_3d = 0;
     avatar &you = get_avatar();
     const tripoint_abs_omt avatar_pos = you.global_omt_location();
-    const tripoint_abs_omt corner_NW = center_abs_omt - point( wnd_dim.window_size_cell.x / 2,
-                                       wnd_dim.window_size_cell.y / 2 );
+    const tripoint_abs_omt corner_NW = center_abs_omt - point( max_col / 2, max_row / 2 );
     const tripoint_abs_omt corner_SE = corner_NW + point( max_col - 1, max_row - 1 );
     const inclusive_cuboid<tripoint> overmap_area( corner_NW.raw(), corner_SE.raw() );
     // Debug vision allows seeing everything
@@ -3804,8 +3804,8 @@ static window_dimensions get_window_dimensions( const catacurses::window &win,
     } else if( overmap_font && g && win == g->w_overmap ) {
         if( use_tiles && use_tiles_overmap ) {
             // tiles might have different dimensions than standard font
-            dim.scaled_font_size.x = tilecontext->get_tile_width();
-            dim.scaled_font_size.y = tilecontext->get_tile_height();
+            dim.scaled_font_size.x = overmap_tilecontext->get_tile_width();
+            dim.scaled_font_size.y = overmap_tilecontext->get_tile_height();
         } else {
             dim.scaled_font_size.x = overmap_font->width;
             dim.scaled_font_size.y = overmap_font->height;
@@ -3926,7 +3926,7 @@ static int map_font_height()
 static int overmap_font_width()
 {
     if( use_tiles && tilecontext && use_tiles_overmap ) {
-        return tilecontext->get_tile_width();
+        return overmap_tilecontext->get_tile_width();
     }
     return ( overmap_font ? overmap_font.get() : font.get() )->width;
 }
@@ -3934,7 +3934,7 @@ static int overmap_font_width()
 static int overmap_font_height()
 {
     if( use_tiles && tilecontext && use_tiles_overmap ) {
-        return tilecontext->get_tile_height();
+        return overmap_tilecontext->get_tile_height();
     }
     return ( overmap_font ? overmap_font.get() : font.get() )->height;
 }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3605,7 +3605,7 @@ void catacurses::init_interface()
         // Setting it to false disables this from getting used.
         use_tiles = false;
     }
-	overmap_tilecontext = std::make_unique<cata_tiles>( renderer, geometry );
+    overmap_tilecontext = std::make_unique<cata_tiles>( renderer, geometry );
     try {
         std::vector<mod_id> dummy;
         overmap_tilecontext->load_tileset(
@@ -3663,8 +3663,8 @@ void load_tileset()
     tilecontext->do_tile_loading_report( []( const std::string & str ) {
         DebugLog( DL::Info, DC::Main ) << str;
     } );
-    
-	if( overmap_tilecontext ) {
+
+    if( overmap_tilecontext ) {
         overmap_tilecontext->load_tileset(
             get_option<std::string>( "OVERMAP_TILES" ),
             world_generator->active_world->info->active_mod_order,

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3682,6 +3682,7 @@ void load_tileset()
 void catacurses::endwin()
 {
     tilecontext.reset();
+    overmap_tilecontext.reset();
     font.reset();
     map_font.reset();
     overmap_font.reset();

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3926,7 +3926,7 @@ static int map_font_height()
 
 static int overmap_font_width()
 {
-    if( use_tiles && tilecontext && use_tiles_overmap ) {
+    if( use_tiles && overmap_tilecontext && use_tiles_overmap ) {
         return overmap_tilecontext->get_tile_width();
     }
     return ( overmap_font ? overmap_font.get() : font.get() )->width;
@@ -3934,7 +3934,7 @@ static int overmap_font_width()
 
 static int overmap_font_height()
 {
-    if( use_tiles && tilecontext && use_tiles_overmap ) {
+    if( use_tiles && overmap_tilecontext && use_tiles_overmap ) {
         return overmap_tilecontext->get_tile_height();
     }
     return ( overmap_font ? overmap_font.get() : font.get() )->height;

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -18,6 +18,7 @@ class window;
 } // namespace catacurses
 
 extern std::unique_ptr<cata_tiles> tilecontext;
+extern std::unique_ptr<cata_tiles> overmap_tilecontext;
 extern std::array<SDL_Color, color_loader<SDL_Color>::COLOR_NAMES_COUNT> windowsPalette;
 
 // This function may refresh the screen, so it should not be used where tiles


### PR DESCRIPTION
## Purpose of change (The Why)

People may prefer the overmap tiles of one tileset but the main tiles of another.

## Describe the solution (The How)

Adds a setting to use a different tileset for the overmap. This results in a different tilecontext object being made and used for the overmap. Also includes some changes to how the overmap gets drawn, since otherwise the overmap ends up displayed incorrectly (offset from center) if there's a difference in tile size between the two tilesets.

## Describe alternatives you've considered

Deal with not liking the overmap tiles of my preferred tilesets.

## Testing

I loaded up the game and ran around for a while, checking the map frequently, making sure everything seems to be showing up properly. Tried it with a few different combinations of tilesets, sometimes with the same tile size and sometimes differing.

## Additional context

PRs that have been ported in here:
- https://github.com/CleverRaven/Cataclysm-DDA/pull/51526
- https://github.com/CleverRaven/Cataclysm-DDA/pull/55341
- https://github.com/CleverRaven/Cataclysm-DDA/pull/51716
- https://github.com/CleverRaven/Cataclysm-DDA/pull/51879
- https://github.com/CleverRaven/Cataclysm-DDA/pull/51748

Full credit goes to KorGgenT, Xenoamor (or Joshua Booth? different name shows up on the PR vs. the commit), and ferociousdork for this. I just pulled in their changes and made some very minor adjustments for divergences between the forks.

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [X] This PR ports commits from DDA or other cataclysm forks.
  - [X] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [X] I have linked the URL of original PR(s) in the description.
