### PR TITLE
feat(balance): MOLLE pack, Survivor Harness have more holsters, holster options

### DIFF
--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -186,7 +186,7 @@
     "id": "survivor_vest",
     "type": "ARMOR",
     "name": { "str": "survivor harness", "str_pl": "survivor harnesses" },
-    "description": "A custom-built light harness covered with pouches and including an integral tactical sling for a small rifle or other such weapon.  Durable and carefully crafted to be comfortable to wear.  Activate to holster/draw your weapon.",
+    "description": "A custom-built light harness covered with pouches and including a few integral tactical slings for firearms, magazines, and field tools.  Durable and carefully crafted to be comfortable to wear.  Activate to holster/draw your weapon.",
     "weight": "320 g",
     "volume": "1250 ml",
     "price": "200 USD",
@@ -197,14 +197,19 @@
     "color": "green",
     "covers": [ "torso" ],
     "coverage": 20,
-    "encumbrance": 4,
+    "encumbrance": 5,
     "storage": "3 L",
     "material_thickness": 2,
     "use_action": {
       "type": "holster",
-      "max_volume": "3750 ml",
-      "min_volume": "1250 ml",
-      "skills": [ "smg", "shotgun", "rifle", "launcher" ]
+      "holster_prompt": "Stow equipment",
+      "holster_msg": "You stow your %s",
+      "min_volume": "250ml",
+      "max_volume": "3750ml",
+      "multi": 4,
+      "draw_cost": 120,
+      "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD", "SHEATH_AXE", "MAG_COMPACT", "MAG_BULKY", "MAG_BELT", "SPEEDLOADER", "BELT_CLIP" ],
+      "skills": [ "smg", "shotgun", "rifle", "launcher", "pistol" ]
     },
     "valid_mods": [ "steel_padded", "alloy_padded", "resized_large" ],
     "flags": [ "WATER_FRIENDLY", "STURDY", "WAIST", "COMPACT" ]

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -640,7 +640,7 @@
       "holster_prompt": "Stow gear",
       "holster_msg": "You stow your %s",
       "min_volume": "250ml",
-      "max_volume": "3750ml",
+      "max_volume": "2500ml",
       "multi": 2,
       "draw_cost": 120,
       "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD", "SHEATH_AXE", "MAG_COMPACT", "MAG_BULKY", "MAG_BELT", "SPEEDLOADER", "BELT_CLIP" ],

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -616,7 +616,7 @@
     "repairs_like": "bigback",
     "type": "ARMOR",
     "name": { "str": "MOLLE pack" },
-    "description": "The Modular Lightweight Load-carrying Equipment is an advanced military backpack.  Covered with pockets and straps, it strikes a fine balance between storage space and encumbrance.",
+    "description": "The Modular Lightweight Load-carrying Equipment is an advanced military backpack.  Covered with pockets and equipment straps, it strikes a fine balance between storage space and encumbrance.",
     "weight": "966 g",
     "volume": "2500 ml",
     "price": "67 USD",
@@ -634,7 +634,18 @@
     "warmth": 10,
     "material_thickness": 2,
     "valid_mods": [ "resized_large" ],
-    "flags": [ "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "use_action": {
+      "type": "holster",
+      "holster_prompt": "Stow gear",
+      "holster_msg": "You stow your %s",
+      "min_volume": "250ml",
+      "max_volume": "3750ml",
+      "multi": 2,
+      "draw_cost": 120,
+      "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD", "SHEATH_AXE", "MAG_COMPACT", "MAG_BULKY", "MAG_BELT", "SPEEDLOADER", "BELT_CLIP" ],
+      "skills": [ "pistol", "smg", "shotgun", "rifle", "launcher" ]
+    }
   },
   {
     "id": "petpack",

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -747,7 +747,8 @@
         [ "leather_pouch", 2 ],
         [ "dump_pouch", 1 ],
         [ "purse", 2 ],
-        [ "fanny", 2 ]
+        [ "fanny", 2 ],
+        [ "webbing_belt", 2 ]
       ],
       [ [ "duct_tape", 300 ] ]
     ]
@@ -886,13 +887,13 @@
       [
         [ "tacvest", 1 ],
         [ "legrig", 1 ],
-        [ "vest", 1 ],
         [ "tool_belt", 1 ],
         [ "ragpouch", 3 ],
         [ "leather_pouch", 2 ],
         [ "dump_pouch", 1 ],
         [ "purse", 2 ],
-        [ "fanny", 2 ]
+        [ "fanny", 2 ],
+        [ "webbing_belt", 1 ]
       ],
       [ [ "duct_tape", 50 ] ]
     ]


### PR DESCRIPTION
The survivor harness was already fairly good as an upgraded back holster, but sadly it was no true MOLLE rig, and neither was the MOLLE pack. Until armor mods are added, giving a use to webbing belts other than disassembling them and giving the survivor harness and MOLLE pack some holster slots should help.

<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
Literally the entire point of the MOLLE pack IRL is that you can hang a wide variety of equipment loadouts from its belts, allowing you to load it with the kit you need without making custom backpacks for each soldier.
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
The MOLLE pack and the survivor harness have been modified to have a number of holster slots for a wide variety of equipment, allowing you to finally actually use the MOLLE system, at least in some fashion.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Hitting my head against a table until I've decided creating a unified equipment mod system sounds feasible, actually.
## Testing
I loaded in a character, debugged in a MOLLE pack and a survivor harness, wore both, used both of their holsters.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
