### PR TITLE
feat: Enable a wider variety of Adult Toys

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -836,6 +836,11 @@
   },
   {
     "type": "item_action",
+    "id": "BULLET_VIBE_ON",
+    "name": { "str": "Turn off toy" }
+  },
+  {
+    "type": "item_action",
     "id": "VORTEX",
     "name": { "str": "Use" }
   },

--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -988,5 +988,10 @@
     "type": "item_action",
     "id": "AMPUTATE",
     "name": { "str": "(Debug) Amputate body part" }
+  },
+  {
+    "type": "item_action",
+    "id": "sex_toy",
+    "name": { "str": "Relieve some tension" }
   }
 ]

--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -1283,6 +1283,7 @@
       [ "dinosuit", 4 ],
       [ "zentai", 5 ],
       [ "vibrator", 5 ],
+      [ "bullet_vibrator", 5 ],
       { "item": "condom", "prob": 30, "count": [ 1, 5 ] },
       [ "snuggie", 5 ],
       [ "flyer", 10 ],

--- a/data/json/itemgroups/Clothing_Gear/gear_civilian.json
+++ b/data/json/itemgroups/Clothing_Gear/gear_civilian.json
@@ -44,6 +44,7 @@
       [ "mp3", 20 ],
       [ "portable_game", 50 ],
       [ "vibrator", 5 ],
+      [ "bullet_vibrator", 5 ],
       [ "gum", 50 ],
       { "group": "ammo_pocket_batteries", "prob": 50 },
       [ "wrapper", 50 ],

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -722,6 +722,7 @@
     "items": [
       [ "barrette", 30 ],
       { "item": "vibrator", "prob": 20, "charges-min": 0, "charges-max": 25 },
+      { "item": "bullet_vibrator", "prob": 20, "charges-min": 0, "charges-max": 25 },
       [ "bubblewrap", 30 ],
       [ "syringe", 35 ],
       [ "glowstick_dead", 15 ],
@@ -1848,6 +1849,7 @@
       [ "portable_game", 8 ],
       [ "game_watch", 2 ],
       [ "vibrator", 6 ],
+      [ "bullet_vibrator", 6 ],
       [ "usb_drive", 8 ],
       [ "firecracker_pack", 1 ],
       [ "firecracker", 1 ],

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -12,6 +12,7 @@
       { "group": "tools_cleaning_small", "prob": 10 },
       { "group": "ammo_pocket_batteries_full", "prob": 50 },
       { "item": "vibrator", "prob": 3 },
+      { "item": "bullet_vibrator", "prob": 3 },
       { "item": "condom", "prob": 5, "count": [ 1, 3 ] },
       { "item": "mag_porn", "prob": 20 },
       { "item": "lighter", "prob": 60 },
@@ -277,6 +278,7 @@
       [ "game_watch", 2 ],
       [ "deck_of_cards", 2 ],
       [ "vibrator", 5 ],
+      [ "bullet_vibrator", 5 ],
       [ "string_36", 40 ],
       [ "chain", 20 ],
       [ "steel_chunk", 30 ],
@@ -1464,6 +1466,7 @@
     "items": [
       [ "corset", 20 ],
       [ "vibrator", 20 ],
+      [ "bullet_vibrator", 20 ],
       [ "leather_cat_tail", 20 ],
       [ "leather_cat_ears", 20 ],
       [ "leather_collar", 20 ],
@@ -1587,7 +1590,8 @@
       [ "smart_phone", 65 ],
       [ "mp3", 65 ],
       [ "radio_car_box", 35 ],
-      [ "vibrator", 1 ]
+      [ "vibrator", 1 ],
+      [ "bullet_vibrator", 1 ]
     ]
   },
   {

--- a/data/json/itemgroups/Locations_MapExtras/mansion.json
+++ b/data/json/itemgroups/Locations_MapExtras/mansion.json
@@ -767,6 +767,7 @@
       [ "candle", 50 ],
       [ "rope_6", 50 ],
       [ "vibrator", 40 ],
+      [ "bullet_vibrator", 40 ],
       [ "camisole", 40 ],
       [ "panties", 40 ],
       [ "bra", 40 ],

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -944,6 +944,7 @@
       { "item": "bondage_mask", "prob": 5 },
       { "item": "flask_hip", "prob": 5 },
       { "item": "vibrator", "prob": 5 },
+      { "item": "bullet_vibrator", "prob": 5 },
       { "item": "tux", "prob": 1 },
       { "item": "gown", "prob": 1 },
       { "item": "long_glove_white", "prob": 1 },

--- a/data/json/itemgroups/electronics.json
+++ b/data/json/itemgroups/electronics.json
@@ -79,6 +79,7 @@
       [ "portable_game", 12 ],
       [ "game_watch", 3 ],
       [ "vibrator", 10 ],
+      [ "bullet_vibrator", 10 ],
       [ "flashlight", 40 ],
       [ "heavy_flashlight", 10 ],
       [ "radio", 20 ],

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -650,6 +650,7 @@
     "name": { "str": "bullet vibrator (on)" },
     "copy-from": "bullet_vibrator",
     "power_draw": 50000,
+    "revert_to": "bullet_vibe",
     "description": "This battery-devouring device is just the thing to knead the tension out and help you relax.  You can feel it buzzing away all that tension.",
     "use_action": [ "BULLET_VIBE_ON" ]
   },

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -651,7 +651,7 @@
     "category": "electronics",
     "name": { "str": "bullet vibrator (on)" },
     "copy-from": "bullet_vibrator",
-    "power_draw": 50000,
+    "power_draw": 25000,
     "revert_to": "bullet_vibrator",
     "description": "This battery-devouring device is just the thing to knead the tension out and help you relax.  You can feel it buzzing away all that tension.",
     "use_action": [ "BULLET_VIBE_ON" ]

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -590,7 +590,7 @@
     "color": "dark_gray",
     "ammo": "battery",
     "charges_per_use": 10,
-    "use_action": "VIBE",
+    "use_action": { "type": "sex_toy", "moves": 60000 },
     "magazines": [
       [
         "battery",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -608,6 +608,53 @@
     "magazine_well": "250 ml"
   },
   {
+    "id": "bullet_vibrator",
+    "type": "TOOL",
+    "category": "electronics",
+    "name": { "str": "bullet vibrator (off)" },
+    "description": "This battery-devouring device is just the thing to knead the tension out and help you relax.  Use it to turn it on and start letting it buzz away.",
+    "weight": "100 g",
+    "volume": "100 ml",
+    "price": "55 USD",
+    "price_postapoc": "1 USD",
+    "material": [ "aluminum", "plastic" ],
+    "symbol": ";",
+    "color": "dark_gray",
+    "ammo": "battery",
+    "use_action": {
+      "type": "transform",
+      "target": "bullet_vibrator_on",
+      "active": true,
+      "msg": "You turn on the bullet vibe and place it appropriately.",
+      "moves": 100
+    },
+    "magazines": [
+      [
+        "battery",
+        [
+          "light_battery_cell",
+          "light_plus_battery_cell",
+          "light_minus_battery_cell",
+          "light_atomic_battery_cell",
+          "light_minus_atomic_battery_cell",
+          "light_minus_disposable_cell",
+          "light_disposable_cell"
+        ]
+      ]
+    ],
+    "magazine_well": "100 ml"
+  },
+  {
+    "id": "bullet_vibrator_on",
+    "type": "TOOL",
+    "category": "electronics",
+    "name": { "str": "bullet vibrator (on)" },
+    "copy-from": "bullet_vibrator",
+    "power_draw": 50000,
+    "description": "This battery-devouring device is just the thing to knead the tension out and help you relax.  You can feel it buzzing away all that tension.",
+    "use_action": [ "BULLET_VIBE_ON" ]
+  },
+  {
     "id": "gps_device",
     "type": "TOOL",
     "category": "electronics",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -650,7 +650,7 @@
     "name": { "str": "bullet vibrator (on)" },
     "copy-from": "bullet_vibrator",
     "power_draw": 50000,
-    "revert_to": "bullet_vibe",
+    "revert_to": "bullet_vibrator",
     "description": "This battery-devouring device is just the thing to knead the tension out and help you relax.  You can feel it buzzing away all that tension.",
     "use_action": [ "BULLET_VIBE_ON" ]
   },

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -589,7 +589,6 @@
     "symbol": ";",
     "color": "dark_gray",
     "ammo": "battery",
-    "charges_per_use": 10,
     "use_action": { "type": "sex_toy", "moves": 60000 },
     "magazines": [
       [

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -625,7 +625,9 @@
       "target": "bullet_vibrator_on",
       "active": true,
       "msg": "You turn on the bullet vibe and place it appropriately.",
-      "moves": 100
+      "moves": 100,
+      "need_charges": 1,
+      "need_charges_msg": "The vibrator's battery is dead."
     },
     "magazines": [
       [

--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -963,5 +963,21 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "tools": [ [ [ "mil_gps_device", -1 ] ] ],
     "components": [ [ [ "scouter", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "bullet_vibrator",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_TOOLS",
+    "skill_used": "fabrication",
+    "skills_required": [ "electronics", 1 ],
+    "difficulty": 3,
+    "time": "15 m",
+    "reversible": true,
+    "autolearn": true,
+    "using": [ [ "soldering_standard", 4 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "tools": [ [ [ "mold_plastic", -1 ] ] ],
+    "components": [ [ [ "superglue", 1 ] ], [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 1 ] ], [ [ "cable", 5 ] ], [ [ "motor_micro", 1 ] ] ]
   }
 ]

--- a/data/mods/MagicalNights/items/enchanted/enchanted_misc.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted_misc.json
@@ -330,8 +330,7 @@
     "color": "dark_gray",
     "ammo": "crystallized_mana",
     "magazines": [ [ "crystallized_mana", [ "small_mana_crystal" ] ] ],
-    "charges_per_use": 5,
-    "use_action": "VIBE",
+    "use_action": { "type": "sex_toy", "moves": 60000 },
     "magazine_well": "250 ml"
   }
 ]

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1066,6 +1066,7 @@ void Item_factory::init()
     add_iuse( "WEAK_ANTIBIOTIC", &iuse::weak_antibiotic );
     add_iuse( "WEATHER_TOOL", &iuse::weather_tool );
     add_iuse( "XANAX", &iuse::xanax );
+    add_iuse( "BULLET_VIBE_ON", &iuse::bullet_vibe_on );
 
     // Obsolete - just dummies, won't be called
     add_iuse( "HOTPLATE", &iuse::toggle_heats_food );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1112,6 +1112,7 @@ void Item_factory::init()
     add_actor( std::make_unique<weigh_self_actor>() );
     add_actor( std::make_unique<gps_device_actor>() );
     add_actor( std::make_unique<sew_advanced_actor>() );
+    add_actor( std::make_unique<sex_toy_actor>() );
 
     // An empty dummy group, it will not spawn anything. However, it makes that item group
     // id valid, so it can be used all over the place without need to explicitly check for it.

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9302,3 +9302,26 @@ int use_function::call( player &p, item &it, bool active, const tripoint &pos ) 
 {
     return actor->use( p, it, active, pos );
 }
+
+int iuse::bullet_vibe_on( player *p, item *it, bool t, const tripoint & )
+{
+    if( t ) { // Normal use
+        if( p->has_item( *it ) ) {
+            // vibrator exists
+            p->add_morale( MORALE_FEELING_GOOD, 1, 30, 5_minutes, 2_minutes, true );
+            p->mod_fatigue(1); // Might be excessive fatigue drain
+        }
+    } else {
+        // Most generic way to figure out the base item I can think of
+        // There's *probably* a better way to do this, but this works
+        std::string active_item = it->typeId().str();
+        std::string base_item = active_item.erase(active_item.rfind('_'));
+        
+        p->add_msg_if_player( _( "The %s turns off." ), it->display_name() );
+        it->convert( itype_id(base_item) );
+        it->deactivate();
+
+    }
+    return it->type->charges_to_use();
+}
+

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9309,7 +9309,7 @@ int iuse::bullet_vibe_on( player *p, item *it, bool t, const tripoint & )
         if( p->has_item( *it ) ) {
             // Only triggers every 1 minute so that fatigue isn't ridiculous
             if( calendar::once_every( 1_minutes ) ) {
-                p->add_morale( MORALE_FEELING_GOOD, 1, 30, 5_minutes, 2_minutes, true );
+                p->add_morale( MORALE_FEELING_GOOD, 1, 30, 20_minutes, 10_minutes, true );
                 p->mod_fatigue( 1 );
             }
         }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9307,8 +9307,8 @@ int iuse::bullet_vibe_on( player *p, item *it, bool t, const tripoint & )
 {
     if( t ) { // Normal use
         if( p->has_item( *it ) ) {
-            // Only triggers every 5 minutes so that fatigue isn't ridiculous
-            if( calendar::once_every( 5_minutes ) ) {
+            // Only triggers every 1 minute so that fatigue isn't ridiculous
+            if( calendar::once_every( 1_minutes ) ) {
                 p->add_morale( MORALE_FEELING_GOOD, 1, 30, 5_minutes, 2_minutes, true );
                 p->mod_fatigue( 1 );
             }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9307,9 +9307,11 @@ int iuse::bullet_vibe_on( player *p, item *it, bool t, const tripoint & )
 {
     if( t ) { // Normal use
         if( p->has_item( *it ) ) {
-            // vibrator exists
-            p->add_morale( MORALE_FEELING_GOOD, 1, 30, 5_minutes, 2_minutes, true );
-            p->mod_fatigue(1); // Might be excessive fatigue drain
+            // Only triggers every 5 minutes so that fatigue isn't ridiculous
+            if(calendar::once_every(5_minutes)) {
+                p->add_morale( MORALE_FEELING_GOOD, 1, 30, 5_minutes, 2_minutes, true );
+                p->mod_fatigue(1);
+            }
         }
     } else {
         // Most generic way to figure out the base item I can think of

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -172,6 +172,7 @@ int toggle_ups_charging( player *, item *, bool, const tripoint & );
 int report_grid_charge( player *, item *, bool, const tripoint & );
 int report_grid_connections( player *, item *, bool, const tripoint & );
 int modify_grid_connections( player *, item *, bool, const tripoint & );
+int bullet_vibe_on( player *, item *, bool, const tripoint & );
 
 // MACGUFFINS
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -103,6 +103,7 @@ static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
 static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_STUDY_SPELL( "ACT_STUDY_SPELL" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
+static const activity_id ACT_VIBE( "ACT_VIBE" );
 
 static const efftype_id effect_accumulated_mutagen( "accumulated_mutagen" );
 static const efftype_id effect_asthma( "asthma" );
@@ -5237,4 +5238,50 @@ int change_scent_iuse::use( player &p, item &it, bool, const tripoint & ) const
 std::unique_ptr<iuse_actor> change_scent_iuse::clone() const
 {
     return std::make_unique<change_scent_iuse>( *this );
+}
+
+void sex_toy_actor::load( JsonObject const &obj) {
+    moves = obj.get_int("moves", 60000); // default is 10 minutes
+}
+
+ret_val<bool> sex_toy_actor::can_use(const Character &c, const item &i, bool, const tripoint &) const {
+    if(c.is_npc()) {
+        return ret_val<bool>::make_failure(); // Creepy, status quo
+    }
+    if (c.is_mounted()) {
+        return ret_val<bool>::make_failure( _("You can't do *that* while mounted"));
+    }
+    if( ( c.is_underwater() ) && ( !( ( c.has_trait( trait_id("GILLS") ) ) ||
+                                       ( c.has_trait( trait_id("GILLS_CEPH") ) ) ||
+                                       ( c.is_wearing( itype_id("rebreather_on") ) ) ||
+                                       ( c.is_wearing( itype_id("rebreather_xl_on") ) ) ||
+                                       ( c.is_wearing( itype_id("mask_h20survivor_on") ) ) ) ) ) {
+        return ret_val<bool>::make_failure( _("Are you trying to drown yourself?"));
+    }
+    if( !i.units_sufficient( c ) ) {
+        return ret_val<bool>::make_failure(  _( "The %s's batteries are dead." ), i.tname() );
+    }
+    if( c.get_fatigue() >= fatigue_levels::dead_tired ) {
+        return ret_val<bool>::make_failure(  _( "*Your* batteries are dead." ) );
+    }
+    return ret_val<bool>::make_success();
+}
+
+std::unique_ptr<iuse_actor> sex_toy_actor::clone() const
+{
+    return std::make_unique<sex_toy_actor>( *this );
+}
+
+int sex_toy_actor::use(player &p, item &i, bool, const tripoint &) const {
+    if( i.ammo_remaining() > 0 ) {
+        p.add_msg_if_player( _( "You fire up your %s and start getting the tension out." ),
+                                i.tname() );
+    } else {
+        p.add_msg_if_player( _( "You whip out your %s and start getting the tension out." ),
+                                i.tname() );
+    }
+    p.assign_activity( ACT_VIBE, moves, -1, 0, "de-stressing" );
+    p.activity->tools.emplace_back( i );
+
+    return i.type->charges_to_use();
 }

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1265,3 +1265,20 @@ class heat_food_actor : public iuse_actor
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
+/**
+ * Relieve some tension built up in the cataclysm
+ * More generalized form of old VIBE iuse
+ */
+class sex_toy_actor : public iuse_actor
+{
+    public:
+        int moves;
+
+        sex_toy_actor(const std::string &type = "sex_toy" ) : iuse_actor(type) {};
+        ~sex_toy_actor() override = default;
+        void load(const JsonObject &obj) override;
+        int use(player &p, item &i, bool, const tripoint &) const override;
+        ret_val<bool> can_use( const Character &, const item &, bool, const tripoint & ) const override;
+        std::unique_ptr<iuse_actor> clone() const override;
+};
+

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -192,14 +192,7 @@ item_location_type wield_item_location::where( ) const
 detached_ptr<item> worn_item_location::detach( item *it )
 {
     detached_ptr<item> res;
-    holder->remove_worn_items_with( [&it, &res]( detached_ptr<item> &&ch ) {
-        if( &*ch == it ) {
-            res = std::move( ch );
-            return detached_ptr<item>();
-        } else {
-            return std::move( ch );
-        }
-    } );
+    res = holder->worn.remove( it );
     if( !res ) {
         debugmsg( "Failed to find worn item in detach" );
     }


### PR DESCRIPTION
## Purpose of change (The Why)

The existing VIBE iuse was clearly made exclusively for vibrators, and also only for a specific *kind* of vibrator. As such, two changes were desired:

1. A more generalized sex toy iuse that functions similar to the old VIBE iuse
2. A method of representing toys such as bullet vibrators, where the user could conceivably move around and do things while still using them.

## Describe the solution (The How)

- Creates a new iuse_actor `sex_toy`, which is meant to be a more generalized form of the old VIBE iuse
- Adds a BULLET_VIBRATOR_ON iuse, which functions very similarly to the MP3_ON iuse.

- Also changes the vanilla vibrator and MN's mana-powered vibrator over to the new iuse_action
- Adds a bullet vibrator item
  - Adds the bullet vibrator item to the same "normal" itemgroups as the basic vibrator at the same odds.

## Describe alternatives you've considered

- Figuring out how to make the bullet vibe an iuse_actor instead
- Not adding the bullet vibe

I felt the bullet vibe in vanilla is a good example for others on how to arrange things.

- Adding a dildo or some other user of the sex_toy iuse actor

Just didn't feel like it, can be left to a later PR.

## Testing

The game loads, the items function how one would expect

However, "charges_on_use" does NOT work with the sex toy iuse_actor for some reason. Then again, imo the charges used should come from the actual 'activity', not a base cost.

## Additional context

Surprisingly, the text/ASCII fallback for the bullet vibe actually looks pretty good. I'm sure someone will still want to add a new texture for it though.

Also, this may cause me to make MP3 functions *far* less hard-coded in the future since I came up with the simple way to handle the on->off transformation.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description. (does not exist)
