### PR TITLE
fix: let you ask for equipment in mission after asking advice.

### DIFF
--- a/data/json/npcs/TALK_COMMON_MISSION.json
+++ b/data/json/npcs/TALK_COMMON_MISSION.json
@@ -98,7 +98,7 @@
   {
     "id": "TALK_MISSION_ADVICE",
     "type": "talk_topic",
-    "responses": [ { "text": "Sounds good, thanks.", "topic": "TALK_NONE" }, { "text": "Sounds good.  Bye!", "topic": "TALK_DONE" } ]
+    "responses": [ { "text": "Sounds good, thanks.", "topic": "TALK_MISSION_ACCEPTED" }, { "text": "Sounds good.  Bye!", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_MISSION_REJECTED",


### PR DESCRIPTION
## Purpose of change (The Why)

Bad you can't do this because you can do inverse. We recognize it as a bug.

## Describe the solution (The How)

Link back to previous topic, looks like it works.

## Describe alternatives you've considered

Going to bed.

## Testing

<img width="2046" height="1206" alt="image" src="https://github.com/user-attachments/assets/6e0ac51b-4f1f-42c2-8db4-6136132a4907" />


## Additional context

<img width="406" height="101" alt="image" src="https://github.com/user-attachments/assets/baa2d1e4-d85d-4de0-9649-bef21164d488" />


## Checklist
### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.