### PR TITLE
feat: lua bindings for missions

### DIFF
--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -19,6 +19,7 @@
 #include "map.h"
 #include "martialarts.h"
 #include "material.h"
+#include "mission.h"
 #include "monfaction.h"
 #include "monster.h"
 #include "mtype.h"
@@ -793,6 +794,7 @@ void cata::reg_all_bindings( sol::state &lua )
     reg_game_ids( lua );
     mod_mutation_branch( lua );
     reg_magic( lua );
+    reg_mission( lua );
     reg_recipe( lua );
     reg_coords_library( lua );
     reg_constants( lua );

--- a/src/catalua_bindings.h
+++ b/src/catalua_bindings.h
@@ -29,6 +29,7 @@ void reg_hooks_examples( sol::state &lua );
 void reg_item( sol::state &lua );
 void reg_locale_api( sol::state &lua );
 void reg_map( sol::state &lua );
+void reg_mission( sol::state &lua );
 void reg_monster( sol::state &lua );
 void mod_mutation_branch( sol::state &lua );
 void reg_magic( sol::state &lua );

--- a/src/catalua_bindings_ids.cpp
+++ b/src/catalua_bindings_ids.cpp
@@ -17,6 +17,7 @@
 #include "mapdata.h"
 #include "martialarts.h"
 #include "material.h"
+#include "mission.h"
 #include "monfaction.h"
 #include "monstergenerator.h"
 #include "morale_types.h"

--- a/src/catalua_bindings_mission.cpp
+++ b/src/catalua_bindings_mission.cpp
@@ -1,0 +1,76 @@
+#include "catalua_bindings.h"
+
+#include "avatar.h"
+#include "catalua.h"
+#include "catalua_bindings_utils.h"
+#include "coordinates.h"
+#include "mission.h"
+#include "translations.h"
+#include "catalua_impl.h"
+#include "catalua_log.h"
+#include "catalua_luna.h"
+#include "catalua_luna_doc.h"
+
+void cata::detail::reg_mission( sol::state &lua )
+{
+#define UT_CLASS mission
+    /* NOTE: These changes are applied to the "MutationBranchRaw" Lua obj.
+    * Because mutation_branch was bound as an ID, the actual object is
+    * shoved into a 'Raw' binding.
+    * The following code makes that useful, while also stopping the
+    * related object from being messed with.
+    */
+
+    sol::usertype<mission> ut =
+        luna::new_usertype<mission>(
+            lua,
+            luna::no_bases,
+            luna::constructors <
+            // Define your actual constructors here
+            mission()
+            > ()
+        );
+
+    //SET_FX_T( mission_id, mission_id const );
+
+
+    DOC( "Returns true if the mission has a deadline." );
+    SET_FX_T( name,         std::string() );
+    SET_FX_T( has_deadline,         bool() const );
+    SET_FX_T( get_deadline,         time_point() const );
+    SET_FX_T( get_description,         std::string() const );
+    SET_FX_T( has_target,         bool() const );
+    //SET_FX_T( &get_target,         const tripoint_abs_omt() const );
+    //SET_FX_T( &get_type,         const mission_type() const );
+    SET_FX_T( has_follow_up,         bool() const );
+    //SET_FX_T( get_follow_up,         mission_type_id() const );
+    SET_FX_T( get_value,         int() const );
+    SET_FX_T( get_id,         int() const );
+    //SET_FX_T( &get_item_id,         const itype_id() const );
+    // SET_FX_T( get_npc_id,         character_id() const );
+    //SET_FX_T( &get_likely_rewards,         const std::vector<std::pair<int, itype_id>>() const );
+    SET_FX_T( has_generic_rewards,         bool() const );
+    SET_FX_T( is_assigned,         bool() const );
+
+    luna::set_fx( ut, "assign",
+    []( mission & m, avatar & u ) -> void {
+        m.assign( u );
+    } );
+
+    luna::set_fx( ut, "reserve_new",
+    []( const mission_type_id & type, const character_id & npc_id ) -> mission * {
+        return mission::reserve_new( type, npc_id );
+    } );
+
+    luna::set_fx( ut, "reserve_random",
+    []( mission_origin origin, const tripoint & p, const character_id & npc_id ) -> mission * {
+        return mission::reserve_random( origin, tripoint_abs_omt( p ), npc_id );
+    } );
+
+    // Add (de-)serialization functions so we can carry
+    // our horde over the save/load boundary
+    reg_serde_functions( ut );
+
+    // Add more stuff like arithmetic operators, to_string operator, etc.
+#undef UT_CLASS // #define UT_CLASS mutation_branch
+};

--- a/src/catalua_luna_doc.h
+++ b/src/catalua_luna_doc.h
@@ -17,6 +17,7 @@ enum mf_attitude : int;
 enum monster_attitude : int;
 enum npc_attitude : int;
 enum npc_need : int;
+
 namespace sfx
 {
 enum class channel : int;
@@ -36,6 +37,7 @@ class ma_buff;
 class map;
 class map_stack;
 class material_type;
+class mission;
 class monster;
 class npc;
 class player;
@@ -120,6 +122,7 @@ LUNA_VAL( item, "Item" );
 LUNA_VAL( item_stack, "ItemStack" );
 LUNA_VAL( map, "Map" );
 LUNA_VAL( map_stack, "MapStack" );
+LUNA_VAL( mission, "Mission" );
 LUNA_VAL( monster, "Monster" );
 LUNA_VAL( npc, "Npc" );
 LUNA_VAL( npc_opinion, "NpcOpinion" );


### PR DESCRIPTION
## Purpose of change (The Why)
Currently you can't assign missions with lua, which is a very important feature. This will let us port profession-specific mission starts with lua instead of EoC, and this is also a necessary prerequisite for porting Sky Islands.
## Describe the solution (The How)
Adds lua bindings for `Mission` and `mission_type`
## Describe alternatives you've considered
## Testing
```
-- create a tripoint (absolute overmap tile coords)
local pos = Tripoint.new(0, 0, 0)
-- pick mission_origin as integer 2 (profession/player start)
local origin = 2
-- get the avatar
local player = gapi.get_avatar()
-- create a new random mission
local m = Mission.reserve_random(origin, pos, player:getID())
-- assign it to the player
m:assign(player)
```
## Additional context
## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
