### PR TITLE
feat(balance): All rare martial arts books now spawn in the recycling center

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -655,7 +655,7 @@
       [ "manual_dodge", 20 ],
       [ "manual_driving", 20 ],
       [ "manual_throw", 20 ],
-      [ "manual_zui_quan", 20 ],
+      { "group": "rare_martial_arts_books", "prob": 20 },
       [ "howto_computer", 20 ],
       [ "touristmap", 25 ],
       [ "regionaltransportmap", 25 ],


### PR DESCRIPTION
## Purpose of change (The Why)
"Clearly nobody in the Cata universe cares much for Zui Quan if you always find it in recycling centers"
- This is a lie

## Describe the solution (The How)
Make all rare martial arts equally hated

## Describe alternatives you've considered
Make all martial arts equally hated

## Testing
It loads, that's a group, that's the issue line

## Additional context
They even often have rare martial arts books. For some reason I only ever find Zui Quan there, which is still damn good.
- I wonder why?

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.