### PR TITLE
feat(balance): Reloading from bandoliers and pouches is no longer slower when full

### DIFF
--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -500,11 +500,11 @@ item_location_type contents_item_location::where() const
 
 int contents_item_location::obtain_cost( const Character &ch, int qty, const item *it ) const
 {
-    if( container->can_holster( *it ) ) {
+    if( container->get_use( "holster" ) ) {
         auto ptr = dynamic_cast<const holster_actor *>
                    ( container->type->get_use( "holster" )->get_actor_ptr() );
         return dynamic_cast<const player *>( &ch )->item_handling_cost( *it, false, ptr->draw_cost );
-    } else if( container->is_bandolier() ) {
+    } else if( container->get_use( "bandolier"  ) ) {
         auto ptr = dynamic_cast<const bandolier_actor *>
                    ( container->type->get_use( "bandolier" )->get_actor_ptr() );
         return dynamic_cast<const player *>( &ch )->item_handling_cost( *it, false, ptr->draw_cost );

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -504,7 +504,7 @@ int contents_item_location::obtain_cost( const Character &ch, int qty, const ite
         auto ptr = dynamic_cast<const holster_actor *>
                    ( container->type->get_use( "holster" )->get_actor_ptr() );
         return dynamic_cast<const player *>( &ch )->item_handling_cost( *it, false, ptr->draw_cost );
-    } else if( container->get_use( "bandolier"  ) ) {
+    } else if( container->get_use( "bandolier" ) ) {
         auto ptr = dynamic_cast<const bandolier_actor *>
                    ( container->type->get_use( "bandolier" )->get_actor_ptr() );
         return dynamic_cast<const player *>( &ch )->item_handling_cost( *it, false, ptr->draw_cost );


### PR DESCRIPTION
## Purpose of change (The Why)
It's an evil issue

## Describe the solution (The How)
Make it check for the action, not for the action being usable (I.E. it having room)

## Describe alternatives you've considered
None

## Testing
Spawn in leg mag pouch, fill it, it is no longer slower then inventory.

## Additional context
SCREM

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.