### PR TITLE
fix(mods/MonsterGirls): Add forgotten bunnygirl mutagen

### DIFF
--- a/data/mods/Monster_Girls/migration.json
+++ b/data/mods/Monster_Girls/migration.json
@@ -218,5 +218,15 @@
     "id": "iv_mutagen_fish",
     "type": "MIGRATION",
     "replace": "iv_mutagen"
+  },
+  {
+    "id": "mutagen_rabbit",
+    "type": "MIGRATION",
+    "replace": "mutagen_bunnygirl"
+  },
+  {
+    "id": "iv_mutagen_rabbit",
+    "type": "MIGRATION",
+    "replace": "iv_mutagen_bunnygirl"
   }
 ]

--- a/data/mods/Monster_Girls/mutagens.json
+++ b/data/mods/Monster_Girls/mutagens.json
@@ -167,5 +167,19 @@
     "copy-from": "mutagen_serpent",
     "name": "Lamia mutagen",
     "use_action": { "type": "mutagen", "mutation_category": "LAMIA" }
+  },
+  {
+    "id": "iv_mutagen_bunnygirl",
+    "type": "COMESTIBLE",
+    "copy-from": "iv_mutagen_rabbit",
+    "name": "Usagimimi serum",
+    "use_action": { "type": "mutagen_iv", "mutation_category": "BUNNYGIRL" }
+  },
+  {
+    "id": "mutagen_bunnygirl",
+    "type": "COMESTIBLE",
+    "copy-from": "mutagen_rabbit",
+    "name": "Usagimimi mutagen",
+    "use_action": { "type": "mutagen", "mutation_category": "BUNNYGIRL" }
   }
 ]

--- a/data/mods/Monster_Girls/recipes.json
+++ b/data/mods/Monster_Girls/recipes.json
@@ -150,5 +150,17 @@
     "result": "mutagen_lamia",
     "copy-from": "mutagen_serpent",
     "components": [ [ [ "mutagen", 1 ] ], [ [ "egg_reptile", 1 ], [ "scute_piece", 3 ] ], [ [ "ammonia", 1 ], [ "lye_powder", 100 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "iv_mutagen_bunnygirl",
+    "copy-from": "iv_mutagen_rabbit",
+    "components": [ [ [ "mutagen_rabbit", 2 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "mutagen_bunnygirl",
+    "copy-from": "mutagen_rabbit",
+    "components": [ [ [ "mutagen", 1 ] ], [ [ "carrot", 3 ], [ "irradiated_carrot", 1 ] ], [ [ "ammonia", 1 ], [ "lye_powder", 100 ] ] ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

I forgot, in my haste to add bunnygirls, to actually give them a mutagen. And to migrate rabbit mutagen.

## Describe the solution (The How)

Adds the relevant mutagens and migrations

## Describe alternatives you've considered

- Implode

## Testing

I made sure I got the recipes ans the names of the rabbit mutagens correct. It also lints.

## Additional context

Wow, that's embarrassing of me.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
