### PR TITLE
feat: Vehicleparts can now define integrated tools

### DIFF
--- a/data/json/vehicleparts/utilities.json
+++ b/data/json/vehicleparts/utilities.json
@@ -15,7 +15,12 @@
     "damage_reduction": { "all": 30 },
     "description": "A small but complete kitchen unit, powered from the vehicle's batteries.",
     "durability": 80,
-    "flags": [ "CARGO", "OBSTACLE", "KITCHEN", "FAUCET", "COVERED" ],
+    "flags": [ "CARGO", "OBSTACLE", "CRAFTER", "FAUCET", "COVERED" ],
+    "integrated_tools": [
+      "pot",
+      "pan",
+      "hotplate"
+    ],
     "item": "kitchen_unit",
     "location": "center",
     "looks_like": "f_oven",
@@ -48,7 +53,11 @@
     "damage_reduction": { "all": 24 },
     "description": "A welding rig mounted in the vehicle, that draws power from the vehicle's batteries.  You still need glare protection.  'e'xamine the tile with the rig to use it to repair items in your inventory.  If you attempt to craft an item or perform a repair that requires a welder, you will be given the option of using the welding rig.",
     "durability": 80,
-    "flags": [ "CARGO", "OBSTACLE", "WELDRIG", "COVERED" ],
+    "flags": [ "CARGO", "OBSTACLE", "CRAFTER", "COVERED" ],
+    "integrated_tools": [
+      "soldering_iron",
+      "welder"
+    ],
     "item": "weldrig",
     "location": "center",
     "name": { "str": "welding rig" },
@@ -84,7 +93,13 @@
     "damage_reduction": { "all": 20 },
     "description": "A multi-function crafting station, with a water purifier, food processor, food dehydrator, vacuum sealer, and hand press for making ammo.  Draws power from the vehicle's batteries.  'e'xamine the tile with the kitchen buddy to access the water faucet or to purify water in a vehicle tank or in a container in your inventory.  If you attempt to craft an item that needs one of the kitchen buddy's functions, it will automatically be selected as a tool.",
     "durability": 80,
-    "flags": [ "CARGO", "OBSTACLE", "CRAFTRIG", "WATER_PURIFIER", "COVERED" ],
+    "flags": [ "CARGO", "OBSTACLE", "CRAFTER", "WATER_PURIFIER", "COVERED" ],
+    "integrated_tools": [
+      "dehydrator",
+      "vac_sealer",
+      "food_processor",
+      "press"
+    ],
     "item": "craftrig",
     "location": "center",
     "looks_like": "f_sink",
@@ -119,7 +134,11 @@
     "damage_reduction": { "all": 19 },
     "description": "A small chemistry station, including a hotplate and electrolysis setup powered by the vehicle's batteries.  'e'xamine the tile with the chemistry lab to access the water faucet or to heat up food with the hotplate.  If you attempt to craft an item that needs one of the chemistry lab's functions, it will automatically be selected as a tool.",
     "durability": 80,
-    "flags": [ "CARGO", "OBSTACLE", "CHEMLAB", "FAUCET", "COVERED" ],
+    "flags": [ "CARGO", "OBSTACLE", "CRAFTER", "FAUCET", "COVERED" ],
+    "integrated_tools": [
+      "chemistry_set",
+      "electrolysis_kit"
+    ],
     "item": "chemlab",
     "location": "center",
     "looks_like": "f_workbench",
@@ -151,7 +170,10 @@
     "damage_reduction": { "all": 29 },
     "description": "A electric forge for metalworking, powered by the vehicle's batteries.  With a hammer and other tools, you could use this for metalworking.  If you attempt to craft an item that needs a forge, you will be given the option of selecting it as a tool.",
     "durability": 80,
-    "flags": [ "CARGO", "OBSTACLE", "FORGE" ],
+    "flags": [ "CARGO", "OBSTACLE", "CRAFTER" ],
+    "integrated_tools": [
+      "forge"
+    ],
     "item": "forgerig",
     "location": "center",
     "looks_like": "f_forge_rock",
@@ -183,7 +205,10 @@
     "damage_reduction": { "all": 30 },
     "description": "Combining a fixed-up dissector, workbench and advanced electronics, this is a marvel capable of butchering, dissecting and cutting like nothing else!",
     "durability": 80,
-    "flags": [ "CARGO", "OBSTACLE", "BUTCHER_EQ", "TRANSPARENT", "FLAT_SURF" ],
+    "flags": [ "CARGO", "OBSTACLE", "CRAFTER", "TRANSPARENT", "FLAT_SURF" ],
+    "integrated_tools": [
+      "fake_adv_butchery"
+    ],
     "item": "adv_butchery",
     "location": "center",
     "looks_like": "vp_autodoc",
@@ -215,7 +240,10 @@
     "damage_reduction": { "all": 25 },
     "description": "A electric kiln for baking brick or clay, powered by the vehicle's batteries.  You could use this to harden bricks or clay.  If you attempt to craft an item that needs a kiln, you will be given the option of selecting it as a tool.",
     "durability": 80,
-    "flags": [ "CARGO", "OBSTACLE", "KILN" ],
+    "flags": [ "CARGO", "OBSTACLE", "CRAFTER" ],
+    "integrated_tools": [
+      "kiln"
+    ],
     "item": "kilnrig",
     "location": "center",
     "looks_like": "f_kiln_empty",

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -27,6 +27,7 @@
 #include "translations.h"
 #include "vehicle.h"
 #include "vehicle_part.h"
+#include "veh_type.h"
 #include "vpart_position.h"
 #include "calendar.h"
 #include "character.h"
@@ -45,6 +46,7 @@ static const itype_id itype_aspirin( "aspirin" );
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_codeine( "codeine" );
 static const itype_id itype_heroin( "heroin" );
+static const itype_id itype_hotplate( "hotplate" );
 static const itype_id itype_salt_water( "salt_water" );
 static const itype_id itype_tramadol( "tramadol" );
 static const itype_id itype_oxycodone( "oxycodone" );
@@ -563,14 +565,9 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
 
         //Adds faucet to kitchen stuff; may be horribly wrong to do such....
         //ShouldBreak into own variable
-        const std::optional<vpart_reference> kpart = vp.part_with_feature( "KITCHEN", true );
-        const std::optional<vpart_reference> butcherpart = vp.part_with_feature( "BUTCHER_EQ", true );
+        const std::optional<vpart_reference> crafterpart = vp.part_with_feature( "CRAFTER", true );
+
         const std::optional<vpart_reference> faupart = vp.part_with_feature( "FAUCET", true );
-        const std::optional<vpart_reference> weldpart = vp.part_with_feature( "WELDRIG", true );
-        const std::optional<vpart_reference> craftpart = vp.part_with_feature( "CRAFTRIG", true );
-        const std::optional<vpart_reference> forgepart = vp.part_with_feature( "FORGE", true );
-        const std::optional<vpart_reference> kilnpart = vp.part_with_feature( "KILN", true );
-        const std::optional<vpart_reference> chempart = vp.part_with_feature( "CHEMLAB", true );
         const std::optional<vpart_reference> autoclavepart = vp.part_with_feature( "AUTOCLAVE", true );
         const std::optional<vpart_reference> cargo = vp.part_with_feature( "CARGO", true );
 
@@ -579,6 +576,24 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
             for( const auto &it : items ) {
                 add_item_by_items_type_cache( *it, false, false, false );
             }
+        }
+
+        static const flag_id flag_PSEUDO( "PSEUDO" );
+        static const flag_id flag_HEATS_FOOD( "HEATS_FOOD" );
+        static const flag_id flag_FLATSURF( "FLAT_SURFACE" );
+
+
+        if( crafterpart && !found_parts.contains( &*crafterpart ) ) {
+            for( itype_id id : crafterpart->info().craftertools() ) {
+                item &tool = *item::spawn_temporary( id, bday );
+                tool.charges = veh->fuel_left( itype_battery, true );
+                tool.item_tags.insert( flag_PSEUDO );
+                if( id == itype_hotplate ) {
+                    tool.item_tags.insert( flag_HEATS_FOOD );
+                }
+                add_item_by_items_type_cache( tool, false );
+            }
+            found_parts.insert( &*crafterpart );
         }
 
         if( faupart && !found_parts.contains( &*faupart ) ) {
@@ -592,96 +607,6 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
             found_parts.insert( &*faupart );
         }
 
-        static const flag_id flag_PSEUDO( "PSEUDO" );
-        static const flag_id flag_HEATS_FOOD( "HEATS_FOOD" );
-        static const flag_id flag_FLATSURF( "FLAT_SURFACE" );
-
-        if( kpart && !found_parts.contains( &*kpart ) ) {
-            item &hotplate = *item::spawn_temporary( "hotplate", bday );
-            hotplate.charges = veh->fuel_left( itype_battery, true );
-            hotplate.item_tags.insert( flag_PSEUDO );
-            // TODO: Allow disabling
-            hotplate.item_tags.insert( flag_HEATS_FOOD );
-            add_item_by_items_type_cache( hotplate, false );
-
-            item &pot = *item::spawn_temporary( "pot", bday );
-            pot.set_flag( flag_PSEUDO );
-            add_item_by_items_type_cache( pot, false );
-            item &pan = *item::spawn_temporary( "pan", bday );
-            pan.set_flag( flag_PSEUDO );
-            add_item_by_items_type_cache( pan, false );
-            found_parts.insert( &*kpart );
-        }
-        if( butcherpart &&
-            !found_parts.contains( &*butcherpart ) ) { //copy n paste code moment(this will go wrong)
-            item &butchery = *item::spawn_temporary( "fake_adv_butchery", bday );
-            butchery.charges = veh->fuel_left( itype_battery, true );
-            butchery.item_tags.insert( flag_PSEUDO );
-            //A very hacky way to make game take vehicle part into the account for flat surface
-            butchery.item_tags.insert( flag_FLATSURF );
-            add_item_by_items_type_cache( butchery, false );
-            found_parts.insert( &*butcherpart );
-        }
-        if( weldpart && !found_parts.contains( &*weldpart ) ) {
-            item &welder = *item::spawn_temporary( "welder", bday );
-            welder.charges = veh->fuel_left( itype_battery, true );
-            welder.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( welder, false );
-
-            item &soldering_iron = *item::spawn_temporary( "soldering_iron", bday );
-            soldering_iron.charges = veh->fuel_left( itype_battery, true );
-            soldering_iron.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( soldering_iron, false );
-            found_parts.insert( &*weldpart );
-        }
-        if( craftpart && !found_parts.contains( &*craftpart ) ) {
-            item &vac_sealer = *item::spawn_temporary( "vac_sealer", bday );
-            vac_sealer.charges = veh->fuel_left( itype_battery, true );
-            vac_sealer.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( vac_sealer, false );
-
-            item &dehydrator = *item::spawn_temporary( "dehydrator", bday );
-            dehydrator.charges = veh->fuel_left( itype_battery, true );
-            dehydrator.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( dehydrator, false );
-
-            item &food_processor = *item::spawn_temporary( "food_processor", bday );
-            food_processor.charges = veh->fuel_left( itype_battery, true );
-            food_processor.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( food_processor, false );
-
-            item &press = *item::spawn_temporary( "press", bday );
-            press.charges = veh->fuel_left( itype_battery, true );
-            press.set_flag( flag_PSEUDO );
-            add_item_by_items_type_cache( press, false );
-            found_parts.insert( &*craftpart );
-        }
-        if( forgepart && !found_parts.contains( &*forgepart ) ) {
-            item &forge = *item::spawn_temporary( "forge", bday );
-            forge.charges = veh->fuel_left( itype_battery, true );
-            forge.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( forge, false );
-            found_parts.insert( &*forgepart );
-        }
-        if( kilnpart && !found_parts.contains( &*kilnpart ) ) {
-            item &kiln = *item::spawn_temporary( "kiln", bday );
-            kiln.charges = veh->fuel_left( itype_battery, true );
-            kiln.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( kiln, false );
-            found_parts.insert( &*kilnpart );
-        }
-        if( chempart && !found_parts.contains( &*chempart ) ) {
-            item &chemistry_set = *item::spawn_temporary( "chemistry_set", bday );
-            chemistry_set.charges = veh->fuel_left( itype_battery, true );
-            chemistry_set.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( chemistry_set, false );
-
-            item &electrolysis_kit = *item::spawn_temporary( "electrolysis_kit", bday );
-            electrolysis_kit.charges = veh->fuel_left( itype_battery, true );
-            electrolysis_kit.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( electrolysis_kit, false );
-            found_parts.insert( &*chempart );
-        }
         if( autoclavepart && !found_parts.contains( &*autoclavepart ) ) {
             item &autoclave = *item::spawn_temporary( "autoclave", bday );
             autoclave.charges = veh->fuel_left( itype_battery, true );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5305,150 +5305,35 @@ std::vector<detached_ptr<item>> map::use_charges( const tripoint &origin, const 
             continue;
         }
 
-        const std::optional<vpart_reference> kpart = vp.part_with_feature( "FAUCET", true );
-        const std::optional<vpart_reference> weldpart = vp.part_with_feature( "WELDRIG", true );
-        const std::optional<vpart_reference> craftpart = vp.part_with_feature( "CRAFTRIG", true );
-        const std::optional<vpart_reference> butcherpart = vp.part_with_feature( "BUTCHER_EQ", true );
-        const std::optional<vpart_reference> forgepart = vp.part_with_feature( "FORGE", true );
-        const std::optional<vpart_reference> kilnpart = vp.part_with_feature( "KILN", true );
-        const std::optional<vpart_reference> chempart = vp.part_with_feature( "CHEMLAB", true );
+        const std::optional<vpart_reference> crafterpart = vp.part_with_feature( "CRAFTER", true );
+        const std::optional<vpart_reference> faupart = vp.part_with_feature( "FAUCET", true );
         const std::optional<vpart_reference> autoclavepart = vp.part_with_feature( "AUTOCLAVE", true );
         const std::optional<vpart_reference> cargo = vp.part_with_feature( "CARGO", true );
 
-        if( kpart ) { // we have a faucet, now to see what to drain
+        if( crafterpart ) {
+            for( itype_id id : crafterpart->info().craftertools() ) {
+                if( type == id ) {
+                    detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
+                    tmp->charges = crafterpart->vehicle().drain( itype_battery, quantity );
+                    quantity -= tmp->charges;
+                    ret.push_back( std::move( tmp ) );
+
+                    if( quantity == 0 ) {
+                        return ret;
+                    }
+                }
+            }
+        }
+        if( faupart ) { // we have a faucet, now to see what to drain
             itype_id ftype = itype_id::NULL_ID();
 
-            // Special case hotplates which draw battery power
-            if( type == itype_hotplate ) {
-                ftype = itype_battery;
-            } else {
-                ftype = type;
-            }
+            ftype = type;
 
             // TODO: add a sane birthday arg
             //TODO!: check if we actually need the return  here
             detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
-            tmp->charges = kpart->vehicle().drain( ftype, quantity );
+            tmp->charges = faupart->vehicle().drain( ftype, quantity );
             // TODO: Handle water poison when crafting starts respecting it
-            quantity -= tmp->charges;
-            ret.push_back( std::move( tmp ) );
-
-            if( quantity == 0 ) {
-                return ret;
-            }
-        }
-
-        if( weldpart ) { // we have a weldrig, now to see what to drain
-            itype_id ftype = itype_id::NULL_ID();
-
-            if( type == itype_welder ) {
-                ftype = itype_battery;
-            } else if( type == itype_soldering_iron ) {
-                ftype = itype_battery;
-            }
-            // TODO: add a sane birthday arg
-            detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
-            tmp->charges = weldpart->vehicle().drain( ftype, quantity );
-            quantity -= tmp->charges;
-            ret.push_back( std::move( tmp ) );
-
-            if( quantity == 0 ) {
-                return ret;
-            }
-        }
-
-        if( craftpart ) { // we have a craftrig, now to see what to drain
-            itype_id ftype = itype_id::NULL_ID();
-
-            if( type == itype_press ) {
-                ftype = itype_battery;
-            } else if( type == itype_vac_sealer ) {
-                ftype = itype_battery;
-            } else if( type == itype_dehydrator ) {
-                ftype = itype_battery;
-            } else if( type == itype_food_processor ) {
-                ftype = itype_battery;
-            }
-
-            // TODO: add a sane birthday arg
-            detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
-            tmp->charges = craftpart->vehicle().drain( ftype, quantity );
-            quantity -= tmp->charges;
-            ret.push_back( std::move( tmp ) );
-
-            if( quantity == 0 ) {
-                return ret;
-            }
-        }
-
-        if( butcherpart ) {// we have a butchery station, now to see what to drain
-            itype_id ftype = itype_id::NULL_ID();
-
-            if( type == itype_butchery ) {
-                ftype = itype_battery;
-            }
-
-            // TODO: add a sane birthday arg
-            detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
-            tmp->charges = butcherpart->vehicle().drain( ftype, quantity );
-            quantity -= tmp->charges;
-            ret.push_back( std::move( tmp ) );
-
-            if( quantity == 0 ) {
-                return ret;
-            }
-        }
-
-        if( forgepart ) { // we have a veh_forge, now to see what to drain
-            itype_id ftype = itype_id::NULL_ID();
-
-            if( type == itype_forge ) {
-                ftype = itype_battery;
-            }
-
-            // TODO: add a sane birthday arg
-            detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
-            tmp->charges = forgepart->vehicle().drain( ftype, quantity );
-            quantity -= tmp->charges;
-            ret.push_back( std::move( tmp ) );
-
-            if( quantity == 0 ) {
-                return ret;
-            }
-        }
-
-        if( kilnpart ) { // we have a veh_kiln, now to see what to drain
-            itype_id ftype = itype_id::NULL_ID();
-
-            if( type == itype_kiln ) {
-                ftype = itype_battery;
-            }
-
-            // TODO: add a sane birthday arg
-            detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
-            tmp->charges = kilnpart->vehicle().drain( ftype, quantity );
-            quantity -= tmp->charges;
-            ret.push_back( std::move( tmp ) );
-
-            if( quantity == 0 ) {
-                return ret;
-            }
-        }
-
-        if( chempart ) { // we have a chem_lab, now to see what to drain
-            itype_id ftype = itype_id::NULL_ID();
-
-            if( type == itype_chemistry_set ) {
-                ftype = itype_battery;
-            } else if( type == itype_hotplate ) {
-                ftype = itype_battery;
-            } else if( type == itype_electrolysis_kit ) {
-                ftype = itype_battery;
-            }
-
-            // TODO: add a sane birthday arg
-            detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
-            tmp->charges = chempart->vehicle().drain( ftype, quantity );
             quantity -= tmp->charges;
             ret.push_back( std::move( tmp ) );
 

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -342,6 +342,23 @@ void vpart_info::load_workbench( std::optional<vpslot_workbench> &wbptr, const J
     assert( wbptr );
 }
 
+void vpart_info::load_crafter( std::optional<vpslot_crafter> &craftptr, const JsonObject &jo )
+{
+    vpslot_crafter craft_info{};
+    if( craftptr ) {
+        craft_info = *craftptr;
+    }
+
+    JsonArray tools = jo.get_array( "integrated_tools" );
+
+    for( std::string cur : tools ) {
+        craft_info.fake_parts.emplace_back( itype_id( cur ) );
+    }
+
+    craftptr = craft_info;
+    assert( craftptr );
+}
+
 /**
  * Reads in a vehicle part from a JsonObject.
  */
@@ -487,7 +504,9 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
     if( def.has_flag( "WORKBENCH" ) ) {
         load_workbench( def.workbench_info, jo );
     }
-
+    if( def.has_flag( "CRAFTER" ) ) {
+        load_crafter( def.crafter_info, jo );
+    }
     // Dummy
     // TODO: Implement
     jo.get_string_array( "categories" );
@@ -975,7 +994,10 @@ int vpart_info::propeller_diameter() const
 {
     return has_flag( VPFLAG_PROPELLER ) ? propeller_info->propeller_diameter : 0;
 }
-
+const std::vector<itype_id> vpart_info::craftertools() const
+{
+    return crafter_info->fake_parts;
+}
 const std::optional<vpslot_workbench> &vpart_info::get_workbench_info() const
 {
     return workbench_info;

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -131,6 +131,10 @@ struct vpslot_workbench {
     units::volume allowed_volume = 0_ml;
 };
 
+struct vpslot_crafter {
+    std::vector<itype_id> fake_parts;
+};
+
 struct transform_terrain_data {
     std::set<std::string> pre_flags;
     std::string post_terrain;
@@ -154,6 +158,7 @@ class vpart_info
         std::optional<vpslot_wing> wing_info;
         std::optional<vpslot_balloon> balloon_info;
         std::optional<vpslot_workbench> workbench_info;
+        std::optional<vpslot_crafter> crafter_info;
 
     public:
         /** Translated name of a part */
@@ -323,6 +328,7 @@ class vpart_info
         float lift_coff() const;
         int propeller_diameter() const;
         float balloon_height() const;
+        const std::vector<itype_id> craftertools() const;
         /**
          * Getter for optional workbench info
          */
@@ -367,6 +373,7 @@ class vpart_info
         static void load_wing( std::optional<vpslot_wing> &wptr, const JsonObject &jo );
         static void load_balloon( std::optional<vpslot_balloon> &balptr, const JsonObject &jo );
         static void load_propeller( std::optional<vpslot_propeller> &proptr, const JsonObject &jo );
+        static void load_crafter( std::optional<vpslot_crafter> &craftptr, const JsonObject &jo );
         static void load( const JsonObject &jo, const std::string &src );
         static void finalize();
         static void check();


### PR DESCRIPTION
## Purpose of change (The Why)
For the fun of it

## Describe the solution (The How)
Let vehicle parts define integrated tools using the "CRAFTER" flag and the "integrated_tools" array

## Describe alternatives you've considered
None

## Testing
Spawn a welding cart
Weld something
You consume welding cart charges
It no longer uses the old system

## Additional context
This is not a port
I have not written docs yet, I will get to it
## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.