### PR TITLE
feat: Item groups can now be reset and have some items deleted & make CRIT use it

### DIFF
--- a/data/mods/CRT_EXPANSION/items/crt_item_groups.json
+++ b/data/mods/CRT_EXPANSION/items/crt_item_groups.json
@@ -84,44 +84,30 @@
   {
     "type": "item_group",
     "id": "mil_jackets",
-    "items": [ {
-        "distribution": [
-          { "item": "crt_jacket", "prob": 10 },
-          { "item": "crt_iduster", "prob": 10 },
-          { "item": "jacket_army", "prob": 80 }
-        ]
-    } ]
+    "items": [
+      {
+        "distribution": [ { "item": "crt_jacket", "prob": 10 }, { "item": "crt_iduster", "prob": 10 }, { "item": "jacket_army", "prob": 80 } ]
+      }
+    ]
   },
   {
     "type": "item_group",
     "id": "mil_pants",
-    "items": [ {
-        "distribution": [
-          { "item": "crt_pants", "prob": 20 },
-          { "item": "pants_army", "prob": 80 }
-        ]
-    } ]
+    "items": [ { "distribution": [ { "item": "crt_pants", "prob": 20 }, { "item": "pants_army", "prob": 80 } ] } ]
   },
   {
     "type": "item_group",
     "id": "mil_boots",
-    "items": [ {
-        "distribution": [
-          { "item": "crt_la_boots", "prob": 10 },
-          { "item": "crt_boots", "prob": 10 },
-          { "item": "boots_combat", "prob": 80 }
-        ]
-    } ]
+    "items": [
+      {
+        "distribution": [ { "item": "crt_la_boots", "prob": 10 }, { "item": "crt_boots", "prob": 10 }, { "item": "boots_combat", "prob": 80 } ]
+      }
+    ]
   },
   {
     "type": "item_group",
     "id": "mil_belts",
-    "items": [ {
-        "distribution": [
-          { "item": "crt_belt", "prob": 20 },
-          { "item": "webbing_belt", "prob": 80 }
-        ]
-    } ]
+    "items": [ { "distribution": [ { "item": "crt_belt", "prob": 20 }, { "item": "webbing_belt", "prob": 80 } ] } ]
   },
   {
     "type": "item_group",
@@ -207,18 +193,8 @@
     "type": "item_group",
     "subtype": "collection",
     "//": "Standard (non-winter) set of clothes worn by soldiers and paramilitary forces.",
-    "delete": [
-      { "item": "boots_combat" },
-      { "item": "jacket_army" },
-      { "item": "pants_army" },
-      { "item": "webbing_belt" }
-    ],
-    "items": [
-      { "group": "mil_jackets" },
-      { "group": "mil_boots" },
-      { "group": "mil_pants" },
-      { "group": "mil_belts" }
-    ]
+    "delete": [ { "item": "boots_combat" }, { "item": "jacket_army" }, { "item": "pants_army" }, { "item": "webbing_belt" } ],
+    "items": [ { "group": "mil_jackets" }, { "group": "mil_boots" }, { "group": "mil_pants" }, { "group": "mil_belts" } ]
   },
   {
     "id": "clothing_military_winter",

--- a/data/mods/CRT_EXPANSION/items/crt_item_groups.json
+++ b/data/mods/CRT_EXPANSION/items/crt_item_groups.json
@@ -83,6 +83,48 @@
   },
   {
     "type": "item_group",
+    "id": "mil_jackets",
+    "items": [ {
+        "distribution": [
+          { "item": "crt_jacket", "prob": 10 },
+          { "item": "crt_iduster", "prob": 10 },
+          { "item": "jacket_army", "prob": 80 }
+        ]
+    } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mil_pants",
+    "items": [ {
+        "distribution": [
+          { "item": "crt_pants", "prob": 20 },
+          { "item": "pants_army", "prob": 80 }
+        ]
+    } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mil_boots",
+    "items": [ {
+        "distribution": [
+          { "item": "crt_la_boots", "prob": 10 },
+          { "item": "crt_boots", "prob": 10 },
+          { "item": "boots_combat", "prob": 80 }
+        ]
+    } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mil_belts",
+    "items": [ {
+        "distribution": [
+          { "item": "crt_belt", "prob": 20 },
+          { "item": "webbing_belt", "prob": 80 }
+        ]
+    } ]
+  },
+  {
+    "type": "item_group",
     "id": "crt_rare",
     "items": [
       { "item": "ds_monitor", "prob": 10 },
@@ -165,7 +207,18 @@
     "type": "item_group",
     "subtype": "collection",
     "//": "Standard (non-winter) set of clothes worn by soldiers and paramilitary forces.",
-    "items": [ { "group": "crt_armor", "prob": 15 } ]
+    "delete": [
+      { "item": "boots_combat" },
+      { "item": "jacket_army" },
+      { "item": "pants_army" },
+      { "item": "webbing_belt" }
+    ],
+    "items": [
+      { "group": "mil_jackets" },
+      { "group": "mil_boots" },
+      { "group": "mil_pants" },
+      { "group": "mil_belts" }
+    ]
   },
   {
     "id": "clothing_military_winter",

--- a/docs/en/mod/json/reference/items/item_spawn.md
+++ b/docs/en/mod/json/reference/items/item_spawn.md
@@ -35,10 +35,12 @@ The format is this:
     "id": "<some name>",
     "ammo": <some number>,
     "magazine": <some number>,
+    "delete": [ ... ],
     "entries": [ ... ]
 }
 ```
 
+`purge` is optional. It is a bool for weather or not all previous things defined in the item group should be purged.
 `subtype` is optional. It can be `collection` or `distribution`. If unspecified, it defaults to
 `old`, which denotes that this item group uses the old format (which is technically a distribution).
 
@@ -153,6 +155,23 @@ explicit min and max values. In other words `"count": [a,b]` is the same as
 
 The container is checked and the item is put inside the container, and the charges of the item are
 capped/increased to match the size of the container.
+
+### Delete array
+
+The `delete` list contains entries, each of which can be one of the followingi:
+
+1. Item
+   ```json
+   { "item": "<item-id>" }
+   ```
+
+2. Group
+   ```json
+   { "group": "<group-id>" }
+   ```
+
+All previously defined items with these ids will be removed from the list, if they do not exist
+there is no error emmitted, it just skips along ( as it was most likely already removed by another mod )
 
 ### Ammo and Magazines
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3240,9 +3240,14 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
     } else if( subtype != "collection" ) {
         jsobj.throw_error( "unknown item group type", "subtype" );
     }
+    if( jsobj.has_bool( "purge" ) ) {
+        if( jsobj.get_bool( "purge" ) ) {
+            isd = nullptr;
+        }
+    }
+
     Item_group *ig = make_group_or_throw( group_id, isd, type, jsobj.get_int( "ammo", 0 ),
                                           jsobj.get_int( "magazine", 0 ) );
-
     if( subtype == "old" ) {
         for( const JsonValue entry : jsobj.get_array( "items" ) ) {
             if( entry.test_object() ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3296,9 +3296,9 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
         for( const JsonValue entry : jsobj.get_array( "delete" ) ) {
             if( entry.test_object() ) {
                 JsonObject obj = entry.get_object();
-                if( obj.has_member( "item" ) ){
+                if( obj.has_member( "item" ) ) {
                     ig->remove_specific_item( obj.get_string( "item" ) );
-                } else if( obj.has_member( "group" ) ){
+                } else if( obj.has_member( "group" ) ) {
                     ig->remove_specific_group( obj.get_string( "group" ) );
                 }
             }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3287,6 +3287,18 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
             }
         }
     }
+    if( jsobj.has_member( "delete" ) ) {
+        for( const JsonValue entry : jsobj.get_array( "delete" ) ) {
+            if( entry.test_object() ) {
+                JsonObject obj = entry.get_object();
+                if( obj.has_member( "item" ) ){
+                    ig->remove_specific_item( obj.get_string( "item" ) );
+                } else if( obj.has_member( "group" ) ){
+                    ig->remove_specific_group( obj.get_string( "group" ) );
+                }
+            }
+        }
+    }
 }
 
 

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -548,6 +548,44 @@ bool Item_group::remove_item( const itype_id &itemid )
     return items.empty();
 }
 
+bool Item_group::remove_specific_item( const std::string &itemid )
+{
+    for( prop_list::iterator a = items.begin(); a != items.end(); ) {
+        auto b = dynamic_cast<Single_item_creator*>( a.get() );
+        if( b == nullptr ){
+            ++a;
+        } else if( ( *b )->type == Single_item_creator::Type::S_ITEM ) {
+            if( itemid == ( *b )->id ) {
+                sum_prob -= ( *a )->probability;
+                a = items.erase( a );
+                return true;
+            }
+        } else {
+            ++a;
+        }
+    }
+    return items.empty();
+}
+
+bool Item_group::remove_specific_group( const std::string &itemid )
+{
+    for( prop_list::iterator a = items.begin(); a != items.end(); ) {
+        auto b = dynamic_cast<Single_item_creator*>( *a );
+        if( b == nullptr ){
+            ++a;
+        } else if( ( *b )->type == Single_item_creator::Type::S_ITEM_GROUP ) {
+            if( itemid == ( *b )->id ) {
+                sum_prob -= ( *a )->probability;
+                a = items.erase( a );
+                return true;
+            }
+        } else {
+            ++a;
+        }
+    }
+    return items.empty();
+}
+
 bool Item_group::replace_item( const itype_id &itemid, const itype_id &replacementid )
 {
     for( const std::unique_ptr<Item_spawn_data> &elem : items ) {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -551,8 +551,8 @@ bool Item_group::remove_item( const itype_id &itemid )
 bool Item_group::remove_specific_item( const std::string &itemid )
 {
     for( prop_list::iterator a = items.begin(); a != items.end(); ) {
-        auto b = dynamic_cast<Single_item_creator*>( ( &*a )->get() );
-        if( b == nullptr ){
+        auto b = dynamic_cast<Single_item_creator *>( ( &*a )->get() );
+        if( b == nullptr ) {
             ++a;
         } else if( b->type == Single_item_creator::Type::S_ITEM ) {
             if( itemid == b->id ) {
@@ -571,8 +571,8 @@ bool Item_group::remove_specific_item( const std::string &itemid )
 bool Item_group::remove_specific_group( const std::string &itemid )
 {
     for( prop_list::iterator a = items.begin(); a != items.end(); ) {
-        auto b = dynamic_cast<Single_item_creator*>( ( &*a )->get() );
-        if( b == nullptr ){
+        auto b = dynamic_cast<Single_item_creator *>( ( &*a )->get() );
+        if( b == nullptr ) {
             ++a;
         } else if( b->type == Single_item_creator::Type::S_ITEM_GROUP ) {
             if( itemid == b->id ) {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -551,11 +551,11 @@ bool Item_group::remove_item( const itype_id &itemid )
 bool Item_group::remove_specific_item( const std::string &itemid )
 {
     for( prop_list::iterator a = items.begin(); a != items.end(); ) {
-        auto b = dynamic_cast<Single_item_creator*>( a.get() );
+        auto b = dynamic_cast<Single_item_creator*>( ( &*a )->get() );
         if( b == nullptr ){
             ++a;
-        } else if( ( *b )->type == Single_item_creator::Type::S_ITEM ) {
-            if( itemid == ( *b )->id ) {
+        } else if( b->type == Single_item_creator::Type::S_ITEM ) {
+            if( itemid == b->id ) {
                 sum_prob -= ( *a )->probability;
                 a = items.erase( a );
                 return true;
@@ -570,11 +570,11 @@ bool Item_group::remove_specific_item( const std::string &itemid )
 bool Item_group::remove_specific_group( const std::string &itemid )
 {
     for( prop_list::iterator a = items.begin(); a != items.end(); ) {
-        auto b = dynamic_cast<Single_item_creator*>( *a );
+        auto b = dynamic_cast<Single_item_creator*>( ( &*a )->get() );
         if( b == nullptr ){
             ++a;
-        } else if( ( *b )->type == Single_item_creator::Type::S_ITEM_GROUP ) {
-            if( itemid == ( *b )->id ) {
+        } else if( b->type == Single_item_creator::Type::S_ITEM_GROUP ) {
+            if( itemid == b->id ) {
                 sum_prob -= ( *a )->probability;
                 a = items.erase( a );
                 return true;

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -560,6 +560,7 @@ bool Item_group::remove_specific_item( const std::string &itemid )
                 a = items.erase( a );
                 return true;
             }
+            ++a;
         } else {
             ++a;
         }
@@ -579,6 +580,7 @@ bool Item_group::remove_specific_group( const std::string &itemid )
                 a = items.erase( a );
                 return true;
             }
+            ++a;
         } else {
             ++a;
         }

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -295,6 +295,8 @@ class Item_group : public Item_spawn_data
         detached_ptr<item> create_single( const time_point &birthday, RecursionList &rec ) const override;
         void check_consistency( const std::string &context ) const override;
         bool remove_item( const itype_id &itemid ) override;
+        bool remove_specific_item( const std::string &itemid );
+        bool remove_specific_group( const std::string &itemid );
         bool replace_item( const itype_id &itemid, const itype_id &replacementid ) override;
         bool has_item( const itype_id &itemid ) const override;
         std::set<const itype *> every_item() const override;


### PR DESCRIPTION
## Purpose of change (The Why)
Seemed to be a wanted change,
And 100% needed for the CRIT mod
So here you go!

## Describe the solution (The How)
Add the "remove" array to item groups
With an { "item": item_id } it will remove the item from the group
With an { "group": group_id } it will remove the subgroup from the group
This may not function for nested distributions or collections, but is much better then the current state.

## Describe alternatives you've considered
Don't add it?
Change the variable names

## Testing
Go into a military gear installation with CRIT on, see that it properly deletes only certain items
Or add it to your own mods and watch the fix work

## Additional context
THE PRIORITY LIST NEEDS TO EXIST, SAVE ME FROM THE TEDIUM OF JSONIZING THE CHARCOAL COOKER!

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.