### PR TITLE
docs: place purge itemgroup documentation in both places it should be

### DIFF
--- a/docs/en/mod/json/reference/items/item_spawn.md
+++ b/docs/en/mod/json/reference/items/item_spawn.md
@@ -35,6 +35,7 @@ The format is this:
     "id": "<some name>",
     "ammo": <some number>,
     "magazine": <some number>,
+    "purge": <true/false>,
     "delete": [ ... ],
     "entries": [ ... ]
 }


### PR DESCRIPTION
## Purpose of change (The Why)
I'm really bad at missing little things
Followup to the mildest mistake in #7191 
## Describe the solution (The How)
Add purge field docs to missing spot

## Describe alternatives you've considered
Leave the docs that way, It sounds fine :)

## Testing
Eyes

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.