### PR TITLE
feat(ui): improve monologue menu

### DIFF
--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -370,7 +370,7 @@ bool Messages::has_undisplayed_messages()
 }
 
 // Returns pairs of message log type id and untranslated name
-static const std::vector<std::pair<game_message_type, const char *>> &msg_type_and_names()
+const std::vector<std::pair<game_message_type, const char *>> &msg_type_and_names()
 {
     static const std::vector<std::pair<game_message_type, const char *>> type_n_names = {
         { m_good, translate_marker_context( "message type", "good" ) },

--- a/src/messages.h
+++ b/src/messages.h
@@ -35,6 +35,7 @@ void serialize( JsonOut &json );
 void deserialize( const JsonObject &json );
 } // namespace Messages
 
+const std::vector<std::pair<game_message_type, const char *>> &msg_type_and_names();
 void add_msg( std::string msg );
 template<typename ...Args>
 inline void add_msg( const std::string &msg, Args &&... args )

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -617,10 +617,47 @@ void game::chat()
             break;
         }
         case NPC_CHAT_MONOLOGUE: {
-            std::string popupdesc =
-                _( "What do you want to monologue?  (This has no in-game effect! Use +, -, or ? at the start to add context.)" );
+            // Build help text
+            const auto &help_fmt = _(
+                                       "<color_light_gray>You can add a prefix to your monologue to set the tone or emotion."
+                                       " Valid prefixes are:</color> %s\n"
+                                       "\n"
+                                       "<color_white>Examples:</color>\n"
+                                       "  <color_light_green>good: You feel like it's going to be a good day.</color>\n"
+                                       "  <color_light_red>bad: You don't like the look of this place…</color>\n"
+                                       "  <color_light_blue>info: The empty house reminds you of old times.</color>\n"
+                                       "  <color_yellow>warning: You say 'Stay close, I hear something moving!'</color>\n"
+                                       "\n"
+                                       "<color_light_gray>Leave off the prefix for a neutral monologue.</color>\n"
+                                   );
+
+            std::vector<std::string> type_strings;
+            const auto &type_list = msg_type_and_names();
+
+            for( auto it = type_list.begin(); it != type_list.end(); ++it ) {
+                if( debug_mode || it->first != m_debug ) {
+                    const auto &col_name = get_all_colors().get_name( msgtype_to_color( it->first ) );
+                    type_strings.push_back( string_format(
+                                                pgettext( "message log", "<color_%s>%s</color>" ),
+                                                col_name, pgettext( "message type", it->second ) ) );
+                }
+            }
+
+            // Join them with commas, period at the end
+            std::string type_text;
+            for( size_t i = 0; i < type_strings.size(); ++i ) {
+                type_text += type_strings[i];
+                if( i + 1 < type_strings.size() ) {
+                    type_text += "<color_light_gray>, </color>";
+                } else {
+                    type_text += "<color_light_gray>.</color>";
+                }
+            }
+
+            std::string popupdesc = string_format( help_fmt, type_text );
+
             string_input_popup popup;
-            popup.title( _( "Monologue" ) )
+            popup.title( _( "" ) )
             .width( 64 )
             .description( popupdesc )
             .identifier( "sentence" )
@@ -756,16 +793,46 @@ void game::chat()
         u.shout( string_format( _( "%s yelling %s" ), u.disp_name(), message ), is_order );
     }
     if( !monologue_msg.empty() ) {
-        if( monologue_msg[0] == '-' ) {
-            add_msg( m_bad, _( "%s" ), monologue_msg.substr( 1 ) );
-        } else if( monologue_msg[0] == '+' ) {
-            add_msg( m_good, _( "%s" ), monologue_msg.substr( 1 ) );
-        } else if( monologue_msg[0] == '?' ) {
-            add_msg( m_info, _( "%s" ), monologue_msg.substr( 1 ) );
-        } else {
+        // Normalize input for case-insensitive matching
+        std::string lower = monologue_msg;
+        std::transform( lower.begin(), lower.end(), lower.begin(), ::tolower );
+
+        bool matched = false;
+        const auto &type_list = msg_type_and_names();
+
+        for( const auto &entry : type_list ) {
+            if( !debug_mode && entry.first == m_debug ) {
+                continue; // skip debug type unless debug_mode is on
+            }
+
+            std::string type_name = pgettext( "message type", entry.second );
+            std::string prefix = type_name + ":"; // e.g. "good:" or "bad:"
+
+            // lowercase for comparison
+            std::string lower_prefix = prefix;
+            std::transform( lower_prefix.begin(), lower_prefix.end(), lower_prefix.begin(), ::tolower );
+
+            if( lower.rfind( lower_prefix, 0 ) == 0 ) {
+                // Match found: remove prefix
+                std::string text = monologue_msg.substr( prefix.size() );
+
+                // Trim a leading space if present
+                if( !text.empty() && text[0] == ' ' ) {
+                    text = text.substr( 1 );
+                }
+
+                add_msg( entry.first, _( "%s" ), text );
+                matched = true;
+                break;
+            }
+        }
+
+        if( !matched ) {
+            // No prefix: just show plain text
             add_msg( _( "%s" ), monologue_msg );
         }
     }
+
 
     u.moves -= 100;
 }


### PR DESCRIPTION
## Purpose of change (The Why)
Our monologue menu was hacked together from DDA's addition, and I didn't do a great job.
## Describe the solution (The How)
Steal code from the message log to use in the monologue section.
## Describe alternatives you've considered
## Testing
Spawned into a world, opened the monologue menu and confirmed that each type of message works as expected.
## Additional context
Opening as a draft because although it compiles, I get a linker error for some reason and I'll probably need Scarf or Rosa to look at it.

<img width="1915" height="995" alt="image" src="https://github.com/user-attachments/assets/6a8672cc-ab1e-4b7b-aedc-9af3dda48160" />
## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
