### PR TITLE
feat(mods/crt_expansion): More CRIT rebalances and use of new MOLLE holsters

### DIFF
--- a/data/mods/CRT_EXPANSION/items/crt_armor.json
+++ b/data/mods/CRT_EXPANSION/items/crt_armor.json
@@ -104,8 +104,8 @@
       "draw_cost": 150,
       "multi": 3,
       "skills": [ "pistol", "smg", "shotgun", "rifle", "launcher" ],
-      "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD", "SHEATH_AXE", "MAG_COMPACT", "MAG_BULKY", "MAG_BELT", "SPEEDLOADER", "BELT_CLIP" ],
-    }
+      "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD", "SHEATH_AXE", "MAG_COMPACT", "MAG_BULKY", "MAG_BELT", "SPEEDLOADER", "BELT_CLIP" ]
+    },
     "flags": [ "BELTED", "OVERSIZE", "NO_QUICKDRAW", "STURDY", "WATERPROOF" ]
   },
   {
@@ -116,6 +116,7 @@
     "description": "C.R.I.T. standard-issue chestrig, has mesh and MOLLE loops for gear and slots with light-armor padding.",
     "color": "dark_gray",
     "material": [ "kevlar", "plastic" ],
+    "use_action": {
       "type": "holster",
       "holster_prompt": "Stash ammo",
       "holster_msg": "You stash your %s.",
@@ -123,7 +124,7 @@
       "max_volume": "750 ml",
       "draw_cost": 40,
       "skills": [ "pistol", "smg", "shotgun", "launcher" ],
-      "flags": [ "SHEATH_KNIFE", "BELT_CLIP" "MAG_COMPACT", "SPEEDLOADER" ]
+      "flags": [ "SHEATH_KNIFE", "BELT_CLIP", "MAG_COMPACT", "SPEEDLOADER" ]
     },
     "flags": [ "STURDY", "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS" ]
   },

--- a/data/mods/CRT_EXPANSION/items/crt_armor.json
+++ b/data/mods/CRT_EXPANSION/items/crt_armor.json
@@ -90,14 +90,22 @@
     "copy-from": "molle_pack",
     "type": "ARMOR",
     "name": "C.R.I.T. backpack",
-    "description": "C.R.I.T. standard-issue pack.  Based on the MOLLE backpack's design, this smaller pack strikes a fine balance between storage space and encumbrance and allows a larger weapon to be holstered, drawing and holstering is still rather awkward even with the magnetized clips, but practice helps.",
+    "description": "C.R.I.T. standard-issue pack.  Based on the MOLLE backpack's design, this smaller pack strikes a fine balance between storage space and encumbrance and allows multiple larger weapons to be holstered, drawing and holstering is still rather awkward even with the magnetized clips, but practice helps.",
     "color": "dark_gray",
     "storage": "9 L",
     "encumbrance": 3,
     "max_encumbrance": 7,
     "material_thickness": 2,
     "material": [ "leather", "kevlar" ],
-    "use_action": { "type": "holster", "max_volume": "3250 ml", "draw_cost": 150, "skills": [ "smg", "shotgun", "rifle" ] },
+    "use_action": {
+      "type": "holster",
+      "max_volume": "3250 ml",
+      "min_volume": "250ml",
+      "draw_cost": 150,
+      "multi": 3,
+      "skills": [ "pistol", "smg", "shotgun", "rifle", "launcher" ],
+      "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD", "SHEATH_AXE", "MAG_COMPACT", "MAG_BULKY", "MAG_BELT", "SPEEDLOADER", "BELT_CLIP" ],
+    }
     "flags": [ "BELTED", "OVERSIZE", "NO_QUICKDRAW", "STURDY", "WATERPROOF" ]
   },
   {
@@ -108,6 +116,15 @@
     "description": "C.R.I.T. standard-issue chestrig, has mesh and MOLLE loops for gear and slots with light-armor padding.",
     "color": "dark_gray",
     "material": [ "kevlar", "plastic" ],
+      "type": "holster",
+      "holster_prompt": "Stash ammo",
+      "holster_msg": "You stash your %s.",
+      "multi": 4,
+      "max_volume": "750 ml",
+      "draw_cost": 40,
+      "skills": [ "pistol", "smg", "shotgun", "launcher" ],
+      "flags": [ "SHEATH_KNIFE", "BELT_CLIP" "MAG_COMPACT", "SPEEDLOADER" ]
+    },
     "flags": [ "STURDY", "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {

--- a/data/mods/CRT_EXPANSION/items/crt_clothes.json
+++ b/data/mods/CRT_EXPANSION/items/crt_clothes.json
@@ -96,23 +96,6 @@
     "flags": [ "SKINTIGHT", "WATER_FRIENDLY" ]
   },
   {
-    "id": "crt_belt",
-    "copy-from": "survivor_belt_notools",
-    "type": "ARMOR",
-    "name": "C.R.I.T. web belt",
-    "description": "C.R.I.T. standard-issue belt.  Keeps your trousers up and your tools on your hip.",
-    "color": "blue",
-    "material": [ "leather", "brass" ],
-    "use_action": {
-      "type": "holster",
-      "holster_prompt": "Sheath blade",
-      "holster_msg": "You sheath your %s",
-      "min_volume": "0 ml",
-      "max_volume": "1 L",
-      "flags": [ "BELT_CLIP", "SHEATH_KNIFE", "SHEATH_SWORD" ]
-    }
-  },
-  {
     "id": "crt_rec_duster",
     "repairs_like": "duster_survivor",
     "type": "ARMOR",

--- a/data/mods/CRT_EXPANSION/items/crt_item_groups.json
+++ b/data/mods/CRT_EXPANSION/items/crt_item_groups.json
@@ -76,8 +76,7 @@
             "distribution": [ { "item": "crt_pants", "prob": 70 }, { "item": "crt_legrig", "prob": 20 }, { "item": "crt_sarmor", "prob": 10 } ]
           },
           { "item": "knife_crt", "prob": 5 }
-        ],
-        "prob": 10
+        ]
       }
     ]
   },
@@ -189,6 +188,12 @@
     ]
   },
   {
+    "id": "clothing_soldier_shirt",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "item": "crt_sarmor", "prob": 5 } ]
+  },
+  {
     "id": "clothing_military",
     "type": "item_group",
     "subtype": "collection",
@@ -201,7 +206,8 @@
     "type": "item_group",
     "subtype": "collection",
     "//": "Winter set of clothes worn by soldiers and paramilitary forces.",
-    "items": [ { "group": "crt_armor", "prob": 15 } ]
+    "delete": [ { "item": "boots_combat" }, { "item": "webbing_belt" } ],
+    "items": [ { "group": "mil_boots" }, { "group": "mil_belts" } ]
   },
   {
     "type": "item_group",

--- a/data/mods/CRT_EXPANSION/scenarios/crt_classes.json
+++ b/data/mods/CRT_EXPANSION/scenarios/crt_classes.json
@@ -112,7 +112,6 @@
           "pants_army",
           "armguard_hard",
           "mre_veggy_box",
-          "crt_backpack",
           "two_way_radio",
           "crt_gloves_liner",
           "gloves_tactical",
@@ -122,7 +121,7 @@
         ],
         "entries": [
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_crt", "container-item": "sheath" },
+          { "item": "crt_backpack", "contents-item": [ "knife_crt" ] },
           { "item": "m4a1", "ammo-item": "556", "contents-item": [ "shoulder_strap", "grip", "holo_sight" ] },
           { "item": "modularvestsuper", "contents-group": "army_mags_m4" }
         ]
@@ -199,14 +198,12 @@
           "crt_canteen",
           "crt_legrig",
           "socks",
-          "crt_la_boots",
-          "knife_crt",
-          "crt_solarpack"
+          "crt_la_boots"
         ],
         "entries": [
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "sleeping_bag_roll", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "crt_laser_pistol", "container-item": "holster" }
+          { "item": "crt_solarpack", "contents-item": [ "crt_laser_pistol", "knife_crt" ] },
+          { "item": "sleeping_bag_roll", "custom-flags": [ "no_auto_equip" ] }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -243,14 +240,12 @@
           "crt_la_boots",
           "two_way_radio",
           "1st_aid",
-          "bandages",
-          "knife_crt",
-          "crt_solarpack"
+          "bandages"
         ],
         "entries": [
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "sleeping_bag_roll", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "crt_laser_pistol", "container-item": "holster" }
+          { "item": "crt_solarpack", "contents-item": [ "crt_laser_pistol", "knife_crt" ] }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -494,7 +489,6 @@
           "crt_helmet",
           "crt_helmet_liner",
           "crt_gasmask",
-          "crt_backpack",
           "crt_em_vest",
           "crt_sarmor",
           "army_top",
@@ -519,8 +513,7 @@
         "entries": [
           { "item": "sleeping_bag_roll", "custom-flags": [ "no_auto_equip" ] },
           { "item": "water_clean", "container-item": "crt_canteen" },
-          { "item": "knife_crt", "container-item": "crt_belt" },
-          { "item": "holster", "contents-group": "crit_gun_specops" },
+          { "item": "crt_backpack", "contents-group": "crit_gun_specops", "contents-item": "knife_crt" },
           { "item": "signal_flare", "charges": 5 }
         ]
       },
@@ -605,7 +598,6 @@
           "crt_helmet",
           "crt_helmet_liner",
           "glasses_bal",
-          "crt_backpack",
           "crt_iduster",
           "army_top",
           "crt_gloves",
@@ -622,8 +614,8 @@
           "pellet"
         ],
         "entries": [
+          { "item": "crt_backpack", "contents-item": [ "crt_hatchet" ] },
           { "item": "pelletgun", "ammo-item": "pellet", "contents-item": "shoulder_strap" },
-          { "item": "crt_hatchet", "container-item": "crt_belt" },
           { "item": "water_clean", "container-item": "canteen" }
         ]
       },


### PR DESCRIPTION
## Purpose of change (The Why)
Follow up to #7169 with regards to CRIT balance
Also does some work following up on #7191 for CRIT (as it only changed clothing_military, not clothing_military_winter)
## Describe the solution (The How)
Buff the CRIT backpack to add the new holster slots (So it aint worse all around)
Have starts that use the CRIT (solar/back)pack use it in replacement of holsters and sheaths
Add CRIT Solider Gear as a rare possibility for solider shirts
Buff the CRIT chestrig to be able to hold small tools & knives so it is distiguishable from the chestrig
Removes duplicated definition of crt_belt, other copy is in crt_armor.json

## Describe alternatives you've considered
None

## Testing
Spawn in, it loads, can pull and place the weapons from the professions backpacks
My eyes don't see any spelling errors!

## Additional context
It does not show stuff in the solarpacks in the Choose character screen, I have no clue why this is...
But once in it properly allows the unholstering and reholstering of weapons

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.