### PR TITLE
fix: Vehicle Parts with the EXTENDABLE flag now can be smashed and collide with things

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1079,7 +1079,8 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
         std::vector<int> parts_in_square = parts_at_relative( part.mount, true );
         int structures_found = 0;
         for( auto &square_part_index : parts_in_square ) {
-            if( part_info( square_part_index ).location == part_location_structure ) {
+            if( part_info( square_part_index ).location == part_location_structure ||
+                part_info( square_part_index ).has_flag( VPFLAG_EXTENDABLE ) ) {
                 structures_found++;
             }
         }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -438,7 +438,7 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
     for( int p = 0; static_cast<size_t>( p ) < parts.size(); p++ ) {
         const vpart_info &info = part_info( p );
         if( ( info.location != part_location_structure && !info.has_flag( VPFLAG_EXTENDABLE )
-                && info.rotor_diameter() == 0 ) || parts[ p ].removed ) {
+              && info.rotor_diameter() == 0 ) || parts[ p ].removed ) {
             continue;
         }
         empty = false;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -437,8 +437,8 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
     bool empty = true;
     for( int p = 0; static_cast<size_t>( p ) < parts.size(); p++ ) {
         const vpart_info &info = part_info( p );
-        if( ( info.location != part_location_structure && info.rotor_diameter() == 0 ) ||
-            parts[ p ].removed ) {
+        if( ( info.location != part_location_structure && !info.has_flag( VPFLAG_EXTENDABLE )
+                && info.rotor_diameter() == 0 ) || parts[ p ].removed ) {
             continue;
         }
         empty = false;


### PR DESCRIPTION
## Purpose of change (The Why)
Planes don't flap their wings, nor do blimps flap their balloons

## Describe the solution (The How)
Check not only for it being a structural part, but also being extendible

## Describe alternatives you've considered
Keep the clearly broken behavior

## Testing
Run a plane wing into a car, it breaky
Spawn a sledgehammer, let out your rage on a plane wing, it also breaky
Summon forth a blimp to perform a building demolition, blimp breaky and building breaky

## Additional context
Blimp armor may need to be toned down, I could run through a brick house without issue

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.