### PR TITLE
feat(mods/aftershock): Un-hardcode MP3 player functionality

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -556,11 +556,6 @@
   },
   {
     "type": "item_action",
-    "id": "MP3",
-    "name": { "str": "Play music" }
-  },
-  {
-    "type": "item_action",
     "id": "MP3_ON",
     "name": { "str": "Turn off music" }
   },
@@ -998,5 +993,10 @@
     "type": "item_action",
     "id": "sex_toy",
     "name": { "str": "Relieve some tension" }
+  },
+  {
+    "type": "item_action",
+    "id": "music_player",
+    "name": { "str": "Listen to music" }
   }
 ]

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -365,7 +365,16 @@
     "initial_charges": 160,
     "max_charges": 200,
     "flags": [ "RECHARGE", "NO_UNLOAD", "NO_RELOAD" ],
-    "use_action": [ "MP3", "TOGGLE_UPS_CHARGING" ],
+    "use_action": [
+      {
+        "type": "music_player",
+        "target": "mp3_on",
+        "msg": "You put in the earbuds and start listening to music.",
+        "moves": 200,
+        "need_charges": 5
+      },
+      "TOGGLE_UPS_CHARGING"
+    ],
     "charges_per_use": 1
   },
   {
@@ -470,17 +479,24 @@
         "need_charges": 5,
         "transform_charges": 1,
         "need_charges_msg": "The smartphone's charge is too low.",
-        "type": "transform"
+        "type": "transform",
+        "menu_text": "Activate Flashlight"
       },
       "CAMERA",
-      "MP3",
+      {
+        "type": "music_player",
+        "target": "smart_phone_music",
+        "msg": "You put in the earbuds and start listening to music.",
+        "moves": 200,
+        "need_charges": 5
+      },
       "PORTABLE_GAME",
       "TOGGLE_UPS_CHARGING"
     ],
     "flags": [ "WATCH", "ALARMCLOCK", "RECHARGE", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
-    "id": "smartphone_music",
+    "id": "smart_phone_music",
     "copy-from": "smart_phone",
     "type": "TOOL",
     "name": { "str": "smartphone - music", "str_pl": "smartphones - music" },
@@ -524,10 +540,16 @@
         "target": "afs_atomic_smartphone_flashlight",
         "msg": "You activate the flashlight app.",
         "active": true,
-        "type": "transform"
+        "type": "transform",
+        "menu_text": "Activate Flashlight"
       },
       "CAMERA",
-      "MP3"
+      {
+        "type": "music_player",
+        "target": "afs_atomic_smartphone_music",
+        "msg": "You put in the earbuds and start listening to music.",
+        "moves": 200
+      }
     ],
     "flags": [ "WATCH", "ALARMCLOCK", "NO_UNLOAD", "NO_RELOAD" ]
   },

--- a/data/json/obsoletion/migration.json
+++ b/data/json/obsoletion/migration.json
@@ -718,5 +718,10 @@
     "id": "22_cb",
     "type": "MIGRATION",
     "replace": "22_cphp"
+  },
+  {
+    "id": "smartphone_music",
+    "type": "MIGRATION",
+    "replace": "smart_phone_music"
   }
 ]

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -10,18 +10,23 @@
     "material": [ "superalloy", "aluminum" ],
     "use_action": [
       {
-        "target": "afs_atomic_wraitheon_flashlight",
+        "target": "afs_wraitheon_smartphone_flashlight",
         "msg": "You activate the flashlight app.",
         "active": true,
         "type": "transform"
       },
       "CAMERA",
-      "MP3",
+      {
+        "type": "music_player",
+        "target": "afs_wraitheon_smartphone_music",
+        "msg": "You put in the earbuds and start listening to music.",
+        "moves": 200
+      },
       "ROBOTCONTROL"
     ]
   },
   {
-    "id": "afs_atomic_wraitheon_music",
+    "id": "afs_wraitheon_smartphone_music",
     "copy-from": "afs_wraitheon_smartphone",
     "type": "TOOL",
     "name": { "str": "Wraitheon executive's smartphone - music", "str_pl": "Wraitheon executive's smartphones - music" },
@@ -31,7 +36,7 @@
     "flags": [ "WATCH", "TRADER_AVOID", "ALARMCLOCK", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
-    "id": "afs_atomic_wraitheon_flashlight",
+    "id": "afs_wraitheon_smartphone_flashlight",
     "copy-from": "afs_atomic_smartphone_flashlight",
     "type": "TOOL",
     "name": { "str": "Executive's smartphone - Flashlight", "str_pl": "Executive's smartphones - Flashlight" },

--- a/data/mods/Aftershock/migration.json
+++ b/data/mods/Aftershock/migration.json
@@ -56,5 +56,15 @@
     "id": "afs_freezer",
     "type": "MIGRATION",
     "replace": "freezer"
+  },
+  {
+    "id": "afs_atomic_wraitheon_music",
+    "type": "MIGRATION",
+    "replace": "afs_wraitheon_smartphone_music"
+  },
+  {
+    "id": "afs_atomic_wraitheon_flashlight",
+    "type": "MIGRATION",
+    "replace": "afs_wraitheon_smartphone_flashlight"
   }
 ]

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -999,7 +999,6 @@ void Item_factory::init()
     add_iuse( "MININUKE", &iuse::mininuke );
     add_iuse( "MOLOTOV_LIT", &iuse::molotov_lit );
     add_iuse( "MOP", &iuse::mop );
-    add_iuse( "MP3", &iuse::mp3 );
     add_iuse( "MP3_ON", &iuse::mp3_on );
     add_iuse( "MULTICOOKER", &iuse::multicooker );
     add_iuse( "MYCUS", &iuse::mycus );
@@ -1114,6 +1113,7 @@ void Item_factory::init()
     add_actor( std::make_unique<gps_device_actor>() );
     add_actor( std::make_unique<sew_advanced_actor>() );
     add_actor( std::make_unique<sex_toy_actor>() );
+    add_actor( std::make_unique<iuse_music_player>() );
 
     // An empty dummy group, it will not spawn anything. However, it makes that item group
     // id valid, so it can be used all over the place without need to explicitly check for it.

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3659,35 +3659,6 @@ int iuse::tazer2( player *p, item *it, bool b, const tripoint &pos )
     return 0;
 }
 
-int iuse::mp3( player *p, item *it, bool, const tripoint & )
-{
-    // TODO: avoid item id hardcoding to make this function usable for pure json-defined devices.
-    if( !it->units_sufficient( *p ) ) {
-        p->add_msg_if_player( m_info, _( "The device's batteries are dead." ) );
-    } else if( p->has_active_item( itype_mp3_on ) || p->has_active_item( itype_smartphone_music ) ||
-               p->has_active_item( itype_afs_atomic_smartphone_music ) ||
-               p->has_active_item( itype_afs_atomic_wraitheon_music ) ) {
-        p->add_msg_if_player( m_info, _( "You are already listening to music!" ) );
-    } else {
-        p->add_msg_if_player( m_info, _( "You put in the earbuds and start listening to music." ) );
-        if( it->typeId() == itype_mp3 ) {
-            it->convert( itype_mp3_on );
-            it->activate();
-        } else if( it->typeId() == itype_smart_phone ) {
-            it->convert( itype_smartphone_music );
-            it->activate();
-        } else if( it->typeId() == itype_afs_atomic_smartphone ) {
-            it->convert( itype_afs_atomic_smartphone_music );
-            it->activate();
-        } else if( it->typeId() == itype_afs_wraitheon_smartphone ) {
-            it->convert( itype_afs_atomic_wraitheon_music );
-            it->activate();
-        }
-        p->mod_moves( -200 );
-    }
-    return it->type->charges_to_use();
-}
-
 static std::string get_music_description()
 {
     const std::array<std::string, 5> descriptions = {{

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3757,23 +3757,15 @@ int iuse::mp3_on( player *p, item *it, bool t, const tripoint &pos )
             play_music( *p, pos, 0, 20 );
         }
     } else { // Turning it off
-        if( it->typeId() == itype_mp3_on ) {
-            p->add_msg_if_player( _( "The mp3 player turns off." ) );
-            it->convert( itype_mp3 );
-            it->deactivate();
-        } else if( it->typeId() == itype_smartphone_music ) {
-            p->add_msg_if_player( _( "The phone turns off." ) );
-            it->convert( itype_smart_phone );
-            it->deactivate();
-        } else if( it->typeId() == itype_afs_atomic_smartphone_music ) {
-            p->add_msg_if_player( _( "The phone turns off." ) );
-            it->convert( itype_afs_atomic_smartphone );
-            it->deactivate();
-        } else if( it->typeId() == itype_afs_atomic_wraitheon_music ) {
-            p->add_msg_if_player( _( "The phone turns off." ) );
-            it->convert( itype_afs_wraitheon_smartphone );
-            it->deactivate();
-        }
+        // Creatively make it so that the reversion isn't hard-coded
+        // There's *probably* a better way to do this, but this works
+        std::string active_item = it->typeId().str();
+        std::string base_item = active_item.erase( active_item.rfind( '_' ) );
+
+        p->add_msg_if_player( _( "The %s turns off." ), it->display_name() );
+        it->convert( itype_id( base_item ) );
+        it->deactivate();
+
         p->mod_moves( -200 );
     }
     return it->type->charges_to_use();

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -102,7 +102,6 @@ int pick_lock( player *, item *, bool, const tripoint & );
 int portal( player *, item *, bool, const tripoint & );
 int tazer( player *, item *, bool, const tripoint & );
 int tazer2( player *, item *, bool, const tripoint & );
-int mp3( player *, item *, bool, const tripoint & );
 int mp3_on( player *, item *, bool, const tripoint & );
 int rpgdie( player *, item *, bool, const tripoint & );
 int dive_tank( player *, item *, bool, const tripoint & );

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1282,3 +1282,36 @@ class sex_toy_actor : public iuse_actor
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
+class iuse_music_player : public iuse_actor
+{
+    public:
+        /** displayed if player sees transformation with %s replaced by item name */
+        translation msg_transform;
+
+        /** type of the resulting item */
+        itype_id target;
+
+        /**does the item requires to be worn to be activable*/
+        bool need_worn = false;
+
+        /**does the item requires to be wielded to be activable*/
+        bool need_wielding = false;
+
+        /** subtracted from @ref Creature::moves when transformation is successful */
+        int moves = 0;
+
+        /** minimum charges (if any) required for transformation */
+        int need_charges = 0;
+
+        /** charges needed for process of transforming item */
+        int transform_charges = 0;
+
+        iuse_music_player( const std::string &type = "music_player" ) : iuse_actor( type ) {}
+
+        ~iuse_music_player() override = default;
+        void load( const JsonObject &obj ) override;
+        int use( player &, item &, bool, const tripoint & ) const override;
+        ret_val<bool> can_use( const Character &, const item &, bool, const tripoint & ) const override;
+        std::unique_ptr<iuse_actor> clone() const override;
+};
+


### PR DESCRIPTION
## Purpose of change (The Why)

Hardcoded functions, especially for something as simple as an MP3 player, are bad.

Also, the comments in the code specifically wanted this all to become more friendly to fully-JSON definitions of music players.

In the process of doing #7170 , I realized that I had stumbled upon a great way to un-hardcode the `mp3_on` function (in terms of the  reverting to the base item when turned off) when making the code for the bullet vibe.

## Describe the solution (The How)

- Uses the same "chop off the suffix" strategy from #7170 in `mp3_on` to unhardcode the turning off part
- Converts the fundamental bits of the base `mp3` into a new iuse action `music_player` to transform the music players
  - This is essentially a stripped-down version of the transform iuse action, specifically made because we don't support multiple transform actions on a single item.
- Makes the necessary changes to Vanilla items
  - The classic MP3 player, the smartphone, and the atomic smartphone all got changed over to the new system
    - The smartphone in particular also got the id of its music version normalized to make the reversion function work.
- Also took care of the hold-out in Aftershock (The Wraitheon Executive Phone)
  - This included similar normalization of the variant ids as the vanilla smartphone 

## Describe alternatives you've considered

- Add a potential field (or two) to all items to facilitate keeping entirely to the old iuse functions

That felt like it would probably be a little unwise, adding some bloat to every item.
- Convert it all over to a really custom iuse action

Probably *possible*, but not the simplest route to go down.

## Testing

Loaded into the game, made sure that the Smartphone, MP3 Player, and Atomic Smartphone all play music correctly and can correctly revert back.

## Additional context

Once again, technology as a whole benefits from the advancements brought about by the adult industry ;P

I don't believe we technically document the iuses and iuse actions anywhere in the docs. We probably *should*, but that's a task for another (wholly docs-focused) PR

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [x] This is a PR that removes JSON entities. (technically)
  - [x] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves. (id migration)
