### PR TITLE
fix(UI): standardize profession variable names

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1628,7 +1628,7 @@ tab_direction set_profession( avatar &u, points_left &points,
 
             // Profession traits
             const auto prof_traits = sorted_profs[cur_id]->get_locked_traits();
-            buffer += colorize( _( "Profession traits:" ), c_light_blue ) + "\n";
+            buffer += colorize( _( "Traits:" ), c_light_blue ) + "\n";
             if( prof_traits.empty() ) {
                 buffer += pgettext( "set_profession_trait", "None" ) + std::string( "\n" );
             } else {
@@ -1644,7 +1644,7 @@ tab_direction set_profession( avatar &u, points_left &points,
                 return localized_compare( std::make_pair( a.first->display_category(), a.first->name() ),
                                           std::make_pair( b.first->display_category(), b.first->name() ) );
             } );
-            buffer += colorize( _( "Profession skills:" ), c_light_blue ) + "\n";
+            buffer += colorize( _( "Skills:" ), c_light_blue ) + "\n";
             if( prof_skills.empty() ) {
                 buffer += pgettext( "set_profession_skill", "None" ) + std::string( "\n" );
             } else {
@@ -1662,7 +1662,7 @@ tab_direction set_profession( avatar &u, points_left &points,
 
             // Profession items
             const auto prof_items = sorted_profs[cur_id]->items( u.male, u.get_mutations() );
-            buffer += colorize( _( "Profession items:" ), c_light_blue ) + "\n";
+            buffer += colorize( _( "Items:" ), c_light_blue ) + "\n";
             if( prof_items.empty() ) {
                 buffer += pgettext( "set_profession_item", "None" ) + std::string( "\n" );
             } else {
@@ -1699,7 +1699,7 @@ tab_direction set_profession( avatar &u, points_left &points,
             std::sort( begin( prof_CBMs ), end( prof_CBMs ), []( const bionic_id & a, const bionic_id & b ) {
                 return a->activated && !b->activated;
             } );
-            buffer += colorize( _( "Profession bionics:" ), c_light_blue ) + "\n";
+            buffer += colorize( _( "Bionics:" ), c_light_blue ) + "\n";
             if( prof_CBMs.empty() ) {
                 buffer += pgettext( "set_profession_bionic", "None" ) + std::string( "\n" );
             } else {
@@ -1741,7 +1741,7 @@ tab_direction set_profession( avatar &u, points_left &points,
             std::optional<int> cash = sorted_profs[cur_id]->starting_cash();
 
             if( cash.has_value() ) {
-                buffer += colorize( _( "Profession money:" ), c_light_blue ) + "\n";
+                buffer += colorize( _( "Money:" ), c_light_blue ) + "\n";
                 buffer += format_money( cash.value() ) + "\n";
             }
 


### PR DESCRIPTION
## Purpose of change (The Why)
It's unclear why certain things in the PROFESSION tab of character creation have "Profession" in front of their names, for example: "Profession items", "Profession bionics", etc. Additionally, it's unclear why others don't. For example, "Pets", "Vehicle", etc.
## Describe the solution (The How)
Remove the "Profession" prefix from entries that have it. This seemed redundant, and therefore the better choice between renaming everything to start with "Profession" and removing it from everything that has it.
## Describe alternatives you've considered
Changing them all to start with "Profession", this seemed redundant.
## Testing
Compiled and loaded, everything worked as expected.
## Additional context
<img width="395" height="481" alt="image" src="https://github.com/user-attachments/assets/b6048c35-dd43-4b30-9308-4920e6bfce48" />


## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
