### PR TITLE
fix: Resolve Save Id changing errors

### DIFF
--- a/src/world.cpp
+++ b/src/world.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <chrono>
 
+#include "catacharset.h"
 #include "game.h"
 #include "avatar.h"
 #include "debug.h"
@@ -640,7 +641,11 @@ sqlite3 *world::get_player_db()
     }
 
     if( last_save_id != g->u.get_save_id() ) {
-        throw std::runtime_error( "Save ID changed without reloading the world object" );
+        copy_file(
+            info->folder_path() + "/" + base64_encode( last_save_id ) + ".sqlite3",
+            info->folder_path() + "/" + base64_encode( g->u.get_save_id() ) + ".sqlite3"
+        );
+        save_db = open_db( info->folder_path() + "/" + get_player_path() + ".sqlite3" ); 
     }
 
     return save_db;

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -645,7 +645,7 @@ sqlite3 *world::get_player_db()
             info->folder_path() + "/" + base64_encode( last_save_id ) + ".sqlite3",
             info->folder_path() + "/" + base64_encode( g->u.get_save_id() ) + ".sqlite3"
         );
-        save_db = open_db( info->folder_path() + "/" + get_player_path() + ".sqlite3" ); 
+        save_db = open_db( info->folder_path() + "/" + get_player_path() + ".sqlite3" );
     }
 
     return save_db;


### PR DESCRIPTION
## Purpose of change (The Why)
Chaosvolt has repetitively demonstrated the need for it

## Describe the solution (The How)
Don't crash, just copy the save file like it should

## Describe alternatives you've considered
Also delete the old save file

## Testing
Use the Debug menu -> player -> change thingies -> change save name
Unlike before it no longer crashes and you save and load right

## Additional context
This issue has been persistent and with recent changes is a ticking bomb

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.