### PR TITLE
fix: Item spawnrate applies to corpse loot once more

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/map_extras.json
+++ b/data/json/itemgroups/Locations_MapExtras/map_extras.json
@@ -2,6 +2,13 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "map_extra_corpse",
+    "//": "Individual dead body separated into its own group for re-use",
+    "entries": [ { "item": "corpse", "damage": 3 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "map_extra_science",
     "entries": [
       { "item": "id_science", "prob": 50, "//": "half the time an id card" },
@@ -10,15 +17,14 @@
       { "group": "lab_pants", "damage-min": 1, "damage-max": 3 },
       { "group": "lab_shoes", "damage-min": 1, "damage-max": 3 },
       { "group": "lab_torso", "damage-min": 1, "damage-max": 3 },
-      { "group": "underwear", "damage-min": 1, "damage-max": 3 },
-      { "item": "corpse", "damage": 3, "//": "always a corpse, pulped!" }
+      { "group": "underwear", "damage-min": 1, "damage-max": 3 }
     ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "map_extra_military",
-    "entries": [ { "group": "military_corpse_extra_items" }, { "item": "corpse", "damage": 3 } ]
+    "entries": [ { "group": "military_corpse_extra_items" } ]
   },
   {
     "type": "item_group",
@@ -33,8 +39,7 @@
       {
         "distribution": [ { "group": "fridge_alcohol_random", "prob": 75 }, { "group": "smokedrugs", "prob": 25 } ],
         "prob": 50
-      },
-      { "item": "corpse", "damage": 3 }
+      }
     ]
   },
   {
@@ -49,8 +54,7 @@
       {
         "distribution": [ { "group": "fridge_alcohol_random", "prob": 75 }, { "group": "smokedrugs", "prob": 25 } ],
         "prob": 50
-      },
-      { "item": "corpse", "damage": 3 }
+      }
     ]
   },
   {
@@ -79,8 +83,7 @@
       {
         "distribution": [ { "group": "fridge_alcohol_random", "prob": 75 }, { "group": "smokedrugs", "prob": 25 } ],
         "prob": 50
-      },
-      { "item": "corpse", "damage": 3 }
+      }
     ]
   },
   {
@@ -99,8 +102,7 @@
           { "group": "archery_hunting", "prob": 25, "damage": [ 0, 2 ] }
         ],
         "prob": 75
-      },
-      { "item": "corpse", "damage": 3 }
+      }
     ]
   },
   {
@@ -114,21 +116,20 @@
       {
         "distribution": [ { "item": "bandana", "damage": [ 1, 4 ], "prob": 50 }, { "item": "bandana_head", "damage": [ 1, 4 ], "prob": 25 } ],
         "prob": 10
-      },
-      { "item": "corpse", "damage": 3 }
+      }
     ]
   },
   {
     "id": "map_extra_police",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "mon_zombie_cop_death_drops" }, { "item": "corpse", "damage": 3 } ]
+    "entries": [ { "group": "mon_zombie_cop_death_drops" } ]
   },
   {
     "id": "map_extra_swat",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "mon_zombie_swat_death_drops" }, { "item": "corpse", "damage": 3 } ]
+    "entries": [ { "group": "mon_zombie_swat_death_drops" } ]
   },
   {
     "type": "item_group",

--- a/data/json/mapgen/map_extras/corpses.json
+++ b/data/json/mapgen/map_extras/corpses.json
@@ -7,10 +7,10 @@
       "place_nested": [
         {
           "chunks": [
-            [ "lost_campers_chunk_1", 35 ],
-            [ "lost_campers_chunk_2", 30 ],
-            [ "lost_campers_chunk_3", 10 ],
-            [ "lost_campers_chunk_4", 25 ]
+            [ "nested_collegekids_a", 35 ],
+            [ "nested_collegekids_b", 30 ],
+            [ "nested_collegekids_c", 10 ],
+            [ "nested_collegekids_d", 25 ]
           ],
           "x": 1,
           "y": 1
@@ -22,10 +22,47 @@
   {
     "type": "mapgen",
     "method": "json",
-    "nested_mapgen_id": "lost_campers_chunk_1",
+    "nested_mapgen_id": "nested_collegekids_a",
     "object": {
       "mapgensize": [ 22, 22 ],
-      "place_loot": [ { "group": "map_extra_college_camping", "chance": 100, "x": [ 0, 21 ], "y": [ 0, 21 ], "repeat": [ 2, 6 ] } ]
+      "place_nested": [ { "chunks": [ [ "lost_campers_chunk_1", 100 ] ], "x": [ 0, 21 ], "y": [ 0, 21 ], "repeat": [ 2, 6 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "nested_collegekids_b",
+    "object": {
+      "mapgensize": [ 22, 22 ],
+      "place_nested": [ { "chunks": [ [ "lost_campers_chunk_2", 100 ] ], "x": [ 0, 21 ], "y": [ 0, 21 ], "repeat": [ 2, 6 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "nested_collegekids_c",
+    "object": {
+      "mapgensize": [ 22, 22 ],
+      "place_nested": [ { "chunks": [ [ "lost_campers_chunk_3", 100 ] ], "x": [ 0, 21 ], "y": [ 0, 21 ], "repeat": [ 2, 6 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "nested_collegekids_d",
+    "object": {
+      "mapgensize": [ 22, 22 ],
+      "place_nested": [ { "chunks": [ [ "lost_campers_chunk_4", 100 ] ], "x": [ 0, 21 ], "y": [ 0, 21 ], "repeat": [ 2, 6 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "lost_campers_chunk_1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 0, "y": 0 } ],
+      "place_items": [ { "item": "map_extra_college_camping", "chance": 100, "x": 0, "y": 0 } ]
     }
   },
   {
@@ -33,8 +70,9 @@
     "method": "json",
     "nested_mapgen_id": "lost_campers_chunk_2",
     "object": {
-      "mapgensize": [ 22, 22 ],
-      "place_loot": [ { "group": "map_extra_college_sports", "chance": 100, "x": [ 0, 21 ], "y": [ 0, 21 ], "repeat": [ 2, 6 ] } ]
+      "mapgensize": [ 1, 1 ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 0, "y": 0 } ],
+      "place_items": [ { "item": "map_extra_college_sports", "chance": 100, "x": 0, "y": 0 } ]
     }
   },
   {
@@ -42,8 +80,9 @@
     "method": "json",
     "nested_mapgen_id": "lost_campers_chunk_3",
     "object": {
-      "mapgensize": [ 22, 22 ],
-      "place_loot": [ { "group": "map_extra_college_lake", "chance": 100, "x": [ 0, 21 ], "y": [ 0, 21 ], "repeat": [ 2, 6 ] } ]
+      "mapgensize": [ 1, 1 ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 0, "y": 0 } ],
+      "place_items": [ { "item": "map_extra_college_lake", "chance": 100, "x": 0, "y": 0 } ]
     }
   },
   {
@@ -51,8 +90,9 @@
     "method": "json",
     "nested_mapgen_id": "lost_campers_chunk_4",
     "object": {
-      "mapgensize": [ 22, 22 ],
-      "place_loot": [ { "group": "map_extra_dead_hunter", "chance": 100, "x": [ 0, 21 ], "y": [ 0, 21 ], "repeat": [ 2, 6 ] } ]
+      "mapgensize": [ 1, 1 ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 0, "y": 0 } ],
+      "place_items": [ { "item": "map_extra_dead_hunter", "chance": 100, "x": 0, "y": 0 } ]
     }
   },
   {
@@ -68,18 +108,18 @@
           "repeat": [ 2, 6 ]
         }
       ],
-      "place_loot": [ { "group": "military", "chance": 50, "x": [ 1, 22 ], "y": [ 1, 22 ] } ],
-      "place_monster": [
-        { "group": "GROUP_NETHER_CAPTURED", "x": [ 1, 22 ], "y": [ 1, 22 ], "repeat": [ 1, 3 ] },
-        { "group": "GROUP_MAYBE_MIL", "x": [ 1, 22 ], "y": [ 1, 22 ], "repeat": [ 1, 5 ] }
-      ]
+      "place_loot": [ { "group": "military", "chance": 50, "x": [ 1, 22 ], "y": [ 1, 22 ] } ]
     }
   },
   {
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "lost_squad_chunk_1",
-    "object": { "mapgensize": [ 1, 1 ], "place_loot": [ { "group": "map_extra_military", "chance": 100, "x": 0, "y": 0 } ] }
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 0, "y": 0 } ],
+      "place_items": [ { "item": "map_extra_military", "chance": 100, "x": 0, "y": 0 } ]
+    }
   },
   {
     "type": "mapgen",
@@ -114,7 +154,11 @@
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "lost_science_chunk_1",
-    "object": { "mapgensize": [ 1, 1 ], "place_loot": [ { "group": "map_extra_science", "chance": 100, "x": 0, "y": 0 } ] }
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 0, "y": 0 } ],
+      "place_items": [ { "item": "map_extra_science", "chance": 100, "x": 0, "y": 0 } ]
+    }
   },
   {
     "type": "mapgen",
@@ -224,7 +268,8 @@
     "nested_mapgen_id": "drugbust_crimescene_1",
     "object": {
       "mapgensize": [ 4, 4 ],
-      "place_loot": [ { "group": "map_extra_drugdeal", "chance": 100, "x": 3, "y": 3 } ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 3, "y": 3 } ],
+      "place_items": [ { "item": "map_extra_drugdeal", "chance": 100, "x": 3, "y": 3 } ],
       "place_fields": [
         { "x": [ 0, 2 ], "y": 3, "field": "fd_blood", "intensity": 1, "repeat": [ 1, 3 ] },
         { "x": 3, "y": 3, "field": "fd_blood", "intensity": 1 }
@@ -237,7 +282,8 @@
     "nested_mapgen_id": "drugbust_crimescene_1b",
     "object": {
       "mapgensize": [ 4, 4 ],
-      "place_loot": [ { "group": "map_extra_police", "chance": 100, "x": 3, "y": 3 } ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 3, "y": 3 } ],
+      "place_items": [ { "item": "map_extra_police", "chance": 100, "x": 3, "y": 3 } ],
       "place_fields": [
         { "x": [ 0, 2 ], "y": 3, "field": "fd_blood", "intensity": 1, "repeat": [ 1, 3 ] },
         { "x": 3, "y": 3, "field": "fd_blood", "intensity": 1 }
@@ -250,7 +296,8 @@
     "nested_mapgen_id": "drugbust_crimescene_1c",
     "object": {
       "mapgensize": [ 4, 4 ],
-      "place_loot": [ { "group": "map_extra_swat", "chance": 100, "x": 3, "y": 3 } ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 3, "y": 3 } ],
+      "place_items": [ { "item": "map_extra_swat", "chance": 100, "x": 3, "y": 3 } ],
       "place_fields": [
         { "x": [ 0, 2 ], "y": 3, "field": "fd_blood", "intensity": 1, "repeat": [ 1, 3 ] },
         { "x": 3, "y": 3, "field": "fd_blood", "intensity": 1 }
@@ -263,7 +310,8 @@
     "nested_mapgen_id": "drugbust_crimescene_2",
     "object": {
       "mapgensize": [ 4, 4 ],
-      "place_loot": [ { "group": "map_extra_drugdeal", "chance": 100, "x": 0, "y": 3 } ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 0, "y": 3 } ],
+      "place_items": [ { "item": "map_extra_drugdeal", "chance": 100, "x": 0, "y": 3 } ],
       "place_fields": [
         { "x": [ 1, 3 ], "y": 3, "field": "fd_blood", "intensity": 1, "repeat": [ 1, 3 ] },
         { "x": 0, "y": 3, "field": "fd_blood", "intensity": 1 }
@@ -276,7 +324,8 @@
     "nested_mapgen_id": "drugbust_crimescene_2b",
     "object": {
       "mapgensize": [ 4, 4 ],
-      "place_loot": [ { "group": "map_extra_police", "chance": 100, "x": 0, "y": 3 } ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 0, "y": 3 } ],
+      "place_items": [ { "item": "map_extra_police", "chance": 100, "x": 0, "y": 3 } ],
       "place_fields": [
         { "x": [ 1, 3 ], "y": 3, "field": "fd_blood", "intensity": 1, "repeat": [ 1, 3 ] },
         { "x": 0, "y": 3, "field": "fd_blood", "intensity": 1 }
@@ -289,7 +338,8 @@
     "nested_mapgen_id": "drugbust_crimescene_2c",
     "object": {
       "mapgensize": [ 4, 4 ],
-      "place_loot": [ { "group": "map_extra_swat", "chance": 100, "x": 0, "y": 3 } ],
+      "place_loot": [ { "group": "map_extra_corpse", "x": 0, "y": 3 } ],
+      "place_items": [ { "item": "map_extra_swat", "chance": 100, "x": 0, "y": 3 } ],
       "place_fields": [
         { "x": [ 1, 3 ], "y": 3, "field": "fd_blood", "intensity": 1, "repeat": [ 1, 3 ] },
         { "x": 0, "y": 3, "field": "fd_blood", "intensity": 1 }


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

The corpse sites from `corpses.json` (`mx_military`, `mx_science`, etc.) ignore the global item spawn rate multiplier and always spawn very generous amounts of loot, which for those playing with reduced spawn rates can ruin the challenge. I can only assume this is unintentional, because the old C++ implementation of these extras generated fewer bodies (and therefore less loot) at lower spawn rates.

## Describe the solution (The How)

This happens because the use of `place_loot` with the chance of exactly 100 makes the loot guaranteed. The solution is to use `place_items`, for which no such special case exists.

Simply switching to `place_items` restored the old behavior exactly, but there is one enhancement that is possible: place the corpse itself separately as guaranteed loot, so that the bodies are always there, but their loot may be missing if the random roll fails. This avoids the silly situation that used to be possible, when body sites could generate with 0 actual bodies in them.

#### Overall effect:
- With 1.0x spawn rate, **nothing changes**.
- With lower spawn rates, the loot will be missing from some of the corpses.
- With rates higher than 1.0, the loot amount on each corpse will be more than normal, same as with other item spawns.

## Describe alternatives you've considered

- Simply changing the `chance` to 99 instead of 100. This would work correctly 99% of the time (literally), but it feels wrong.
- Somehow overhauling `jmapgen_loot `and/or `jmapgen_item_group` to provide a different way of spawning guaranteed loot.

## Testing

Just spawned all affected map extras many, many times and observed how they generated. Not sure if there is anything more clever that can be done here.

## Additional context

Example generation of `mx_military `with 0.5x spawn rate. Mapgen rolled 4 bodies in total, but half are missing the items.

<img width="663" height="579" alt="image" src="https://github.com/user-attachments/assets/90939123-25d3-424d-a151-9822e9b7e7d4" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
