### PR TITLE
fix(mods): match monstergirl script behviaor to old one

### DIFF
--- a/data/mods/Monster_Girls/vanilla_mutations.json
+++ b/data/mods/Monster_Girls/vanilla_mutations.json
@@ -1432,10 +1432,7 @@
     "id": "LARGE_OK",
     "copy-from": "LARGE_OK",
     "delete": { "category": [ "BEAST", "URSINE", "CATTLE", "LIZARD", "SERPENT", "RAPTOR", "CHIMERA" ] },
-    "extend": {
-      "category": [ "COWGIRL", "BEARGIRL", "LAMIA" ],
-      "threshreq": [ "THRESH_KITSUNE", "THRESH_BEARGIRL", "THRESH_COWGIRL", "THRESH_LAMIA" ]
-    }
+    "extend": { "category": [ "COWGIRL", "BEARGIRL", "LAMIA" ], "threshreq": [ "THRESH_BEARGIRL", "THRESH_COWGIRL", "THRESH_LAMIA" ] }
   },
   {
     "type": "mutation",
@@ -1477,7 +1474,7 @@
     "id": "STR_UP_4",
     "copy-from": "STR_UP_4",
     "delete": { "category": [ "BEAST", "URSINE" ] },
-    "extend": { "category": [ "BEARGIRL" ], "threshreq": [ "THRESH_KITSUNE", "THRESH_BEARGIRL" ] }
+    "extend": { "category": [ "BEARGIRL" ], "threshreq": [ "THRESH_BEARGIRL" ] }
   },
   {
     "type": "mutation",
@@ -1617,10 +1614,7 @@
     "id": "SMALL_OK",
     "copy-from": "SMALL_OK",
     "delete": { "category": [ "MOUSE", "RAT", "RABBIT", "FELINE", "BIRD", "INSECT", "SPIDER", "TROGLOBITE" ] },
-    "extend": {
-      "category": [ "MOUSEGIRL", "BUNNYGIRL" ],
-      "threshreq": [ "THRESH_MOUSEGIRL", "THRESH_BUNNYGIRL", "THRESH_NEKO", "THRESH_HARPY", "THRESH_SPIDERGIRL" ]
-    }
+    "extend": { "category": [ "MOUSEGIRL", "BUNNYGIRL" ], "threshreq": [ "THRESH_MOUSEGIRL", "THRESH_BUNNYGIRL" ] }
   },
   {
     "type": "mutation",

--- a/scripts/monster_girls_mutations/main.ts
+++ b/scripts/monster_girls_mutations/main.ts
@@ -71,11 +71,12 @@ if (import.meta.main) {
   const validMutations = parseMany(Mutation)(await recursivelyReadJSON(...input))
   const vanilla = parseMany(Vanilla)(await recursivelyReadJSON(extend))
 
-  const mapping = new Map(vanilla.map((v) => [v.id, v.extend.category]))
+  const mapping = new Map(vanilla.map((v) => [v.id, new Set(v.extend.category)]))
 
-  const mutations = validMutations.map(({ type, id, category, threshreq }) => {
+  const mutations = validMutations.map(({ type, id, category, ...m }) => {
     const res = mapping.get(id)
-    const extended = res ? { extend: { category: res, threshreq } } : { valid: false }
+    const threshreq = m.threshreq?.filter((t) => res?.has(t.replace("THRESH_", "")))
+    const extended = res ? { extend: { category: Array.from(res), threshreq } } : { valid: false }
 
     return ({ type, id, "copy-from": id, delete: { category }, ...extended })
   })


### PR DESCRIPTION

## Purpose of change (The Why)

followup to #7207

## Describe the solution (The How)

filter out threshreqs not in category

## Testing

to test:
1. revert `vanilla_mutations.json` to before the new migration script by `git restore --source dfe25f1~1 data/mods/Monster_Girls/vanilla_mutations.json
`
2. run the script with `scripts/monster_girls_mutations/main.ts && tools/format/json_formatter.cgi data/mods/Monster_Girls/vanilla_mutations.json
`
3. check that the output is identical to python version (except ordering, but script output is idempotent so that'd be ok)

## Additional context

<img width="1482" height="378" alt="image" src="https://github.com/user-attachments/assets/fecca728-05d4-4b7c-984d-b430d910ea69" />

https://discord.com/channels/830879262763909202/1415736824025972918/1415774492654833666

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
