### PR TITLE
feat: More random ore veins when players mine into rock

### DIFF
--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -213,6 +213,21 @@
     }
   },
   {
+    "id": "rockmap",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "name": "miners's map",
+    "looks_like": "roadmap",
+    "description": "This is a handmade map of local mineral veins.  There's probably bigger worries than that now, though.",
+    "color": "light_blue",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 180,
+      "terrain": [ "empty_rock", "rock" ],
+      "message": "You mark potential entry points and underground routes in the margins of your map."
+    }
+  },
+  {
     "id": "trailmap",
     "copy-from": "abstractmap",
     "type": "GENERIC",

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -60,6 +60,8 @@
 #include "string_utils.h"
 #include "text_snippets.h"
 #include "translations.h"
+#include "type_id.h"
+#include "weighted_list.h"
 #include "world.h"
 
 static const efftype_id effect_pet( "pet" );
@@ -5722,6 +5724,21 @@ std::vector<tripoint_om_omt> overmap::place_special(
     }
 
     return result.omts_used;
+}
+// Inside empty rock spawn some ores maybe
+void overmap::spawn_ores( const tripoint_om_omt &p )
+{
+    if( one_in( 10 ) ) {
+        weighted_int_list<std::string> ores;
+        ores.add( "iron", 10 );
+        ores.add( "copper", 5 );
+        ores.add( "lead", 3 );
+        ores.add( "tin", 3 );
+        ores.add( "silver", 2 );
+        ores.add( "gold", 1 );
+        add_note( p, string_format( "There will be %s ore here", ores.pick()->c_str() ) );
+
+    }
 }
 
 // Points list maintaining custom order, and allowing fast removal by coordinates

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -478,6 +478,7 @@ class overmap
         std::vector<tripoint_om_omt> place_special(
             const overmap_special &special, const tripoint_om_omt &p, om_direction::type dir,
             const city &cit, bool must_be_unexplored, bool force );
+        void spawn_ores( const tripoint_om_omt &p );
     private:
         /**
          * Iterate over the overmap and place the quota of specials.

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -688,6 +688,9 @@ bool overmapbuffer::seen( const tripoint_abs_omt &p )
 void overmapbuffer::set_seen( const tripoint_abs_omt &p, bool seen )
 {
     const overmap_with_local_coords om_loc = get_om_global( p );
+    if( true && is_ot_match( "empty_rock", ter( p ), ot_match_type::type ) ) {
+        om_loc.om->spawn_ores( om_loc.local );
+    }
     om_loc.om->seen( om_loc.local ) = seen;
 }
 

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -688,7 +688,7 @@ bool overmapbuffer::seen( const tripoint_abs_omt &p )
 void overmapbuffer::set_seen( const tripoint_abs_omt &p, bool seen )
 {
     const overmap_with_local_coords om_loc = get_om_global( p );
-    if( true && is_ot_match( "empty_rock", ter( p ), ot_match_type::type ) ) {
+    if( is_ot_match( "empty_rock", ter( p ), ot_match_type::type ) ) {
         om_loc.om->spawn_ores( om_loc.local );
     }
     om_loc.om->seen( om_loc.local ) = seen;


### PR DESCRIPTION
## Purpose of change (The Why)
@V2LenKagamine wanted something of the sort. This is the current draft so they can suggest changes.

## Describe the solution (The How)
When a solid rock tile is marked as "seen", call a new spawn_ores function which will make a note about the vein and generate a vein there.

## Describe alternatives you've considered
Do it on OM generation instead and cause save file overfill due to most players not doing this style of gameplay

## Testing
Draft so none yet really
Currently has the testers miners's map which reveals all rock on the current overmap to see progress
- Needed because debug reveal does something different then maps and walking into the tile

## Additional context

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.