### PR TITLE
fix(UI): ensure_punctuation handles quotes properly

### DIFF
--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -376,7 +376,7 @@ static auto ensure_punctuation = []( const std::string &desc, char preferred )
         return desc;
     }
     char last = desc.back();
-    if( last == '.' || last == '!' || last == '?' ) {
+    if( last == '.' || last == '!' || last == '?' || last == '"' ) {
         return desc;
     }
     return desc + preferred;


### PR DESCRIPTION
## Purpose of change (The Why)
The recent changes to sound messages in the log didn't account for quotations.
## Describe the solution (The How)
Add a tiny change to fix it.
## Describe alternatives you've considered
## Testing
Spawn skeletons and a few friendly NPCs, notice that the log now properly displays `"What was that? I heard <noise>..."` instead of `"What was that? I heard <noise...".`
## Additional context
Before:
<img width="319" height="114" alt="image" src="https://github.com/user-attachments/assets/263de9bf-11c5-4395-a226-17133bc50876" />

After:
<img width="343" height="301" alt="image" src="https://github.com/user-attachments/assets/66e54b5c-f659-4e09-a951-c9e1451fe393" />

## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
