### PR TITLE
feat(balance): guns on slings gain coverage percent based on volume, allow slinging more rocket launchers, M72 LAW can be worn when packed

### DIFF
--- a/data/json/items/gun/66mm.json
+++ b/data/json/items/gun/66mm.json
@@ -18,7 +18,7 @@
     "modes": [ [ "DEFAULT", "single shot", 1, "NPC_AVOID" ], [ "BURST", "all barrels", 4, "NPC_AVOID" ] ],
     "magazines": [ [ "m235", [ "m74_clip" ] ] ],
     "reload": 600,
-    "valid_mod_locations": [ [ "accessories", 4 ], [ "barrel", 1 ], [ "grip", 1 ], [ "sling", 1 ] ],
+    "valid_mod_locations": [ [ "accessories", 4 ], [ "sling", 1 ], [ "barrel", 1 ], [ "grip", 1 ], [ "sling", 1 ] ],
     "flags": [ "BACKBLAST", "NEVER_JAMS", "PYROMANIAC_WEAPON" ],
     "faults": [  ]
   },
@@ -35,13 +35,14 @@
     "extend": { "flags": [ "NO_RELOAD", "NO_UNLOAD", "BACKBLAST", "TRADER_AVOID" ] },
     "ammo": "66mm",
     "weight": "700 g",
-    "volume": "2500 ml",
+    "volume": "3 L",
     "price_postapoc": "35 USD",
     "bashing": 6,
     "dispersion": 300,
     "durability": 9,
     "clip_size": 1,
     "reload": 150,
+    "default_mods": [ "shoulder_strap" ],
     "valid_mod_locations": [ [ "accessories", 1 ], [ "sling", 1 ], [ "grip", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "underbarrel", 1 ] ]
   }
 ]

--- a/data/json/items/gun/84x246mm.json
+++ b/data/json/items/gun/84x246mm.json
@@ -24,6 +24,7 @@
       [ "grip", 1 ],
       [ "mechanism", 4 ],
       [ "sights", 1 ],
+      [ "sling", 1 ],
       [ "rail", 1 ],
       [ "underbarrel", 1 ]
     ]

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -856,7 +856,7 @@
       "menu_text": "Activate",
       "type": "transform"
     },
-    "armor_data": { "covers": [ "torso" ], "encumbrance": 2, "material_thickness": 1 },
+    "armor_data": { "covers": [ "torso" ], "encumbrance": 2, "coverage": 3, "material_thickness": 1 },
     "flags": [ "ALLOWS_REMOTE_USE", "BELTED", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
   },
   {

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -838,9 +838,9 @@
     "type": "TOOL",
     "category": "guns",
     "name": { "str": "packed M72 LAW" },
-    "description": "This is a M72 LAW, packed in its storage form.  Use it to pop it out and make it ready to fire.  Once it is activated, it cannot be repacked.",
-    "//": "Combined weight of the launcher plus one round of ammo",
-    "weight": "2800 g",
+    "description": "This is a M72 LAW, packed in its storage form with attached shoulder strap.  Use it to pop it out and make it ready to fire.  Once it is activated, it cannot be repacked.",
+    "//": "Combined weight of the launcher, one round of ammo, and shoulder strap.",
+    "weight": "2900 g",
     "volume": "1500 ml",
     "price": "2 kUSD",
     "price_postapoc": "40 USD",
@@ -856,7 +856,8 @@
       "menu_text": "Activate",
       "type": "transform"
     },
-    "flags": [ "ALLOWS_REMOTE_USE" ]
+    "armor_data": { "covers": [ "torso" ], "encumbrance": 2, "material_thickness": 1 },
+    "flags": [ "ALLOWS_REMOTE_USE", "BELTED", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
   },
   {
     "id": "improvised_grenade",

--- a/data/json/uncraft/weapon/explosive.json
+++ b/data/json/uncraft/weapon/explosive.json
@@ -6,6 +6,13 @@
     "difficulty": 6,
     "time": "10 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "copper", 50 ] ], [ [ "chem_compositionb", 300 ] ], [ [ "impact_fuze", 1 ] ], [ [ "scrap", 3 ] ] ]
+    "components": [
+      [ [ "copper", 50 ] ],
+      [ [ "chem_compositionb", 300 ] ],
+      [ [ "impact_fuze", 1 ] ],
+      [ [ "scrap", 1 ] ],
+      [ [ "material_aluminium_ingot", 2 ] ],
+      [ [ "shoulder_strap", 1 ] ]
+    ]
   }
 ]

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6451,8 +6451,9 @@ layer_level item::get_layer() const
 int item::get_avg_coverage() const
 {
     const islot_armor *armor = find_armor_data();
-    if( !armor ) {
-        return 0;
+    if( armor == nullptr ) {
+        // handle wearable guns (e.g. shoulder strap) as special case
+        return is_gun() ? std::min( volume() / 750_ml, 100 ) : 0;
     }
     int avg_coverage = 0;
     int avg_ctr = 0;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6451,9 +6451,9 @@ layer_level item::get_layer() const
 int item::get_avg_coverage() const
 {
     const islot_armor *armor = find_armor_data();
-    if( armor == nullptr ) {
+    if( !armor ) {
         // handle wearable guns (e.g. shoulder strap) as special case
-        return is_gun() ? std::min( volume() / 750_ml, 100 ) : 0;
+        return is_gun() ? std::min( volume() / 500_ml, 100 ) : 0;
     }
     int avg_coverage = 0;
     int avg_ctr = 0;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -327,6 +327,18 @@ int iuse_transform::use( player &p, item &it, bool t, const tripoint &pos ) cons
             } else {
                 it.set_countdown( qty );
             }
+            // If we're setting target charges then check for integral mods too.
+            if( it.type->gun ) {
+                for( const itype_id &mod : it.type->gun->built_in_mods ) {
+                    detached_ptr<item> content = item::spawn( mod, calendar::turn, qty );
+                    content->set_flag( flag_IRREMOVABLE );
+                    it.put_in( std::move( content ) );
+                }
+                for( const itype_id &mod : it.type->gun->default_mods ) {
+                    it.put_in( item::spawn( mod, calendar::turn, qty ) );
+                }
+
+            }
         }
     } else {
         it.convert( container );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

I figured it'd be neat to allow slapping a shoulder strap on more rocket launchers since soldiers frequently carry it that way, but then in the process of trying to make the packed version wearable by default with I discovered that guns equipped with slings have encumbrance but no coverage percent, meaning they're entirely safe from damage when things like the pistol lanyard indicate that it's expected that a gun will be more at risk of damage when worn on a sling compared to a holster (which takes the damage instead of the gun it holds).

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

C++ changes:
1. In item.cpp, `item::get_avg_coverage` now assigns a coverage percent to guns the same way `item::get_encumber_when_containing` does, only difference is set it at 1% coverage per 500 ml of volume, contrast 1 encumbrance per 750 ml volume. It `std::min`s to avoid chicanery from excessively bulky guns that might push coverage above 100%.
2. In iuse_actor.cpp, `iuse_transform::use` now sets default and integrated mods if it's being told to set charges for what it turns into, since that likely means it's making a new item on the spot as opposed to swapping around the state of a transforming ranged weapon.

JSON changes:
1. Added a sling slot to the M202 FLASH.
3. Added a shoulder strap to the M72 LAW as a default mod, so that it's consistent with the packed version becoming wearable as noted below. Additionally, bumped base volume up from 2.5 liters to 3 liters so it's just about doubled when unpacked.
4. Gave the M3 (and by extension the AT4) a sling slot.
5. Set it so you can wear a packed M72 LAW, making mention of coming with a sling already, bumping up its weight by the weight of a shoulder strap. Armor data has the same flags as a shouldert strap, plus half the encumbrance and coverage percent the LAW will have by default when unpacked.
6. Updated the uncraft recipe of the packed LAW to yield a shoulder strap, and also for good measure the two extra scrap metal it yields over uncrafting the ammo itself now turns into 2 aluminum ingots as fits it being made of aluminum.

## Describe alternatives you've considered

1. Making the coverage percent of a slung weapon more or less forgiving.
2. Hacking together some kinda drunk insanity that will permit bow and spear straps to make their contents take damage as if they were a wearable gunmod installed on the weapon instead of a holster containing them. Eh, seems minor to me plus bow slings imply in their description that it's a feature that they protect your bow better than wearing the bow directly on your body would.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Spawned a LAW and a packed LAW, confirmed it shows I can wear both, they have the same damage reduction but the packed version has half the encumbrance and coverage percent of the unpacked version.
4. Unpacked the other LAW, confirmed it spawns with a shoulder strap included.
5. Temporarily set composite bow to have a builtin bow stabilizer, tested to confirm that tranforming it doesn't regrow default mods after taking it off since it doesn't tell it to generate charges on transform.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![231167-3-4-Afghanistan](https://github.com/user-attachments/assets/56336707-1c49-4a85-8375-31063f3aaf52)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
