### PR TITLE
perf(port): zlight performance improvements

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -926,7 +926,7 @@ struct span {
     T cumulative_value;
     bool skip_first_row;
     bool skip_first_column;
-};  
+};
 
 /**
  * Handle splitting the current span in cast_horizontal_zlight_segment and
@@ -1037,7 +1037,8 @@ void cast_horizontal_zlight_segment(
     const tripoint &offset, const int offset_distance,
     const T numerator )
 {
-    constexpr quadrant quad = quadrant_from_x_y( xx_transform + xy_transform, yx_transform + yy_transform );
+    constexpr quadrant quad = quadrant_from_x_y( xx_transform + xy_transform,
+                              yx_transform + yy_transform );
 
     const auto check_blocked = [ =, &blocked_caches]( const tripoint & p ) -> bool{
         switch( quad )
@@ -1221,7 +1222,7 @@ void cast_horizontal_zlight_segment(
                 // If we didn't scan at least 1 z-level, don't iterate further
                 // Otherwise we may "phase" through tiles without checking them or waste time
                 // checking spans that are out of bounds.
-            !check( current_transparency, last_intensity ) ) {
+                !check( current_transparency, last_intensity ) ) {
                 // If we reach the end of the span with terrain being opaque, we don't iterate further.
                 // This means that any encountered transparent tiles from the current span have been
                 // split off into new spans
@@ -1403,7 +1404,7 @@ void cast_vertical_zlight_segment(
                 // If we didn't scan at least 1 z-level, don't iterate further
                 // Otherwise we may "phase" through tiles without checking them or waste time
                 // checking spans that are out of bounds.
-            !check( current_transparency, last_intensity ) ) {
+                !check( current_transparency, last_intensity ) ) {
                 // If we reach the end of the span with terrain being opaque, we don't iterate further.
                 // This means that any encountered transparent tiles from the current span have been
                 // split off into new spans

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -926,11 +926,96 @@ struct span {
     bool skip_first_row;
 };
 
-template<int xx, int xy, int xz, int yx, int yy, int yz, int zz, typename T,
+
+/**
+ * Handle splitting the current span in cast_horizontal_zlight_segment and
+ * cast_vertical_zlight_segment to avoid as much code duplication as possible
+ */
+template<typename T, bool( *check )( const T &, const T & ), T( *accumulate )( const T &, const T &, const int & )>
+static void split_span( std::list<span<T>> &spans, typename std::list<span<T>>::iterator &this_span,
+                        T &current_transparency, const T &new_transparency, const T &last_intensity,
+                        const int distance, slope &new_start_minor,
+                        const slope &trailing_edge_major, const slope &leading_edge_major,
+                        const slope &trailing_edge_minor, const slope &leading_edge_minor )
+{
+    const T next_cumulative_transparency = accumulate( this_span->cumulative_value,
+                                           current_transparency, distance );
+    // We split the span into up to 4 sub-blocks (sub-frustums actually,
+    // this is the view from the origin looking out):
+    // +-------+ <- end major
+    // |   D   |
+    // +---+---+ <- leading edge major
+    // | B | C |
+    // +---+---+ <- trailing edge major
+    // |   A   |
+    // +-------+ <- start major
+    // ^       ^
+    // |       end minor
+    // start minor
+    // A is previously processed row(s). This might be empty.
+    // B is already-processed tiles from current row. This must exist.
+    // C is remainder of current row. This must exist.
+    // D is not yet processed row(s). Might be empty.
+    // A, B and D have the previous transparency, C has the new transparency,
+    //   which might be opaque.
+    // One we processed fully in 2D and only need to extend in last D
+    // Only emit a new span horizontally if previous span was not opaque.
+    // If end_minor is <= trailing_edge_minor, A, B, C remain one span and
+    //  D becomes a new span if present.
+    // If this is the first row processed in the current span, there is no A span.
+    // If this is the last row processed, there is no D span.
+    // If check returns false, A and B are opaque and have no spans.
+    if( check( current_transparency, last_intensity ) ) {
+        // Emit the A span if present, placing it before the current span in the list
+        if( trailing_edge_major > this_span->start_major ) {
+            spans.emplace( this_span,
+                           this_span->start_major, trailing_edge_major,
+                           this_span->start_minor, this_span->end_minor,
+                           next_cumulative_transparency );
+        }
+
+        // Emit the B span if present, placing it before the current span in the list
+        if( trailing_edge_minor > this_span->start_minor ) {
+            spans.emplace( this_span,
+                           std::max( this_span->start_major, trailing_edge_major ),
+                           std::min( this_span->end_major, leading_edge_major ),
+                           this_span->start_minor, trailing_edge_minor,
+                           next_cumulative_transparency );
+        }
+
+        // Overwrite new_start_minor since previous tile is transparent.
+        new_start_minor = trailing_edge_minor;
+    }
+
+    // Emit the D span if present, placing it after the current span in the list
+    if( leading_edge_major < this_span->end_major ) {
+        // Pass true to the span constructor to set skip_first_row to true
+        // This prevents the same row we are currently checking being check by the
+        // new D span
+        spans.emplace( std::next( this_span ),
+                       leading_edge_major, this_span->end_major,
+                       this_span->start_minor, this_span->end_minor,
+                       this_span->cumulative_value, true );
+    }
+
+    // Truncate this_span to the current block.
+    this_span->start_major = std::max( this_span->start_major, trailing_edge_major );
+    this_span->end_major = std::min( this_span->end_major, leading_edge_major );
+
+    // The new span starts at the leading edge of the previous square if it is opaque,
+    // and at the trailing edge of the current square if it is transparent.
+    this_span->start_minor = new_start_minor;
+    this_span->cumulative_value = next_cumulative_transparency;
+
+    new_start_minor = leading_edge_minor;
+    current_transparency = new_transparency;
+}
+
+template<int xx_transform, int xy_transform, int yx_transform, int yy_transform, int z_transform, typename T,
          T( *calc )( const T &, const T &, const int & ),
          bool( *check )( const T &, const T & ),
          T( *accumulate )( const T &, const T &, const int & )>
-void cast_zlight_segment(
+void cast_horizontal_zlight_segment(
     const array_of_grids_of<T> &output_caches,
     const array_of_grids_of<const T> &input_arrays,
     const array_of_grids_of<const bool> &floor_caches,
@@ -938,7 +1023,7 @@ void cast_zlight_segment(
     const tripoint &offset, const int offset_distance,
     const T numerator )
 {
-    constexpr quadrant quad = quadrant_from_x_y( xx + xy, yx + yy );
+    constexpr quadrant quad = quadrant_from_x_y( xx_transform + xy_transform, yx_transform + yy_transform );
 
     const auto check_blocked = [ =, &blocked_caches]( const tripoint & p ) -> bool{
         switch( quad )
@@ -990,12 +1075,11 @@ void cast_zlight_segment(
 
         for( auto this_span = spans.begin(); this_span != spans.end(); ) {
             bool started_block = false;
-            bool current_floor = false;
             // TODO: Precalculate min/max delta.z based on start/end and distance
             for( delta.z = 0; delta.z <= distance; delta.z++ ) {
                 const slope trailing_edge_major( delta.z * 2 - 1, delta.y * 2 + 1 );
                 const slope leading_edge_major( delta.z * 2 + 1, delta.y * 2 - 1 );
-                current.z = offset.z + delta.z * zz;
+                current.z = offset.z + delta.z * z_transform;
                 if( current.z > max_z || current.z < min_z ) {
                     // Current tile is out of bounds, advance to the next tile.
                     continue;
@@ -1021,8 +1105,8 @@ void cast_zlight_segment(
                 bool started_span = false;
                 const int z_index = current.z + OVERMAP_DEPTH;
                 for( delta.x = 0; delta.x <= distance; delta.x++ ) {
-                    current.x = offset.x + delta.x * xx + delta.y * xy + delta.z * xz;
-                    current.y = offset.y + delta.x * yx + delta.y * yy + delta.z * yz;
+                    current.x = offset.x + delta.x * xx_transform + delta.y * xy_transform;
+                    current.y = offset.y + delta.x * yx_transform + delta.y * yy_transform;
                     // Shadowcasting sweeps from the cardinal to the most extreme edge of the octant
                     // XXXX
                     // --->
@@ -1099,76 +1183,195 @@ void cast_zlight_segment(
                         continue;
                     }
 
-                    const T next_cumulative_transparency = accumulate( this_span->cumulative_value,
-                                                           current_transparency, distance );
-                    // We split the span into up to 4 sub-blocks (sub-frustums actually,
-                    // this is the view from the origin looking out):
-                    // +-------+ <- end major
-                    // |   D   |
-                    // +---+---+ <- leading edge major
-                    // | B | C |
-                    // +---+---+ <- trailing edge major
-                    // |   A   |
-                    // +-------+ <- start major
-                    // ^       ^
-                    // |       end minor
-                    // start minor
-                    // A is previously processed row(s). This might be empty.
-                    // B is already-processed tiles from current row. This must exist.
-                    // C is remainder of current row. This must exist.
-                    // D is not yet processed row(s). Might be empty.
-                    // A, B and D have the previous transparency, C has the new transparency,
-                    //   which might be opaque.
-                    // One we processed fully in 2D and only need to extend in last D
-                    // Only emit a new span horizontally if previous span was not opaque.
-                    // If end_minor is <= trailing_edge_minor, A, B, C remain one span and
-                    //  D becomes a new span if present.
-                    // If this is the first row processed in the current span, there is no A span.
-                    // If this is the last row processed, there is no D span.
-                    // If check returns false, A and B are opaque and have no spans.
-                    if( check( current_transparency, last_intensity ) ) {
-                        // Emit the A span if present, placing it before the current span in the list
-                        if( trailing_edge_major > this_span->start_major ) {
-                            spans.emplace( this_span,
-                                           this_span->start_major, trailing_edge_major,
-                                           this_span->start_minor, this_span->end_minor,
-                                           next_cumulative_transparency );
-                        }
 
-                        // Emit the B span if present, placing it before the current span in the list
-                        if( trailing_edge_minor > this_span->start_minor ) {
-                            spans.emplace( this_span,
-                                           std::max( this_span->start_major, trailing_edge_major ),
-                                           std::min( this_span->end_major, leading_edge_major ),
-                                           this_span->start_minor, trailing_edge_minor,
-                                           next_cumulative_transparency );
-                        }
+                    // Handle spliting the span into up to 4 separate spans
+                    split_span<T, check, accumulate>( spans, this_span, current_transparency, new_transparency,
+                                                      last_intensity, distance, new_start_minor,
+                                                      trailing_edge_major, leading_edge_major,
+                                                      trailing_edge_minor, leading_edge_minor );
+                }
 
-                        // Overwrite new_start_minor since previous tile is transparent.
-                        new_start_minor = trailing_edge_minor;
+                // If we end the row with an opaque tile, set the span to start at the next row
+                // since we don't need to process the current one any more.
+                if( !check( current_transparency, last_intensity ) ) {
+                    this_span->start_major = leading_edge_major;
+                }
+            }
+
+            if( !started_block ) {
+                // If we didn't scan at least 1 z-level, don't iterate further
+                // Otherwise we may "phase" through tiles without checking them or waste time
+                // checking spans that are out of bounds.
+                this_span = spans.erase( this_span );
+            } else if( !check( current_transparency, last_intensity ) ) {
+                // If we reach the end of the span with terrain being opaque, we don't iterate further.
+                // This means that any encountered transparent tiles from the current span have been
+                // split off into new spans
+                this_span = spans.erase( this_span );
+            } else {
+                // Cumulative average of the values encountered.
+                this_span->cumulative_value = accumulate( this_span->cumulative_value,
+                                              current_transparency, distance );
+                ++this_span;
+            }
+        }
+    }
+}
+
+template<int x_transform, int y_transform, int z_transform, typename T,
+         T( *calc )( const T &, const T &, const int & ),
+         bool( *check )( const T &, const T & ),
+         T( *accumulate )( const T &, const T &, const int & )>
+void cast_vertical_zlight_segment(
+    const array_of_grids_of<T> &output_caches,
+    const array_of_grids_of<const T> &input_arrays,
+    const array_of_grids_of<const bool> &floor_caches,
+    const array_of_grids_of < const diagonal_blocks > &blocked_caches,
+    const tripoint &offset, const int offset_distance,
+    const T numerator )
+{
+    const int radius = 60 - offset_distance;
+
+    constexpr int min_z = -OVERMAP_DEPTH;
+    constexpr int max_z = OVERMAP_HEIGHT;
+
+    slope new_start_minor( 1, 1 );
+
+    T last_intensity = 0.0;
+    static constexpr tripoint origin( 0, 0, 0 );
+    tripoint delta( 0, 0, 0 );
+    tripoint current( 0, 0, 0 );
+
+    // We start out with one span covering the entire horizontal and vertical space
+    // we are interested in.  Then as changes in transparency are encountered, we truncate
+    // that initial span and insert new spans before/after it in the list, removing any that
+    // are no longer needed as we go.
+    std::list<span<T>> spans = { {
+            slope( 0, 1 ), slope( 1, 1 ),
+            slope( 0, 1 ), slope( 1, 1 ),
+            LIGHT_TRANSPARENCY_OPEN_AIR
+        }
+    };
+    // At each "depth", a.k.a. distance from the origin, we iterate once over the list of spans,
+    // possibly splitting them.
+    for( int distance = 1; distance <= radius; distance++ ) {
+        delta.z = distance;
+        T current_transparency = 0.0f;
+
+        for( auto this_span = spans.begin(); this_span != spans.end(); ) {
+            bool started_block = false;
+            for( delta.y = 0; delta.y <= distance; delta.y++ ) {
+                const slope trailing_edge_major( delta.y * 2 - 1, delta.z * 2 + 1 );
+                const slope leading_edge_major( delta.y * 2 + 1, delta.z * 2 - 1 );
+                current.y = offset.y + delta.y * y_transform;
+                if( current.y < 0 || current.y >= MAPSIZE_Y ) {
+                    // Current tile is out of bounds, advance to the next tile.
+                    continue;
+                } else if( this_span->start_major > leading_edge_major ) {
+                    // Current span has a higher z-value,
+                    // jump to next iteration to catch up.
+                    continue;
+                } else if( this_span->skip_first_row && this_span->start_major == leading_edge_major ) {
+                    // Prevents an infinite loop in some cases after splitting off the D span.
+                    // We don't want to recheck the row that just caused the D span to be split off,
+                    // since that can lead to an identical span being split off again, hence the
+                    // infinite loop.
+                    //
+                    // This could also be accomplished by adding a small epsilon to the start_major
+                    // of the D span but that causes artifacts.
+                    continue;
+                } else if( this_span->end_major < trailing_edge_major ) {
+                    // We've escaped the bounds of the current span we're considering,
+                    // So continue to the next span.
+                    break;
+                }
+
+                bool started_span = false;
+                for( delta.x = 0; delta.x <= distance; delta.x++ ) {
+                    current.x = offset.x + delta.x * x_transform;
+                    current.z = offset.z + delta.z * z_transform;
+                    // Shadowcasting sweeps from the cardinal to the most extreme edge of the octant
+                    // XXXX
+                    // --->
+                    // XXX
+                    // -->
+                    // XX
+                    // ->
+                    // X
+                    // @
+                    //
+                    // Trailing edge -> +-
+                    //                  |+| <- Center of tile
+                    //                   -+ <- Leading Edge
+                    //  Direction of sweep --->
+                    // Use corners of given tile as above to determine angles of
+                    // leading and trailing edges being considered.
+                    const slope trailing_edge_minor( delta.x * 2 - 1, delta.z * 2 + 1 );
+                    const slope leading_edge_minor( delta.x * 2 + 1, delta.z * 2 - 1 );
+
+                    if( current.x < 0 || current.x >= MAPSIZE_X ||
+                        current.z > max_z || current.z < min_z ) {
+                        // Current tile is out of bounds, advance to the next tile.
+                        continue;
+                    } else if( this_span->start_minor > leading_edge_minor ) {
+                        // Current tile comes before the span we're considering, advance to the next tile.
+                        continue;
+                    } else if( this_span->end_minor < trailing_edge_minor ) {
+                        // Current tile is after the span we're considering, continue to next row.
+                        break;
                     }
 
-                    // Emit the D span if present, placing it after the current span in the list
-                    if( leading_edge_major < this_span->end_major ) {
-                    //    // Pass true to the span constructor to set skip_first_row to true
-                    //    // This prevents the same row we are currently checking being check by the
-                    //    // new D span
-                        spans.emplace( std::next( this_span ),
-                                       leading_edge_major, this_span->end_major,
-                                       this_span->start_minor, this_span->end_minor,
-                                       this_span->cumulative_value, true );
+                    const int z_index = current.z + OVERMAP_DEPTH;
+
+                    T new_transparency = ( *input_arrays[z_index] )[current.x][current.y];
+
+                    // If we're looking at a tile with floor or roof from the floor/roof side,
+                    // that tile is actually invisible to us.
+                    bool floor_block = false;
+                    if( current.z < offset.z ) {
+                        if( z_index < ( OVERMAP_LAYERS - 1 ) &&
+                            ( *floor_caches[z_index + 1] )[current.x][current.y] ) {
+                            floor_block = true;
+                            new_transparency = LIGHT_TRANSPARENCY_SOLID;
+                        }
+                    } else if( current.z > offset.z ) {
+                        if( ( *floor_caches[z_index] )[current.x][current.y] ) {
+                            floor_block = true;
+                            new_transparency = LIGHT_TRANSPARENCY_SOLID;
+                        }
                     }
 
-                    // Truncate this_span to the current block.
-                    this_span->start_major = std::max( this_span->start_major, trailing_edge_major );
-                    this_span->end_major = std::min( this_span->end_major, leading_edge_major );
+                    if( !started_block ) {
+                        started_block = true;
+                        current_transparency = new_transparency;
+                    }
 
-                    // The new span starts at the leading edge of the previous square if it is opaque,
-                    // and at the trailing edge of the current square if it is transparent.
-                    this_span->start_minor = new_start_minor;
+                    const int dist = rl_dist( origin, delta ) + offset_distance;
+                    last_intensity = calc( numerator, this_span->cumulative_value, dist );
 
-                    new_start_minor = leading_edge_minor;
-                    current_transparency = new_transparency;
+                    if( !floor_block ) {
+                        ( *output_caches[z_index] )[current.x][current.y] =
+                            std::max( ( *output_caches[z_index] )[current.x][current.y], last_intensity );
+                    }
+
+                    if( !started_span ) {
+                        // Need to reset minor slope, because we're starting a new line
+                        new_start_minor = leading_edge_minor;
+                        started_span = true;
+                    }
+
+                    if( new_transparency == current_transparency ) {
+                        // All in order, no need to split the span.
+                        new_start_minor = leading_edge_minor;
+                        continue;
+                    }
+
+
+                    // Handle spliting the span into up to 4 separate spans
+                    split_span<T, check, accumulate>( spans, this_span, current_transparency, new_transparency,
+                                                      last_intensity, distance, new_start_minor,
+                                                      trailing_edge_major, leading_edge_major,
+                                                      trailing_edge_minor, leading_edge_minor );
                 }
 
                 // If we end the row with an opaque tile, set the span to start at the next row
@@ -1208,46 +1411,128 @@ void cast_zlight(
     const array_of_grids_of < const diagonal_blocks > &blocked_caches,
     const tripoint &origin, const int offset_distance, const T numerator )
 {
-    // Down
-    cast_zlight_segment < 0, 1, 0, 1, 0, 0, -1, T, calc, check, accumulate > (
+    // Down lateral
+
+    //   .
+    //  ..
+    // @..
+    cast_horizontal_zlight_segment < 0, 1, 1, 0, -1, T, calc, check, accumulate > (
         output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
-    cast_zlight_segment < 1, 0, 0, 0, 1, 0, -1, T, calc, check, accumulate > (
+    // ...
+    // ..
+    // @
+    cast_horizontal_zlight_segment < 1, 0, 0, 1, -1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // @..
+    //  ..
+    //   .
+    cast_horizontal_zlight_segment < 0, -1, 1, 0, -1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // ...
+    //  ..
+    //   @
+    cast_horizontal_zlight_segment < -1, 0, 0, 1, -1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // .
+    // ..
+    // ..@
+    cast_horizontal_zlight_segment < 0, 1, -1, 0, -1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // @
+    // ..
+    // ...
+    cast_horizontal_zlight_segment < 1, 0, 0, -1, -1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // ..@
+    // ..
+    // .
+    cast_horizontal_zlight_segment < 0, -1, -1, 0, -1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    //   @
+    //  ..
+    // ...
+    cast_horizontal_zlight_segment < -1, 0, 0, -1, -1, T, calc, check, accumulate > (
         output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 
-    cast_zlight_segment < 0, -1, 0, 1, 0, 0, -1, T, calc, check, accumulate > (
+    // Up lateral
+
+    //   .
+    //  ..
+    // @..
+    cast_horizontal_zlight_segment < 0, 1, 1, 0, 1, T, calc, check, accumulate > (
         output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
-    cast_zlight_segment < -1, 0, 0, 0, 1, 0, -1, T, calc, check, accumulate > (
+    // ...
+    // ..
+    // @
+    cast_horizontal_zlight_segment < 1, 0, 0, 1, 1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // @..
+    //  ..
+    //   .
+    cast_horizontal_zlight_segment < 0, -1, 1, 0, 1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // ...
+    //  ..
+    //   @
+    cast_horizontal_zlight_segment < -1, 0, 0, 1, 1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // .
+    // ..
+    // ..@
+    cast_horizontal_zlight_segment < 0, 1, -1, 0, 1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // @
+    // ..
+    // ...
+    cast_horizontal_zlight_segment < 1, 0, 0, -1, 1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // ..@
+    // ..
+    // .
+    cast_horizontal_zlight_segment < 0, -1, -1, 0, 1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    //   @
+    //  ..
+    // ...
+    cast_horizontal_zlight_segment < -1, 0, 0, -1, 1, T, calc, check, accumulate > (
         output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 
-    cast_zlight_segment < 0, 1, 0, -1, 0, 0, -1, T, calc, check, accumulate > (
+    // Straight up
+
+    // ..
+    // @.
+    cast_vertical_zlight_segment < 1, 1, 1, T, calc, check, accumulate > (
         output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
-    cast_zlight_segment < 1, 0, 0, 0, -1, 0, -1, T, calc, check, accumulate > (
+    // @.
+    // ..
+    cast_vertical_zlight_segment < 1, -1, 1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // ..
+    // .@
+    cast_vertical_zlight_segment < -1, 1, 1, T, calc, check, accumulate > (
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // .@
+    // ..
+    cast_vertical_zlight_segment < -1, -1, 1, T, calc, check, accumulate > (
         output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 
-    cast_zlight_segment < 0, -1, 0, -1, 0, 0, -1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
-    cast_zlight_segment < -1, 0, 0, 0, -1, 0, -1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
+    // Straight down
 
-    // Up
-    cast_zlight_segment<0, 1, 0, 1, 0, 0, 1, T, calc, check, accumulate>(
+    // ..
+    // @.
+    cast_vertical_zlight_segment < 1, 1, -1, T, calc, check, accumulate > (
         output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
-    cast_zlight_segment<1, 0, 0, 0, 1, 0, 1, T, calc, check, accumulate>(
+    // @.
+    // ..
+    cast_vertical_zlight_segment < 1, -1, -1, T, calc, check, accumulate > (
         output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
-
-    cast_zlight_segment < 0, -1, 0, 1, 0, 0, 1, T, calc, check, accumulate > (
+    // ..
+    // .@
+    cast_vertical_zlight_segment < -1, 1, -1, T, calc, check, accumulate > (
         output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
-    cast_zlight_segment < -1, 0, 0, 0, 1, 0, 1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
-
-    cast_zlight_segment < 0, 1, 0, -1, 0, 0, 1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
-    cast_zlight_segment < 1, 0, 0, 0, -1, 0, 1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
-
-    cast_zlight_segment < 0, -1, 0, -1, 0, 0, 1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
-    cast_zlight_segment < -1, 0, 0, 0, -1, 0, 1, T, calc, check, accumulate > (
+    // .@
+    // ..
+    cast_vertical_zlight_segment < -1, -1, -1, T, calc, check, accumulate > (
         output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 }
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
Currently, if a player attempts to fly over a forest with a helicopter or one of the new planes that got recently added
they will experience significant performance issues

This is because the current zlight implementation will recurse around 5 million times when perfoming its calculations if the player is sat above a forest.

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
mostly ports https://github.com/CleverRaven/Cataclysm-DDA/pull/42835
also ports https://github.com/CleverRaven/Cataclysm-DDA/pull/72669

these prs improve the overall performance of the zlight system by removing all recursion,
which results in significant improvements when flying over forests and smaller improvements in towns

the catch is the resulting sightlines produced after this pr are sliiightly less nice looking, I have attached a comparison below

<img width="1132" height="1046" alt="2025-09-14-17:37:52" src="https://github.com/user-attachments/assets/b93a9f91-eb16-44e1-8c8e-30a69fc88c1a" /> 
current nightly

<img width="1109" height="1048" alt="2025-09-14-17:38:07" src="https://github.com/user-attachments/assets/9c41a4c4-041b-4190-b47c-d97021afb86b" />
this pr






and a tracy comparison

<img width="1895" height="977" alt="2025-09-15-12:11:06" src="https://github.com/user-attachments/assets/884858dd-3b0c-44d2-b784-3c6bc7f2056b" />
tracy from currently nightly (1 turn = ~8.5s without tracy on)

<img width="1899" height="975" alt="2025-09-15-12:10:52" src="https://github.com/user-attachments/assets/a71373ce-7ec5-43a7-85b9-6221d22fdded" />
tracy from this pr (1 turn = ~1.5s without tracy on)




<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Improving bn's current implementation,
Which I have tried to do, unfortunately I have had little success in making the current implementation not choke and die on forests without producing results that are much worse looking and performing then the ported prs

## Testing

[save.zip](https://github.com/user-attachments/files/22326533/save.zip)

used the above save for testing, placed `ZoneScoped;` within relevant zlight functions
built the game out with tracy, attached tracy and passed several turns to gather the above tracy screenshots

comparison screenshots taken at overmap tile 205 468

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
I never want to look at the zlight code again in my life

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
