### PR TITLE
feat: multi-recipe nanofab templates, nanofabs dispense liquids

### DIFF
--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -157,6 +157,7 @@
       { "item": "rx11_stimpack", "prob": 10 },
       { "item": "rx12_injector", "prob": 10 },
       { "item": "ampoule", "prob": 10 },
+      { "item": "mutagen", "prob": 10 },
       { "item": "stimpack_ammo", "prob": 10 },
       { "item": "tool_rdx_charge", "prob": 10 },
       { "item": "solar_panel_v3", "prob": 10 },

--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -73,7 +73,7 @@
   },
   {
     "type": "item_group",
-    "id": "nanofab_bots",
+    "id": "nanofab_robotics",
     "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
     "magazine": 100,
     "subtype": "distribution",

--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -73,7 +73,7 @@
   },
   {
     "type": "item_group",
-    "id": "nanofab_recipes",
+    "id": "nanofab_bots",
     "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
     "//2": "rough organization: bots, power, armor, weapon mods, weapons, misc",
     "magazine": 100,
@@ -86,17 +86,34 @@
       { "item": "bot_haulerbot", "prob": 10 },
       { "item": "bot_mech_recon", "prob": 10 },
       { "item": "bot_mech_combat", "prob": 10 },
+      { "item": "bot_chickenbot", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "nanofab_power",
+    "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
+    "//2": "rough organization: bots, power, armor, weapon mods, weapons, misc",
+    "magazine": 100,
+    "subtype": "distribution",
+    "entries": [
       { "item": "bio_power_storage_mkII", "prob": 10 },
       { "item": "huge_atomic_battery_cell", "prob": 10 },
-      { "item": "heavy_atomic_battery_cell", "prob": 10 },
+      { "item": "heavy_atomic_battery_cell", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "nanofab_armor",
+    "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
+    "//2": "rough organization: bots, power, armor, weapon mods, weapons, misc",
+    "magazine": 100,
+    "subtype": "distribution",
+    "entries": [
       { "item": "optical_cloak", "prob": 10 },
       { "item": "holo_cloak", "prob": 10 },
       { "item": "stillsuit", "prob": 10 },
       { "item": "rm13_armor", "prob": 10 },
-      { "item": "rx11_stimpack", "prob": 10 },
-      { "item": "rx12_injector", "prob": 10 },
-      { "item": "ampoule", "prob": 10 },
-      { "item": "stimpack_ammo", "prob": 10 },
       { "item": "power_armor_frame", "prob": 10 },
       { "item": "power_armor_basic", "prob": 10 },
       { "item": "power_armor_light", "prob": 10 },
@@ -104,7 +121,21 @@
       { "item": "power_armor_helmet_basic", "prob": 10 },
       { "item": "power_armor_helmet_heavy", "prob": 10 },
       { "item": "power_armor_helmet_light", "prob": 10 },
-      { "item": "exosuit_military", "prob": 10 },
+      { "item": "exosuit_military", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "nanofab_combat",
+    "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
+    "//2": "rough organization: bots, power, armor, weapon mods, weapons, misc",
+    "magazine": 100,
+    "subtype": "distribution",
+    "entries": [
+      { "item": "rx11_stimpack", "prob": 10 },
+      { "item": "rx12_injector", "prob": 10 },
+      { "item": "ampoule", "prob": 10 },
+      { "item": "stimpack_ammo", "prob": 10 },
       { "item": "high_density_capacitor", "prob": 10 },
       { "item": "beam_scatterer", "prob": 10 },
       { "item": "hk_g80", "prob": 10 },
@@ -115,14 +146,20 @@
       { "item": "emp_gun", "prob": 10 },
       { "item": "plasma_gun", "prob": 10 },
       { "item": "laser_rifle", "prob": 10 },
-      { "item": "v29", "prob": 10 },
-      { "item": "alloy_plate", "prob": 10 },
       { "item": "mininuke", "prob": 10 },
-      { "item": "tool_rdx_charge", "prob": 10 },
       { "item": "50_mk211", "prob": 10 },
-      { "item": "solar_panel_v3", "prob": 10 },
-      { "item": "portal", "prob": 10 }
+      { "item": "tool_rdx_charge", "prob": 10 },
+      { "item": "v29", "prob": 10 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "nanofab_science",
+    "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
+    "//2": "rough organization: bots, power, armor, weapon mods, weapons, misc",
+    "magazine": 100,
+    "subtype": "distribution",
+    "entries": [ { "item": "alloy_plate", "prob": 10 }, { "item": "solar_panel_v3", "prob": 10 }, { "item": "portal", "prob": 10 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -75,7 +75,6 @@
     "type": "item_group",
     "id": "nanofab_bots",
     "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
-    "//2": "rough organization: bots, power, armor, weapon mods, weapons, misc",
     "magazine": 100,
     "subtype": "distribution",
     "entries": [
@@ -85,19 +84,21 @@
       { "item": "bot_prototype_cyborg", "prob": 10 },
       { "item": "bot_haulerbot", "prob": 10 },
       { "item": "bot_mech_recon", "prob": 10 },
-      { "item": "bot_mech_combat", "prob": 10 },
-      { "item": "bot_chickenbot", "prob": 10 }
+      { "item": "bot_mech_combat", "prob": 10 }
     ]
   },
   {
     "type": "item_group",
     "id": "nanofab_power",
     "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
-    "//2": "rough organization: bots, power, armor, weapon mods, weapons, misc",
     "magazine": 100,
     "subtype": "distribution",
     "entries": [
+      { "item": "AID_bio_power_storage_mkII", "prob": 10 },
       { "item": "bio_power_storage_mkII", "prob": 10 },
+      { "item": "plut_cell", "prob": 10 },
+      { "item": "light_atomic_battery_cell", "prob": 10 },
+      { "item": "medium_atomic_battery_cell", "prob": 10 },
       { "item": "huge_atomic_battery_cell", "prob": 10 },
       { "item": "heavy_atomic_battery_cell", "prob": 10 }
     ]
@@ -106,7 +107,6 @@
     "type": "item_group",
     "id": "nanofab_armor",
     "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
-    "//2": "rough organization: bots, power, armor, weapon mods, weapons, misc",
     "magazine": 100,
     "subtype": "distribution",
     "entries": [
@@ -128,14 +128,9 @@
     "type": "item_group",
     "id": "nanofab_combat",
     "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
-    "//2": "rough organization: bots, power, armor, weapon mods, weapons, misc",
     "magazine": 100,
     "subtype": "distribution",
     "entries": [
-      { "item": "rx11_stimpack", "prob": 10 },
-      { "item": "rx12_injector", "prob": 10 },
-      { "item": "ampoule", "prob": 10 },
-      { "item": "stimpack_ammo", "prob": 10 },
       { "item": "high_density_capacitor", "prob": 10 },
       { "item": "beam_scatterer", "prob": 10 },
       { "item": "hk_g80", "prob": 10 },
@@ -148,7 +143,6 @@
       { "item": "laser_rifle", "prob": 10 },
       { "item": "mininuke", "prob": 10 },
       { "item": "50_mk211", "prob": 10 },
-      { "item": "tool_rdx_charge", "prob": 10 },
       { "item": "v29", "prob": 10 }
     ]
   },
@@ -156,10 +150,18 @@
     "type": "item_group",
     "id": "nanofab_science",
     "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
-    "//2": "rough organization: bots, power, armor, weapon mods, weapons, misc",
     "magazine": 100,
     "subtype": "distribution",
-    "entries": [ { "item": "alloy_plate", "prob": 10 }, { "item": "solar_panel_v3", "prob": 10 }, { "item": "portal", "prob": 10 } ]
+    "entries": [
+      { "item": "alloy_plate", "prob": 10 },
+      { "item": "rx11_stimpack", "prob": 10 },
+      { "item": "rx12_injector", "prob": 10 },
+      { "item": "ampoule", "prob": 10 },
+      { "item": "stimpack_ammo", "prob": 10 },
+      { "item": "tool_rdx_charge", "prob": 10 },
+      { "item": "solar_panel_v3", "prob": 10 },
+      { "item": "portal", "prob": 10 }
+    ]
   },
   {
     "type": "item_group",

--- a/data/json/obsoletion/itemgroups.json
+++ b/data/json/obsoletion/itemgroups.json
@@ -212,5 +212,38 @@
     "//2": "This group is for a utensils drawer.",
     "subtype": "collection",
     "entries": [ { "item": "tongs", "prob": 95 }, { "item": "tongs", "prob": 50 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "nanofab_recipes",
+    "//": "Very rare high level loot. This list doesn't spawn anywhere directly, it is used to create the recipes inside nanofabricator templates. ",
+    "//2": "rough organization: bots, power, armor, weapon mods, weapons, misc",
+    "magazine": 100,
+    "subtype": "distribution",
+    "entries": [
+      { "item": "rx11_stimpack", "prob": 10 },
+      { "item": "rx12_injector", "prob": 10 },
+      { "item": "ampoule", "prob": 10 },
+      { "item": "stimpack_ammo", "prob": 10 },
+      { "item": "high_density_capacitor", "prob": 10 },
+      { "item": "beam_scatterer", "prob": 10 },
+      { "item": "hk_g80", "prob": 10 },
+      { "item": "hk_g80mag", "prob": 10 },
+      { "item": "12mm", "prob": 10 },
+      { "item": "plasma_rifle", "prob": 10 },
+      { "item": "rm11b_sniper_rifle", "prob": 10 },
+      { "item": "emp_gun", "prob": 10 },
+      { "item": "plasma_gun", "prob": 10 },
+      { "item": "laser_rifle", "prob": 10 },
+      { "item": "v29", "prob": 10 },
+      { "item": "alloy_plate", "prob": 10 },
+      { "item": "mininuke", "prob": 10 },
+      { "item": "tool_rdx_charge", "prob": 10 },
+      { "item": "50_mk211", "prob": 10 },
+      { "item": "solar_panel_v3", "prob": 10 },
+      { "item": "portal", "prob": 10 },
+      { "item": "tool_rdx_charge", "prob": 10 },
+      { "item": "v29", "prob": 10 }
+    ]
   }
 ]

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -343,7 +343,21 @@ void iexamine::nanofab( player &p, const tripoint &examp )
         return;
     }
 
+    int item_count = 1;
+
     detached_ptr<item> new_item = item::spawn( itype_id( chosen_recipe ), calendar::turn );
+
+    if( new_item->made_of( LIQUID ) ) {
+        const int amount = string_input_popup()
+                           .title( "Dispense how many units?" )
+                           .width( 5 )
+                           .text( std::to_string( 1 ) )
+                           .only_digits( true )
+                           .query_int();
+        item_count = amount;
+
+        new_item = item::spawn( itype_id( chosen_recipe ), calendar::turn, item_count );
+    }
 
     auto qty = std::max( 1, new_item->volume() / 250_ml );
     auto reqs = *requirement_id( "nanofabricator" ) * qty;
@@ -365,6 +379,7 @@ void iexamine::nanofab( player &p, const tripoint &examp )
         new_item->set_flag( flag_FIT );
     }
 
+    // we're sticking an item from our inventory under the nanofabrication dispenser
     if( new_item->made_of( LIQUID ) ) {
         liquid_handler::handle_liquid( std::move( new_item ) );  // let it own the pointer
         return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -365,6 +365,11 @@ void iexamine::nanofab( player &p, const tripoint &examp )
         new_item->set_flag( flag_FIT );
     }
 
+    if( new_item->made_of( LIQUID ) ) {
+        liquid_handler::handle_liquid( std::move( new_item ) );  // let it own the pointer
+        return;
+    }
+
     here.add_item_or_charges( spawn_point, std::move( new_item ) );
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -300,7 +300,7 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ),
             item_group_id( "nanofab_science" ),
             item_group_id( "nanofab_combat" ),
             item_group_id( "nanofab_power" ),
-            item_group_id( "nanofab_bots" ),
+            item_group_id( "nanofab_robotics" ),
             item_group_id( "nanofab_armor" )
         };
 


### PR DESCRIPTION
## Purpose of change (The Why)
Followup to my previous nanofab PR https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6832.

Nanofabricator templates are sort of awkward to use, and this addresses a few different issues with them.
## Describe the solution (The How)
Nanofab templates now store `NANOFAB_GROUP_ID` variables internally instead of `NANOFAB_ITEM_ID`.

Nanofabs can now handle `NANOFAB_GROUP_ID` entries in addition to the legacy `NANOFAB_ITEM_ID` entries.

Nanofabs can now dispense liquids, and prompt the user for a specified amount of liquid to dispense.
## Describe alternatives you've considered
Not hardcoding the specific templates, going to ask for some help on this before I take it out of draft.

May change the groups/add new ones once I get around to it either in this PR or another followup PR. As Fox mentioned on the discord, I think "commercial" nanofab templates for production corporations to print less important items like silverware (or steel and oil, etc) could be a cool route to take in regards to making the nanofabricator more useful as an endgame crafting device. I also REALLY want to add a chicken walker to the bot schematics (as well as the relevant ammunition for each turret).

Allowing the user to put a container item on the nanofab platform, which is then filled with liquid? This would've been harder and I still don't know if it makes much sense to do it this way.
Allowing the nanofab to materialize a new container, fully filled each time? This seemed like it would've been a harder solution, but may be cooler.

Allowing a way to specify a name that isn't hardcoded to the format `nanofab_%s` where %s = `debug_message` results in `nanofabricator template (debug message)`. Don't know the best way to do this however.
## Testing
Created a simple nanofab setup in a derelict shed and spawned nanomaterial. Tried each of the various templates and ensured they spawned items correctly still. Note that I HAVENT tested backwards compatibility yet for old templates, and that this world was created after the changes in this PR.
<details>
<summary>📸 My shack</summary>

<img width="576" height="571" alt="image" src="https://github.com/user-attachments/assets/1f227d97-4962-4a6f-a711-d9026b3c9b84" />

</details>

## Additional context

Unfortunately with the current implementation, if you can't properly store all the liquid you produce (will only work on one container, as well) it will just vanish into thin air without a refund on nanomaterial.

<details>
<summary>📸 Screenshots</summary>

<img width="366" height="407" alt="image" src="https://github.com/user-attachments/assets/5d28b0e1-60be-457f-9a04-0bcbcd25965b" />
<img width="366" height="237" alt="image" src="https://github.com/user-attachments/assets/57057121-b8b0-42c9-bb90-149a56aa0286" />
<img width="366" height="237" alt="image" src="https://github.com/user-attachments/assets/7d69e9b4-e329-4ae1-93c6-80259369520d" />

</details>

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
