### PR TITLE
feat: replace camper NPC with mutant wandering scavenger

### DIFF
--- a/data/json/mapgen/nested/residential_lawn_nested.json
+++ b/data/json/mapgen/nested/residential_lawn_nested.json
@@ -357,7 +357,7 @@
         "___"
       ],
       "terrain": { "_": "t_null" },
-      "place_npcs": [ { "class": "NPC_wandering_survivor", "x": [ 0, 2 ], "y": [ 0, 2 ] } ]
+      "place_npcs": [ { "class": "NPC_wandering_scavenger", "x": [ 0, 2 ], "y": [ 0, 2 ] } ]
     }
   },
   {

--- a/data/json/mapgen/nested/residential_lawn_nested.json
+++ b/data/json/mapgen/nested/residential_lawn_nested.json
@@ -348,7 +348,7 @@
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "res_lawn_randomnpc",
-    "//": "friend or foe?",
+    "//": "friend or foe? probably going to die anyway",
     "object": {
       "mapgensize": [ 3, 3 ],
       "rows": [

--- a/data/json/mapgen/nested/residential_lawn_nested.json
+++ b/data/json/mapgen/nested/residential_lawn_nested.json
@@ -43,7 +43,7 @@
             [ "res_lawn_corpse", 5 ],
             [ "res_lawn_trimmings", 5 ],
             [ "res_lawn_bloodpool", 5 ],
-            [ "res_lawn_randomnpc", 1 ],
+            [ "res_lawn_randomnpc", 2 ],
             [ "res_lawn_boulder", 5 ]
           ],
           "x": 0,
@@ -357,7 +357,7 @@
         "___"
       ],
       "terrain": { "_": "t_null" },
-      "place_npcs": [ { "class": "survivor_camper", "x": [ 0, 2 ], "y": [ 0, 2 ] } ]
+      "place_npcs": [ { "class": "NPC_wandering_survivor", "x": [ 0, 2 ], "y": [ 0, 2 ] } ]
     }
   },
   {
@@ -539,7 +539,7 @@
             [ "res_lawn_trimmings", 5 ],
             [ "res_backyard_dirtpatch", 5 ],
             [ "res_lawn_bloodpool", 5 ],
-            [ "res_lawn_randomnpc", 1 ],
+            [ "res_lawn_randomnpc", 2 ],
             [ "res_lawn_boulder", 5 ]
           ],
           "x": 0,

--- a/data/json/mapgen/nested/roof_nested.json
+++ b/data/json/mapgen/nested/roof_nested.json
@@ -710,7 +710,7 @@
         "___"
       ],
       "terrain": { "_": "t_null" },
-      "place_npcs": [ { "class": "NPC_wandering_survivor", "x": [ 0, 2 ], "y": [ 0, 2 ] } ]
+      "place_npcs": [ { "class": "NPC_wandering_scavenger", "x": [ 0, 2 ], "y": [ 0, 2 ] } ]
     }
   }
 ]

--- a/data/json/mapgen/nested/roof_nested.json
+++ b/data/json/mapgen/nested/roof_nested.json
@@ -583,7 +583,8 @@
             [ "res_roof_survivorbag", 2 ],
             [ "res_roof_scope", 5 ],
             [ "res_roof_feral", 1 ],
-            [ "res_roof_wasp", 1 ]
+            [ "res_roof_wasp", 1 ],
+            [ "res_roof_randomnpc", 1 ]
           ],
           "x": [ 0 ],
           "y": [ 0 ]
@@ -694,6 +695,22 @@
         { "group": "drugs_heal_simple", "x": 0, "y": 0, "chance": 20, "repeat": [ 2, 3 ] },
         { "item": "duffelbag", "x": 0, "y": 0 }
       ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "res_roof_randomnpc",
+    "//": "friend or foe? a bit safer up here",
+    "object": {
+      "mapgensize": [ 3, 3 ],
+      "rows": [
+        "___",
+        "___",
+        "___"
+      ],
+      "terrain": { "_": "t_null" },
+      "place_npcs": [ { "class": "NPC_wandering_survivor", "x": [ 0, 2 ], "y": [ 0, 2 ] } ]
     }
   }
 ]

--- a/data/json/npcs/classes.json
+++ b/data/json/npcs/classes.json
@@ -244,7 +244,12 @@
     "name": { "str": "Wandering Scavenger" },
     "//": "spawns in the res_lawn_randomnpc nested mapgen",
     "job_description": "I'm a wandering soul just trying to survive.",
-    "traits": [ { "group": "BG_survival_story_UNIVERSAL" }, { "group": "NPC_starting_traits" }, { "group": "NPC_mutation_traits" }, { "group": "Appearance_demographics" } ],
+    "traits": [
+      { "group": "BG_survival_story_UNIVERSAL" },
+      { "group": "NPC_starting_traits" },
+      { "group": "NPC_mutation_traits" },
+      { "group": "Appearance_demographics" }
+    ],
     "skills": [
       { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
       { "skill": "melee", "bonus": { "rng": [ 2, 5 ] } },

--- a/data/json/npcs/classes.json
+++ b/data/json/npcs/classes.json
@@ -240,6 +240,25 @@
   },
   {
     "type": "npc_class",
+    "id": "NC_WANDERING_SCAVENGER",
+    "name": { "str": "Wandering Scavenger" },
+    "//": "spawns in the res_lawn_randomnpc nested mapgen",
+    "job_description": "I'm a wandering soul just trying to survive.",
+    "traits": [ { "group": "BG_survival_story_UNIVERSAL" }, { "group": "NPC_starting_traits" }, { "group": "NPC_mutation_traits" }, { "group": "Appearance_demographics" } ],
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
+      { "skill": "melee", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "cutting", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "bashing", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "stabbing", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 0, 3 ] } },
+      { "skill": "archery", "bonus": { "rng": [ 0, 3 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
     "id": "NC_HUNTER",
     "name": { "str": "Hunter" },
     "job_description": "I'm tracking game.",

--- a/data/json/npcs/npc.json
+++ b/data/json/npcs/npc.json
@@ -125,7 +125,7 @@
   },
   {
     "type": "npc",
-    "id": "NPC_wandering_survivor",
+    "id": "NPC_wandering_scavenger",
     "name_suffix": "wandering survivor",
     "//": "spawns in the res_lawn_randomnpc nested mapgen",
     "class": "NC_WANDERING_SCAVENGER",

--- a/data/json/npcs/npc.json
+++ b/data/json/npcs/npc.json
@@ -122,5 +122,15 @@
     "mission_offered": "MISSION_JOIN_TRACKER",
     "chat": "TALK_STRANGER_FRIENDLY",
     "faction": "no_faction"
+  },
+  {
+    "type": "npc",
+    "id": "NPC_wandering_survivor",
+    "name_suffix": "wandering survivor",
+    "class": "NC_WANDERING_SCAVENGER",
+    "attitude": 1,
+    "mission": 7,
+    "chat": "TALK_DONE",
+    "faction": "no_faction"
   }
 ]

--- a/data/json/npcs/npc.json
+++ b/data/json/npcs/npc.json
@@ -127,10 +127,11 @@
     "type": "npc",
     "id": "NPC_wandering_survivor",
     "name_suffix": "wandering survivor",
+    "//": "spawns in the res_lawn_randomnpc nested mapgen",
     "class": "NC_WANDERING_SCAVENGER",
-    "attitude": 1,
+    "attitude": 0,
     "mission": 7,
-    "chat": "TALK_DONE",
+    "chat": "TALK_STRANGER_NEUTRAL",
     "faction": "no_faction"
   }
 ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6858,6 +6858,7 @@
           { "item": "fanny" },
           { "item": "grapnel" },
           { "item": "mbag" },
+          { "item": "sunglasses" },
           { "item": "professional_chemical_thrower", "container-item": "back_holster" },
           { "item": "gas_insecticidal" },
           { "item": "mask_gas", "custom-flags": [ "no_auto_equip" ] },


### PR DESCRIPTION
## Purpose of change (The Why)
The camper NPC that spawns in the middle of the city makes absolutely zero sense.
## Describe the solution (The How)
Replace it with a more fitting NPC and adds a rooftop variant.

Adds sunglasses to the exterminator profession, to better match the intended look.
## Describe alternatives you've considered
Making the NPC use a more toned down NPC_mutation trait group? I imagine most of the time this NPC is going to die anyways, considering they're spawning on a lawn in the city.
## Testing
Teleported around a bit, it was still hard to find (I couldn't in my testing). Spawned it in using debug, NPC spawned as expected.
## Additional context
Various NPCs spawned using this nested mapgen. It would be nice to gate this after a certain time period, but the rarity should be enough.

<img width="344" height="301" alt="image" src="https://github.com/user-attachments/assets/6a64b8d9-6723-469d-b73a-d50e7b93dc98" />

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
