### PR TITLE
refactor: use `contains` and `empty`

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2836,7 +2836,7 @@ void activity_handlers::mend_item_finish( player_activity *act, player *p )
 
     // iterate over attachments and apply the same changes if they have the same fault
     for( const auto &mod : target->gunmods() ) {
-        if( mod->faults.find( fault_id( act->name ) ) == mod->faults.end() ) {
+        if( !mod->faults.contains( fault_id( act->name ) ) ) {
             continue;
         }
         mend( mod );
@@ -4332,7 +4332,7 @@ void activity_handlers::tree_communion_do_turn( player_activity *act, player *p 
             return;
         }
         for( const tripoint_abs_omt &neighbor : points_in_radius( tpt, 1 ) ) {
-            if( seen.find( neighbor ) != seen.end() ) {
+            if( seen.contains( neighbor ) ) {
                 continue;
             }
             seen.insert( neighbor );

--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -139,7 +139,7 @@ void activity_type::load( const JsonObject &jo )
         }
     }
 
-    if( activity_type_all.find( result.id_ ) != activity_type_all.end() ) {
+    if( activity_type_all.contains( result.id_ ) ) {
         debugmsg( "Redefinition of %s", result.id_.c_str() );
     } else {
         activity_type_all.insert( { result.id_, result } );
@@ -152,10 +152,8 @@ void activity_type::check_consistency()
         if( pair.second.verb_.empty() ) {
             debugmsg( "%s doesn't have a verb", pair.first.c_str() );
         }
-        const bool has_actor = activity_actors::deserialize_functions.find( pair.second.id_ ) !=
-                               activity_actors::deserialize_functions.end();
-        const bool has_turn_func = activity_handlers::do_turn_functions.find( pair.second.id_ ) !=
-                                   activity_handlers::do_turn_functions.end();
+        const bool has_actor = activity_actors::deserialize_functions.contains( pair.second.id_ );
+        const bool has_turn_func = activity_handlers::do_turn_functions.contains( pair.second.id_ );
 
         if( pair.second.special_ && !( has_turn_func || has_actor ) ) {
             debugmsg( "%s needs a do_turn function or activity actor if it expects a special behaviour.",
@@ -173,14 +171,14 @@ void activity_type::check_consistency()
     }
 
     for( const auto &pair : activity_handlers::do_turn_functions ) {
-        if( activity_type_all.find( pair.first ) == activity_type_all.end() ) {
+        if( !activity_type_all.contains( pair.first ) ) {
             debugmsg( "The do_turn function %s doesn't correspond to a valid activity_type.",
                       pair.first.c_str() );
         }
     }
 
     for( const auto &pair : activity_handlers::finish_functions ) {
-        if( activity_type_all.find( pair.first ) == activity_type_all.end() ) {
+        if( !activity_type_all.contains( pair.first ) ) {
             debugmsg( "The finish_function %s doesn't correspond to a valid activity_type",
                       pair.first.c_str() );
         }

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -70,7 +70,7 @@ bool advanced_inventory_pane::is_filtered( const item &it ) const
     }
 
     const std::string str = it.tname();
-    if( filtercache.find( str ) == filtercache.end() ) {
+    if( !filtercache.contains( str ) ) {
         const auto filter_fn = item_filter_from_string( filter );
         filtercache[str] = filter_fn;
 

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -633,7 +633,7 @@ bool avatar::read( item *loc, const bool continuous )
                        elem.first->getID().get_value() ) != 0;
     } ) ||
     !std::all_of( activity->values.begin(), activity->values.end(), [&]( int elem ) {
-        return learners.find( g->find_npc( character_id( elem ) ) ) != learners.end();
+        return learners.contains( g->find_npc( character_id( elem ) ) );
     } ) ) {
 
         if( learners.size() == 1 ) {

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -500,8 +500,7 @@ bool gunmod_remove( avatar &you, item &gun, item &mod )
                 if( the_mod->type->gunmod->location == slot.first && free_slots < 0 ) {
                     gunmod_remove( you, gun, *the_mod );
                     free_slots++;
-                } else if( mod_locations.find( the_mod->type->gunmod->location ) ==
-                           mod_locations.end() ) {
+                } else if( !mod_locations.contains( the_mod->type->gunmod->location ) ) {
                     gunmod_remove( you, gun, *the_mod );
                 }
             }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2280,7 +2280,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
             break;
         case C_MONSTER:
             // FIXME: add persistent id to Creature type, instead of using monster pointer address
-            if( monster_override.find( pos ) == monster_override.end() ) {
+            if( !monster_override.contains( pos ) ) {
                 seed = reinterpret_cast<uintptr_t>( g->critter_at<monster>( pos ) );
             }
             break;
@@ -2664,7 +2664,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
         for( point dir : neighborhood ) {
-            if( terrain_override.find( p + dir ) != terrain_override.end() ) {
+            if( terrain_override.contains( p + dir ) ) {
                 neighborhood_overridden = true;
                 break;
             }
@@ -2836,7 +2836,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
         for( point dir : neighborhood ) {
-            if( furniture_override.find( p + dir ) != furniture_override.end() ) {
+            if( furniture_override.contains( p + dir ) ) {
                 neighborhood_overridden = true;
                 break;
             }
@@ -2925,7 +2925,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
         for( point dir : neighborhood ) {
-            if( trap_override.find( p + dir ) != trap_override.end() ) {
+            if( trap_override.contains( p + dir ) ) {
                 neighborhood_overridden = true;
                 break;
             }
@@ -3296,7 +3296,7 @@ bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_
 {
     map &here = get_map();
     if( tileset_ptr->find_tile_type( ZOMBIE_REVIVAL_INDICATOR ) && !invisible[0] &&
-        item_override.find( pos ) == item_override.end() && here.could_see_items( pos, g->u ) ) {
+        !item_override.contains( pos ) && here.could_see_items( pos, g->u ) ) {
         for( auto &i : here.i_at( pos ) ) {
             if( i->is_corpse() ) {
                 if( i->can_revive() || ( i->get_mtype()->zombify_into && !i->has_flag( flag_PULPED ) ) ) {
@@ -3587,16 +3587,16 @@ void cata_tiles::void_monster_override()
 }
 bool cata_tiles::has_draw_override( const tripoint &p ) const
 {
-    return radiation_override.find( p ) != radiation_override.end() ||
-           terrain_override.find( p ) != terrain_override.end() ||
-           furniture_override.find( p ) != furniture_override.end() ||
-           graffiti_override.find( p ) != graffiti_override.end() ||
-           trap_override.find( p ) != trap_override.end() ||
-           field_override.find( p ) != field_override.end() ||
-           item_override.find( p ) != item_override.end() ||
-           vpart_override.find( p ) != vpart_override.end() ||
-           draw_below_override.find( p ) != draw_below_override.end() ||
-           monster_override.find( p ) != monster_override.end();
+    return radiation_override.contains( p ) ||
+           terrain_override.contains( p ) ||
+           furniture_override.contains( p ) ||
+           graffiti_override.contains( p ) ||
+           trap_override.contains( p ) ||
+           field_override.contains( p ) ||
+           item_override.contains( p ) ||
+           vpart_override.contains( p ) ||
+           draw_below_override.contains( p ) ||
+           monster_override.contains( p );
 }
 /* -- Animation Renders */
 void cata_tiles::draw_explosion_frame()
@@ -3865,7 +3865,7 @@ void cata_tiles::get_terrain_orientation( const tripoint &p, int &rota, int &sub
         const std::map<tripoint, ter_id> &ter_override, const bool ( &invisible )[5] )
 {
     map &here = get_map();
-    const bool overridden = ter_override.find( p ) != ter_override.end();
+    const bool overridden = ter_override.contains( p );
     const auto ter = [&]( const tripoint & q, const bool invis ) -> ter_id {
         const auto override = ter_override.find( q );
         return override != ter_override.end() ? override->second :

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5013,7 +5013,7 @@ void Character::on_damage_of_type( int adjusted_damage, damage_type type, const 
                 continue;
             }
             const std::map<bodypart_str_id, int> &bodyparts = info.occupied_bodyparts;
-            if( bodyparts.find( bp.id() ) != bodyparts.end() ) {
+            if( bodyparts.contains( bp.id() ) ) {
                 const int bp_hp = get_part_hp_cur( bp );
                 // The chance to incapacitate is as high as 50% if the attack deals damage equal to one third of the body part's current health.
                 if( x_in_y( adjusted_damage * 3, bp_hp ) && one_in( 2 ) ) {

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -284,7 +284,7 @@ void Character::process_turn()
         !has_effect( effect_sleep ) && !has_effect( effect_narcosis ) ) {
         const tripoint_abs_omt ompos = global_omt_location();
         const point_abs_omt pos = ompos.xy();
-        if( overmap_time.find( pos ) == overmap_time.end() ) {
+        if( !overmap_time.contains( pos ) ) {
             overmap_time[pos] = 1_turns;
         } else {
             overmap_time[pos] += 1_turns;

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -201,7 +201,7 @@ construction_id blueprint_options::get_final_construction(
     }
 
     for( const construction_id &c_id : list_constructions ) {
-        if( c_id == id || skip_index.find( c_id ) != skip_index.end() ) {
+        if( c_id == id || skip_index.contains( c_id ) ) {
             continue;
         }
         const construction &c = *c_id;
@@ -674,7 +674,7 @@ bool zone_manager::has( const zone_type_id &type, const tripoint &where,
 {
     const auto &point_set = get_point_set( type, fac );
     const auto &vzone_set = get_vzone_set( type, fac );
-    return point_set.find( where ) != point_set.end() || vzone_set.find( where ) != vzone_set.end();
+    return point_set.contains( where ) || vzone_set.contains( where );
 }
 
 bool zone_manager::has_near( const zone_type_id &type, const tripoint &where, int range,

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1071,7 +1071,7 @@ void place_construction( const construction_group_str_id &group )
     }
     const tripoint pnt = *pnt_;
 
-    if( valid.find( pnt ) == valid.end() ) {
+    if( !valid.contains( pnt ) ) {
         cons.front()->explain_failure( pnt );
         return;
     }

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -703,7 +703,7 @@ const recipe *select_crafting_recipe( int &batch_size_out )
                 if( !show_hidden ) {
                     current.clear();
                     for( auto i : picking ) {
-                        if( uistate.hidden_recipes.find( i->ident() ) == uistate.hidden_recipes.end() ) {
+                        if( !uistate.hidden_recipes.contains( i->ident() ) ) {
                             current.push_back( i );
                         }
                     }
@@ -903,7 +903,7 @@ const recipe *select_crafting_recipe( int &batch_size_out )
                 popup( _( "Nothing selected!  Press [<color_yellow>ESC</color>]!" ) );
                 continue;
             }
-            if( uistate.favorite_recipes.find( current[line]->ident() ) != uistate.favorite_recipes.end() ) {
+            if( uistate.favorite_recipes.contains( current[line]->ident() ) ) {
                 uistate.favorite_recipes.erase( current[line]->ident() );
             } else {
                 uistate.favorite_recipes.insert( current[line]->ident() );

--- a/src/dependency_tree.cpp
+++ b/src/dependency_tree.cpp
@@ -110,7 +110,7 @@ void dependency_node::inherit_errors()
                 }
             }
         }
-        if( nodes_visited.find( check->key ) != nodes_visited.end() ) {
+        if( nodes_visited.contains( check->key ) ) {
             continue;
         }
         // add check parents, if exist, to stack
@@ -156,7 +156,7 @@ std::vector<dependency_node *> dependency_node::get_dependencies_as_nodes() cons
         nodes_to_check.pop();
 
         // make sure that the one we are checking is not THIS one
-        if( found.find( check->key ) != found.end() ) {
+        if( found.contains( check->key ) ) {
             continue; // just keep going, we aren't really caring about availability right now
         }
 
@@ -216,7 +216,7 @@ std::vector<dependency_node *> dependency_node::get_dependents_as_nodes() const
         dependency_node *check = nodes_to_check.top();
         nodes_to_check.pop();
 
-        if( found.find( check->key ) != found.end() ) {
+        if( found.contains( check->key ) ) {
             // skip it because we recursed for some reason
             continue;
         }
@@ -256,7 +256,7 @@ void dependency_tree::build_node_map(
 {
     for( auto &elem : key_dependency_map ) {
         // check to see if the master node map knows the key
-        if( master_node_map.find( elem.first ) == master_node_map.end() ) {
+        if( !master_node_map.contains( elem.first ) ) {
             master_node_map.emplace( elem.first, elem.first );
         }
     }

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -99,7 +99,7 @@ void diary::spell_changes()
         if( !curr_page->known_spells.empty() ) {
             bool flag = true;
             for( const std::pair<const string_id<spell_type>, int> &elem : curr_page->known_spells ) {
-                if( prev_page->known_spells.find( elem.first ) != prev_page->known_spells.end() ) {
+                if( prev_page->known_spells.contains( elem.first ) ) {
                     const int prev_lvl = prev_page->known_spells[elem.first];
                     if( elem.second != prev_lvl ) {
                         if( flag ) {
@@ -408,7 +408,7 @@ void diary::skill_changes()
 
         bool flag = true;
         for( const std::pair<const string_id<Skill>, int> &elem : curr_page->skill_levels ) {
-            if( prev_page->skill_levels.find( elem.first ) != prev_page->skill_levels.end() ) {
+            if( prev_page->skill_levels.contains( elem.first ) ) {
                 if( prev_page->skill_levels[elem.first] != elem.second ) {
                     if( flag ) {
                         add_to_change_list( _( "Skills:" ) );

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -145,7 +145,7 @@ void distraction_manager_gui::show()
         calcStartPos( startPosition, currentLine, iContentHeight, num_distractions );
 
         for( int i = startPosition; i < num_distractions; ++i ) {
-            if( distractions.find( distractions_status[i] ) == distractions.end() ) {
+            if( !distractions.contains( distractions_status[i] ) ) {
                 debugmsg( "Distraction not valid for Distraction Manager" );
                 continue;
             }

--- a/src/distribution_grid.cpp
+++ b/src/distribution_grid.cpp
@@ -239,7 +239,7 @@ void distribution_grid_tracker::on_saved()
         }
     }
     for( const tripoint_abs_sm &sm_pos : bounds_range ) {
-        if( parent_distribution_grids.find( sm_pos ) == parent_distribution_grids.end() ) {
+        if( !parent_distribution_grids.contains( sm_pos ) ) {
             make_distribution_grid_at( sm_pos );
         }
     }

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -227,7 +227,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
         std::back_inserter( sk ), [&dict]( const Skill & s ) {
             return std::any_of( dict.begin(), dict.end(), [&s]( const recipe * r ) {
                 return r->skill_used == s.ident() ||
-                       r->required_skills.find( s.ident() ) != r->required_skills.end();
+                       r->required_skills.contains( s.ident() );
             } );
         } );
 

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -507,7 +507,7 @@ struct event_transformation_impl : public event_transformation::impl {
         }
 
         for( const std::string &drop_field_name : drop_fields_ ) {
-            if( input_fields.find( drop_field_name ) == input_fields.end() ) {
+            if( !input_fields.contains( drop_field_name ) ) {
                 debugmsg( "event_transformation %s lists field %s to be dropped, but no field "
                           "with that name exists in the input", name, drop_field_name );
             }

--- a/src/examine_item_menu.cpp
+++ b/src/examine_item_menu.cpp
@@ -237,7 +237,7 @@ bool run(
         } );
     }
 
-    if( get_option<std::string>( "HHG_URL" ).length() > 0 ) {
+    if( !get_option<std::string>( "HHG_URL" ).empty() ) {
         add_entry( "OPEN_ITEM_IN_HHG", hint_rating::good, [&]() {
             open_url( get_option<std::string>( "HHG_URL" ) + std::string( "/item/" ) + itm.typeId().c_str() +
                       std::string( "?t=UNDEAD_PEOPLE" ) );

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -1473,8 +1473,8 @@ void explosion_funcs::regular( const queued_explosion &qe )
     const std::function<bool( const Creature & )> &predicate ) {
         if( predicate( *pr.first ) && g->u.sees( *pr.first ) ) {
             const Creature *critter = pr.first;
-            bool blasted = damaged_by_blast.find( critter ) != damaged_by_blast.end();
-            bool shredded = damaged_by_shrapnel.find( critter ) != damaged_by_shrapnel.end();
+            bool blasted = damaged_by_blast.contains( critter );
+            bool shredded = damaged_by_shrapnel.contains( critter );
             std::string cause_description = ( blasted && shredded ) ? _( "the explosion and shrapnel" ) :
                                             blasted ? _( "the explosion" ) :
                                             _( "the shrapnel" );

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -433,7 +433,7 @@ faction *faction_manager::get( const faction_id &id, const bool complain )
                         elem.second.mon_faction = fac_temp.mon_faction;
                         elem.second.epilogue_data = fac_temp.epilogue_data;
                         for( const auto &rel_data : fac_temp.relations ) {
-                            if( elem.second.relations.find( rel_data.first ) == elem.second.relations.end() ) {
+                            if( !elem.second.relations.contains( rel_data.first ) ) {
                                 elem.second.relations[rel_data.first] = rel_data.second;
                             }
                         }

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -70,7 +70,7 @@ void fault::load_fault( const JsonObject &jo )
 
     optional( jo, false, "flags", f.flags );
 
-    if( faults_all.find( f.id_ ) != faults_all.end() ) {
+    if( faults_all.contains( f.id_ ) ) {
         jo.throw_error( "parsed fault overwrites existing definition", "id" );
     } else {
         faults_all[f.id_] = f;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3766,7 +3766,7 @@ std::unordered_set<tripoint> game::get_fishable_locations( int distance, const t
             to_check.pop();
 
             // We've been here before, so bail.
-            if( visited.find( current_point ) != visited.end() ) {
+            if( visited.contains( current_point ) ) {
                 continue;
             }
 
@@ -3807,7 +3807,7 @@ std::vector<monster *> game::get_fishable_monsters( std::unordered_set<tripoint>
         if( critter.has_flag( MF_FISHABLE ) ) {
             const tripoint critter_pos = critter.pos();
             // ...and it is in a fishable location.
-            if( fishable_locations.find( critter_pos ) != fishable_locations.end() ) {
+            if( fishable_locations.contains( critter_pos ) ) {
                 unique_fish.push_back( &critter );
             }
         }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2400,7 +2400,7 @@ bool game::handle_action()
                 break;
 
             case ACTION_OPEN_WIKI:
-                if( get_option<std::string>( "WIKI_DOC_URL" ).length() > 0 ) {
+                if( !get_option<std::string>( "WIKI_DOC_URL" ).empty() ) {
                     open_url( get_option<std::string>( "WIKI_DOC_URL" ) );
                 } else {
                     add_msg( m_bad, _( "Invalid Wiki URL specified!" ) );
@@ -2410,7 +2410,7 @@ bool game::handle_action()
                 break;
 
             case ACTION_OPEN_HHG:
-                if( get_option<std::string>( "HHG_URL" ).length() > 0 ) {
+                if( !get_option<std::string>( "HHG_URL" ).empty() ) {
                     open_url( get_option<std::string>( "HHG_URL" ) + std::string( "/?t=UNDEAD_PEOPLE" ) );
                 } else {
                     add_msg( m_bad, _( "Invalid Hitchhiker's Guide URL specified!" ) );

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -561,7 +561,7 @@ input_manager::t_input_event_list &input_manager::get_or_create_event_list(
 
     // A new action is created in the event that the user creates a local
     // keymapping that masks a global one.
-    if( actions.find( action_descriptor ) == actions.end() ) {
+    if( !actions.contains( action_descriptor ) ) {
         action_attributes &attributes = actions[action_descriptor];
         attributes.name = get_default_action_name( action_descriptor );
         attributes.is_user_created = true;

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1097,7 +1097,7 @@ int inventory::count_item( const itype_id &item_type ) const
 {
     int num = 0;
     const itype_bin bin = get_binned_items();
-    if( bin.find( item_type ) == bin.end() ) {
+    if( !bin.contains( item_type ) ) {
         return num;
     }
     const std::list<const item *> items = get_binned_items().find( item_type )->second;
@@ -1186,7 +1186,7 @@ void inventory::reassign_item( item &it, char invlet, bool remove_old )
 void inventory::update_invlet( item &newit, bool assign_invlet )
 {
     // Avoid letters that have been manually assigned to other things.
-    if( newit.invlet && assigned_invlet.find( newit.invlet ) != assigned_invlet.end() &&
+    if( newit.invlet && assigned_invlet.contains( newit.invlet ) &&
         assigned_invlet[newit.invlet] != newit.typeId() ) {
         newit.invlet = '\0';
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4872,7 +4872,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     }
 
     std::string maintext;
-    if( is_corpse() || item_vars.find( "name" ) != item_vars.end() ) {
+    if( is_corpse() || item_vars.contains( "name" ) ) {
         maintext = type_name( quantity );
     } else if( is_craft() ) {
         maintext = string_format( _( "in progress %s" ), craft_data_->making->result_name() );
@@ -5058,7 +5058,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         ret = utf8_truncate( ret, truncate + truncate_override );
     }
 
-    if( item_vars.find( "item_note" ) != item_vars.end() ) {
+    if( item_vars.contains( "item_note" ) ) {
         //~ %s is an item name. This style is used to denote items with notes.
         return string_format( _( "*%s*" ), ret );
     } else {
@@ -5867,7 +5867,7 @@ const item::FlagsSetType &item::get_flags() const
 
 bool item::has_property( const std::string &prop ) const
 {
-    return type->properties.find( prop ) != type->properties.end();
+    return type->properties.contains( prop );
 }
 
 std::string item::get_property_string( const std::string &prop, const std::string &def ) const
@@ -7542,7 +7542,7 @@ bool item::is_tool() const
 
 bool item::is_transformable() const
 {
-    return type->use_methods.find( "transform" ) != type->use_methods.end();
+    return type->use_methods.contains( "transform" );
 }
 
 bool item::is_artifact() const

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -187,7 +187,7 @@ std::string item_action_generator::get_action_name( const item_action_id &id ) c
 
 bool item_action_generator::action_exists( const item_action_id &id ) const
 {
-    return item_actions.find( id ) != item_actions.end();
+    return item_actions.contains( id );
 }
 
 const item_action &item_action_generator::get_action( const item_action_id &id ) const
@@ -264,7 +264,7 @@ void game::item_action_menu()
     int num = 0;
 
     const auto assigned_action = [&iactions]( const item_action_id & action ) {
-        return iactions.find( action ) != iactions.end();
+        return iactions.contains( action );
     };
 
     std::vector<std::tuple<item_action_id, std::string, std::string>> menu_items;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -600,7 +600,7 @@ void Item_factory::finalize_pre( itype &obj )
 
         auto set_resist = [&obj]( damage_type dt,
         std::function<int( const material_type & )> resist_getter ) {
-            if( obj.armor->resistance.flat.find( dt ) != obj.armor->resistance.flat.end() ) {
+            if( obj.armor->resistance.flat.contains( dt ) ) {
                 return;
             }
             float resist = 0.0f;
@@ -757,7 +757,7 @@ void Item_factory::finalize_item_blacklist()
     }
 
     for( const std::pair<const itype_id, migration> &migrate : migrations ) {
-        if( m_templates.find( migrate.second.replace ) == m_templates.end() ) {
+        if( !m_templates.contains( migrate.second.replace ) ) {
             debugmsg( "Replacement item for migration %s does not exist", migrate.first.c_str() );
             continue;
         }
@@ -1402,7 +1402,7 @@ void Item_factory::check_definitions() const
                                                  ? type->mod->magazine_adaptor
                                                  : target->magazines;
                     for( const ammotype &ammo : acceptable_ammo ) {
-                        if( acceptable_magazines.find( ammo ) == acceptable_magazines.end() ) {
+                        if( !acceptable_magazines.contains( ammo ) ) {
                             msg += string_format( "gunmod can be applied to %s, which has no magazines for ammo %s\n",
                                                   t.c_str(), ammo.str() );
                         }
@@ -2684,7 +2684,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         "TOOL_ARMOR",
         "WHEEL",
     };
-    if( needs_plural.find( jo.get_string( "type" ) ) != needs_plural.end() ) {
+    if( needs_plural.contains( jo.get_string( "type" ) ) ) {
         def.name = translation( translation::plural_tag() );
     } else {
         def.name = translation();
@@ -3493,7 +3493,7 @@ std::vector<item_group_id> Item_factory::get_all_group_names()
 bool Item_factory::add_item_to_group( const item_group_id &group_id, const itype_id &item_id,
                                       int chance )
 {
-    if( m_template_groups.find( group_id ) == m_template_groups.end() ) {
+    if( !m_template_groups.contains( group_id ) ) {
         return false;
     }
     Item_spawn_data &group_to_access = *m_template_groups[group_id];

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1450,7 +1450,7 @@ int iuse::petfood( player *p, item *it, bool, const tripoint & )
         const std::set<std::string> &itemfood = it->get_comestible()->petfood;
         if( !petfood.food.empty() ) {
             for( const std::string &food : petfood.food ) {
-                if( itemfood.find( food ) != itemfood.end() ) {
+                if( itemfood.contains( food ) ) {
                     can_feed = true;
                     break;
                 }
@@ -4401,7 +4401,7 @@ int iuse::chop_logs( player *p, item *it, bool t, const tripoint & )
     };
     const std::function<bool( const tripoint & )> f = [&allowed_ter_id]( const tripoint & pnt ) {
         const ter_id type = g->m.ter( pnt );
-        const bool is_allowed_terrain = allowed_ter_id.find( type ) != allowed_ter_id.end();
+        const bool is_allowed_terrain = allowed_ter_id.contains( type );
         return is_allowed_terrain;
     };
 
@@ -6423,7 +6423,7 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
     for( const tripoint &point_around_figure : points_in_radius ) {
         if( !bounds.is_point_inside( point_around_figure ) ||
             !g->m.sees( camera_pos, point_around_figure, dist + radius ) ||
-            ( ignored_points.find( point_around_figure ) != ignored_points.end() &&
+            ( ignored_points.contains( point_around_figure ) &&
               !( point_around_figure == point && create_figure_desc ) ) ) {
             continue; // disallow photos with not visible objects
         }
@@ -6456,7 +6456,7 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
             const std::string veh_name = colorize( veh.disp_name(), c_light_blue );
             const vehicle *veh_hash = &veh_part_pos->vehicle();
 
-            if( local_vehicles_recorded.find( veh_hash ) == local_vehicles_recorded.end() &&
+            if( !local_vehicles_recorded.contains( veh_hash ) &&
                 point != point_around_figure ) {
                 // new vehicle, point is not center
                 ret_obj.vehicles[ veh_name ] ++;
@@ -6465,8 +6465,8 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
                 //~ %1$s: vehicle part name, %2$s: vehicle name
                 description_part_on_figure = string_format( pgettext( "vehicle part", "%1$s from %2$s" ),
                                              veh_part_pos.part_displayed()->part().name(), veh_name );
-                if( ret_obj.vehicles.find( veh_name ) != ret_obj.vehicles.end() &&
-                    local_vehicles_recorded.find( veh_hash ) != local_vehicles_recorded.end() ) {
+                if( ret_obj.vehicles.contains( veh_name ) &&
+                    local_vehicles_recorded.contains( veh_hash ) ) {
                     // remove vehicle name only if we previously added THIS vehicle name (in case of same name)
                     ret_obj.vehicles[ veh_name ] --;
                     if( ret_obj.vehicles[ veh_name ] <= 0 ) {
@@ -6568,7 +6568,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
 
     const auto map_deincrement_or_erase = []( std::unordered_map<std::string, int> &obj_map,
     const std::string & key ) {
-        if( obj_map.find( key ) != obj_map.end() ) {
+        if( obj_map.contains( key ) ) {
             obj_map[ key ] --;
             if( obj_map[ key ] <= 0 ) {
                 obj_map.erase( key );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -905,7 +905,7 @@ int consume_drug_iuse::use( player &p, item &it, bool, const tripoint & ) const
     }
 
     // this is a smokeable item, we need to make sure player isnt already smoking (ripped from iuse::smoking)
-    if( lit_item.size() != 0 ) {
+    if( !lit_item.empty() ) {
         // make sure we're not already smoking something
         auto cigs = p.items_with( []( const item & it ) {
             return it.is_active() && it.has_flag( flag_LITCIG );
@@ -936,7 +936,7 @@ int consume_drug_iuse::use( player &p, item &it, bool, const tripoint & ) const
     }
 
     // item used to "fake" addiction (ripped from old ecig iuse)
-    if( fake_item.size() != 0 ) {
+    if( !fake_item.empty() ) {
         item *dummy_item = item::spawn_temporary( fake_item, calendar::turn );
         p.consume_effects( *dummy_item );
     }
@@ -1003,7 +1003,7 @@ int consume_drug_iuse::use( player &p, item &it, bool, const tripoint & ) const
                        p.vitamin_rate( v.first ) <= 0_turns );
     }
 
-    if( snippet_category != "" ) {
+    if( !snippet_category.empty() ) {
         std::string snippet_string = "";
         snippet_string = SNIPPET.random_from_category( snippet_category ).value_or(
                              translation() ).translated();

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1177,7 +1177,7 @@ bool spell::target_by_monster_id( const tripoint &p ) const
     }
     bool valid = false;
     if( monster *const target = g->critter_at<monster>( p ) ) {
-        if( type->targeted_monster_ids.find( target->type->id ) != type->targeted_monster_ids.end() ) {
+        if( type->targeted_monster_ids.contains( target->type->id ) ) {
             valid = true;
         }
     }

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -126,7 +126,7 @@ void teleporter_list::translocate( const std::set<tripoint> &targets )
 
 bool teleporter_list::knows_translocator( const tripoint_abs_omt &omt_pos ) const
 {
-    return known_teleporters.find( omt_pos ) != known_teleporters.end();
+    return known_teleporters.contains( omt_pos );
 }
 
 void teleporter_list::serialize( JsonOut &json ) const

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1636,7 +1636,7 @@ uint8_t map::get_known_connections( const tripoint &p, int connect_group,
     }
 #endif
 
-    const bool overridden = override.find( p ) != override.end();
+    const bool overridden = override.contains( p );
     const bool is_transparent = ch.transparency_cache[p.x][p.y] > LIGHT_TRANSPARENCY_SOLID;
 
     // populate connection information
@@ -1687,7 +1687,7 @@ uint8_t map::get_known_connections_f( const tripoint &p, int connect_group,
     }
 #endif
 
-    const bool overridden = override.find( p ) != override.end();
+    const bool overridden = override.contains( p );
     const bool is_transparent = ch.transparency_cache[p.x][p.y] > LIGHT_TRANSPARENCY_SOLID;
 
     // populate connection information
@@ -7304,7 +7304,7 @@ void map::loadn( const tripoint &grid, const bool update_vehicles )
         auto &map_cache = get_cache( grid.z );
         for( const auto &veh : tmpsub->vehicles ) {
             // Only add if not tracking already.
-            if( map_cache.vehicle_list.find( veh.get() ) == map_cache.vehicle_list.end() ) {
+            if( !map_cache.vehicle_list.contains( veh.get() ) ) {
                 map_cache.vehicle_list.insert( veh.get() );
                 if( !veh->loot_zones.empty() ) {
                     map_cache.zone_vehicles.insert( veh.get() );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1410,7 +1410,7 @@ auto mapgen_parameters::add_unique_parameter(
     std::string candidate_name;
     while( true ) {
         candidate_name = string_format( "%s%d", prefix, i );
-        if( map.find( candidate_name ) == map.end() ) {
+        if( !map.contains( candidate_name ) ) {
             break;
         }
         ++i;
@@ -3154,7 +3154,7 @@ const mapgen_palette &string_id<mapgen_palette>::obj() const
 template<>
 bool string_id<mapgen_palette>::is_valid() const
 {
-    return palettes.find( *this ) != palettes.end();
+    return palettes.contains( *this );
 }
 
 void mapgen_palette::check()
@@ -7509,7 +7509,7 @@ namespace mapgen
 
 bool has_update_id( const mapgen_id &id )
 {
-    return update_mapgen.find( id ) != update_mapgen.end();
+    return update_mapgen.contains( id );
 }
 
 } // namespace mapgen

--- a/src/mapsharing.cpp
+++ b/src/mapsharing.cpp
@@ -48,7 +48,7 @@ bool MAP_SHARING::isWorldmenu()
 
 bool MAP_SHARING::isAdmin()
 {
-    return admins.find( getUsername() ) != admins.end();
+    return admins.contains( getUsername() );
 }
 
 void MAP_SHARING::setAdmins( const std::set<std::string> &names )
@@ -64,7 +64,7 @@ void MAP_SHARING::addAdmin( const std::string &name )
 
 bool MAP_SHARING::isDebugger()
 {
-    return debuggers.find( getUsername() ) != debuggers.end();
+    return debuggers.contains( getUsername() );
 }
 
 void MAP_SHARING::setDebuggers( const std::set<std::string> &names )

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -147,7 +147,7 @@ item &Character::used_weapon() const
 
 item &Character::primary_weapon() const
 {
-    if( get_body().find( body_part_arm_r ) == get_body().end() ) {
+    if( !get_body().contains( body_part_arm_r ) ) {
         return null_item_reference();
     }
     return *get_part( body_part_arm_r ).wielding.wielded;
@@ -155,7 +155,7 @@ item &Character::primary_weapon() const
 
 std::vector<item *> Character::wielded_items() const
 {
-    if( get_body().find( body_part_arm_r ) == get_body().end() ) {
+    if( !get_body().contains( body_part_arm_r ) ) {
         return {};
     }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1332,7 +1332,7 @@ tripoint monster::scent_move()
         bool right_scent = false;
         // is the monster tracking this scent
         if( !tracked_scents.empty() ) {
-            right_scent = tracked_scents.find( type_scent ) != tracked_scents.end();
+            right_scent = tracked_scents.contains( type_scent );
         }
         //is this scent recognised by the monster species
         if( !type_scent.is_empty() ) {
@@ -1346,7 +1346,7 @@ tripoint monster::scent_move()
             }
         }
         // is the monster actually ignoring this scent
-        if( !ignored_scents.empty() && ( ignored_scents.find( type_scent ) != ignored_scents.end() ) ) {
+        if( !ignored_scents.empty() && ( ignored_scents.contains( type_scent ) ) ) {
             right_scent = false;
         }
 

--- a/src/mtype.cpp
+++ b/src/mtype.cpp
@@ -73,7 +73,7 @@ std::string mtype::nname( unsigned int quantity ) const
 
 bool mtype::has_special_attack( const std::string &attack_name ) const
 {
-    return special_attacks.find( attack_name ) != special_attacks.end();
+    return special_attacks.contains( attack_name );
 }
 
 bool mtype::has_flag( m_flag flag ) const
@@ -120,7 +120,7 @@ bool mtype::has_placate_trigger( mon_trigger trigger ) const
 
 bool mtype::in_category( const std::string &category ) const
 {
-    return categories.find( category ) != categories.end();
+    return categories.contains( category );
 }
 
 bool mtype::in_species( const species_id &spec ) const

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -103,7 +103,7 @@ std::string enum_to_string<mutagen_technique>( mutagen_technique data )
 
 bool Character::has_trait( const trait_id &b ) const
 {
-    return my_mutations.count( b ) || enchantment_cache->get_mutations().contains( b );
+    return my_mutations.contains( b ) || enchantment_cache->get_mutations().contains( b );
 }
 
 bool Character::has_one_of_traits( const TraitSet &trait_set ) const
@@ -127,7 +127,7 @@ bool Character::has_trait_flag( const trait_flag_str_id &b ) const
 bool Character::has_base_trait( const trait_id &b ) const
 {
     // Look only at base traits
-    return my_traits.find( b ) != my_traits.end();
+    return my_traits.contains( b );
 }
 
 void Character::toggle_trait( const trait_id &trait_ )

--- a/src/mutation_type.cpp
+++ b/src/mutation_type.cpp
@@ -23,14 +23,14 @@ void reset_mutation_types()
 
 bool mutation_type_exists( const std::string &id )
 {
-    return mutation_types.find( id ) != mutation_types.end();
+    return mutation_types.contains( id );
 }
 
 std::vector<trait_id> get_mutations_in_type( const std::string &id )
 {
     std::vector<trait_id> ret;
     for( const mutation_branch &it : mutation_branch::get_all() ) {
-        if( it.types.find( id ) != it.types.end() ) {
+        if( it.types.contains( id ) ) {
             ret.push_back( it.id );
         }
     }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -418,7 +418,7 @@ void avatar::randomize( const bool random_scenario, points_left &points, bool pl
 void Character::clear_cosmetic_traits( std::string mutation_type, trait_id new_trait )
 {
     for( const mutation_branch &mb : mutation_branch::get_all() ) {
-        if( mb.points == 0 && mb.types.count( mutation_type ) ) {
+        if( mb.points == 0 && mb.types.contains( mutation_type ) ) {
             if( has_trait( mb.id ) && mb.id != new_trait ) {
                 toggle_trait( mb.id );
             }
@@ -440,7 +440,7 @@ void avatar::randomize_cosmetics()
 bool avatar::create( character_type type, const std::string &tempname )
 {
     // TODO: This block should not be needed
-    if( get_body().find( body_part_arm_r ) != get_body().end() ) {
+    if( get_body().contains( body_part_arm_r ) ) {
         remove_primary_weapon();
     }
 
@@ -3123,7 +3123,7 @@ trait_id Character::get_random_trait( const std::function<bool( const mutation_b
 void Character::randomize_cosmetic_trait( std::string mutation_type )
 {
     trait_id trait = get_random_trait( [mutation_type]( const mutation_branch & mb ) {
-        return mb.points == 0 && mb.types.count( mutation_type );
+        return mb.points == 0 && mb.types.contains( mutation_type );
     } );
 
     if( trait.is_valid() ) { // <-- IMPORTANT

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2332,13 +2332,13 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
     bool ceiling_blocking_climb = !here.has_floor_or_support( pos() ) ||
                                   here.has_floor_or_support( p + tripoint_above );
     if( sees_dangerous_field( p )
-        || ( nomove != nullptr && nomove->find( p ) != nomove->end() ) ) {
+        || ( nomove != nullptr && nomove->contains( p ) ) ) {
         // Move to a neighbor field instead, if possible.
         // Maybe this code already exists somewhere?
         auto other_points = here.get_dir_circle( pos(), p );
         for( const tripoint &ot : other_points ) {
             if( could_move_onto( ot )
-                && ( nomove == nullptr || nomove->find( ot ) == nomove->end() ) ) {
+                && ( nomove == nullptr || !nomove->contains( ot ) ) ) {
 
                 p = ot;
                 break;
@@ -2356,7 +2356,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
 
     // nomove is used to resolve recursive invocation, so reset destination no
     // matter it was changed by stunned effect or not.
-    if( nomove != nullptr && nomove->find( p ) != nomove->end() ) {
+    if( nomove != nullptr && nomove->contains( p ) ) {
         p = pos();
     }
 
@@ -2646,7 +2646,7 @@ void npc::move_away_from( const tripoint &pt, bool no_bash_atk, std::set<tripoin
     int chance = 2;
     map &here = get_map();
     for( const tripoint &p : here.points_in_radius( pos(), 1 ) ) {
-        if( nomove != nullptr && nomove->find( p ) != nomove->end() ) {
+        if( nomove != nullptr && nomove->contains( p ) ) {
             continue;
         }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3219,19 +3219,19 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
     catacurses::window w_options;
 
     const auto init_windows = [&]( ui_adaptor & ui ) {
-        if( OPTIONS.find( "TERMINAL_X" ) != OPTIONS.end() ) {
-            if( OPTIONS_OLD.find( "TERMINAL_X" ) != OPTIONS_OLD.end() ) {
+        if( OPTIONS.contains( "TERMINAL_X" ) ) {
+            if( OPTIONS_OLD.contains( "TERMINAL_X" ) ) {
                 OPTIONS_OLD["TERMINAL_X"] = OPTIONS["TERMINAL_X"];
             }
-            if( WOPTIONS_OLD.find( "TERMINAL_X" ) != WOPTIONS_OLD.end() ) {
+            if( WOPTIONS_OLD.contains( "TERMINAL_X" ) ) {
                 WOPTIONS_OLD["TERMINAL_X"] = OPTIONS["TERMINAL_X"];
             }
         }
-        if( OPTIONS.find( "TERMINAL_Y" ) != OPTIONS.end() ) {
-            if( OPTIONS_OLD.find( "TERMINAL_Y" ) != OPTIONS_OLD.end() ) {
+        if( OPTIONS.contains( "TERMINAL_Y" ) ) {
+            if( OPTIONS_OLD.contains( "TERMINAL_Y" ) ) {
                 OPTIONS_OLD["TERMINAL_Y"] = OPTIONS["TERMINAL_Y"];
             }
-            if( WOPTIONS_OLD.find( "TERMINAL_Y" ) != WOPTIONS_OLD.end() ) {
+            if( WOPTIONS_OLD.contains( "TERMINAL_Y" ) ) {
                 WOPTIONS_OLD["TERMINAL_Y"] = OPTIONS["TERMINAL_Y"];
             }
         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -955,7 +955,7 @@ bool oter_t::is_hardcoded() const
         "temple_stairs"
     };
 
-    return hardcoded_mapgen.find( get_mapgen_id() ) != hardcoded_mapgen.end();
+    return hardcoded_mapgen.contains( get_mapgen_id() );
 }
 
 void overmap_terrains::load( const JsonObject &jo, const std::string &src )
@@ -1001,7 +1001,7 @@ void overmap_terrains::finalize()
         const_cast<oter_type_t &>( elem ).finalize(); // This cast is ugly, but safe.
     }
 
-    if( region_settings_map.find( "default" ) == region_settings_map.end() ) {
+    if( !region_settings_map.contains( "default" ) ) {
         debugmsg( "ERROR: can't find default overmap settings (region_map_settings 'default'), "
                   "cataclysm pending.  And not the fun kind." );
     }
@@ -3900,7 +3900,7 @@ void overmap::place_forest_trails()
 
             // If we've already visited this point, we don't need to
             // process it since it's already part of another forest.
-            if( visited.find( seed_point.xy() ) != visited.end() ) {
+            if( visited.contains( seed_point.xy() ) ) {
                 continue;
             }
 
@@ -4100,7 +4100,7 @@ void overmap::place_lakes()
     for( int i = 0; i < OMAPX; i++ ) {
         for( int j = 0; j < OMAPY; j++ ) {
             point_om_omt seed_point( i, j );
-            if( visited.find( seed_point ) != visited.end() ) {
+            if( visited.contains( seed_point ) ) {
                 continue;
             }
 
@@ -4155,7 +4155,7 @@ void overmap::place_lakes()
                 for( int ni = -1; ni <= 1 && !shore; ni++ ) {
                     for( int nj = -1; nj <= 1 && !shore; nj++ ) {
                         const point_om_omt n = p + point( ni, nj );
-                        if( lake_set.find( n ) == lake_set.end() ) {
+                        if( !lake_set.contains( n ) ) {
                             shore = true;
                         }
                     }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -952,8 +952,8 @@ static void draw_ascii( ui_adaptor &ui,
             const bool los = see && player_character.overmap_los( omp, sight_points );
             const bool los_sky = player_character.overmap_los( omp_sky, sight_points * 2 );
 
-            const bool is_npc_path = npc_path_route.find( omp ) != npc_path_route.end();
-            const bool is_player_path = player_path_route.find( omp.xy() ) != player_path_route.end();
+            const bool is_npc_path = npc_path_route.contains( omp );
+            const bool is_player_path = player_path_route.contains( omp.xy() );
             const int player_path_z = is_player_path ? player_path_route[ omp.xy() ] : 0;
 
             if( blink && omp == pl_pos ) {

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -680,7 +680,7 @@ bool player_activity::can_resume_with( const player_activity &other, const Chara
 bool player_activity::is_distraction_ignored( distraction_type type ) const
 {
     return ( get_distraction_manager().is_ignored( type ) ||
-             ignored_distractions.find( type ) != ignored_distractions.end() );
+             ignored_distractions.contains( type ) );
 }
 
 void player_activity::ignore_distraction( distraction_type type )

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -602,7 +602,7 @@ void json_item_substitution::load( const JsonObject &jo )
     const std::string title = jo.get_string( item_mode ? "item" : "trait" );
 
     auto check_duplicate_item = [&]( const itype_id & it ) {
-        return substitutions.find( it ) != substitutions.end() ||
+        return substitutions.contains( it ) ||
                std::ranges::find_if( bonuses,
         [&it]( const std::pair<itype_id, trait_requirements> &p ) {
             return p.first == it;

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -528,7 +528,7 @@ std::string recipe::batch_savings_string() const
 std::string recipe::result_name() const
 {
     std::string name = item::nname( result_ );
-    if( uistate.favorite_recipes.find( this->ident() ) != uistate.favorite_recipes.end() ) {
+    if( uistate.favorite_recipes.contains( this->ident() ) ) {
         name = "* " + name;
     }
 

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -70,7 +70,7 @@ const recipe &string_id<recipe>::obj() const
 template<>
 bool string_id<recipe>::is_valid() const
 {
-    return recipe_dict.recipes.find( *this ) != recipe_dict.recipes.end();
+    return recipe_dict.recipes.contains( *this );
 }
 
 const recipe &recipe_dictionary::get_uncraft( const itype_id &id )
@@ -124,7 +124,7 @@ std::vector<const recipe *> recipe_subset::favorite() const
         if( !*r || r->obsolete ) {
             return false;
         }
-        return uistate.favorite_recipes.find( r->ident() ) != uistate.favorite_recipes.end();
+        return uistate.favorite_recipes.contains( r->ident() );
     } );
 
     return res;
@@ -138,7 +138,7 @@ std::vector<const recipe *> recipe_subset::hidden() const
         if( !*r || r->obsolete ) {
             return false;
         }
-        return uistate.hidden_recipes.find( r->ident() ) != uistate.hidden_recipes.end();
+        return uistate.hidden_recipes.contains( r->ident() );
     } );
 
     return res;
@@ -242,7 +242,7 @@ std::vector<const recipe *> recipe_subset::search_result( const itype_id &item )
             return false;
         }
         return item == r->result() ||
-               ( r->has_byproducts() && r->byproducts.find( item ) != r->byproducts.end() );
+               ( r->has_byproducts() && r->byproducts.contains( item ) );
     } );
 
     return res;

--- a/src/recipe_groups.cpp
+++ b/src/recipe_groups.cpp
@@ -97,7 +97,7 @@ std::map<recipe_id, translation> recipe_group::get_recipes_by_id( const std::str
             if( recp_terrain == group.om_terrains.end() ) {
                 continue;
             }
-            if( recp_terrain->second.find( base_om_ter_id ) != recp_terrain->second.end() ) {
+            if( recp_terrain->second.contains( base_om_ter_id ) ) {
                 all_rec.emplace( recp );
             }
         }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -228,8 +228,7 @@ void player_activity::deserialize( JsonIn &jsin )
         return;
     }
 
-    const bool has_actor = activity_actors::deserialize_functions.find( type ) !=
-                           activity_actors::deserialize_functions.end();
+    const bool has_actor = activity_actors::deserialize_functions.contains( type );
 
     // Handle migration of pre-activity_actor activities
     // ACT_MIGRATION_CANCEL will clear the backlog and reset npc state
@@ -1917,7 +1916,7 @@ void monster::load( const JsonObject &data )
     // make sure the loaded monster has every special attack its type says it should have
     for( auto &sa : type->special_attacks ) {
         const std::string &aname = sa.first;
-        if( special_attacks.find( aname ) == special_attacks.end() ) {
+        if( !special_attacks.contains( aname ) ) {
             auto &entry = special_attacks[aname];
             entry.cooldown = rng( 0, sa.second->cooldown );
         }

--- a/src/simple_pathfinding.cpp
+++ b/src/simple_pathfinding.cpp
@@ -254,7 +254,7 @@ simple_path<tripoint_abs_omt> find_overmap_path( const tripoint_abs_omt &source,
     std::unordered_map<tripoint_abs_omt, navigation_node> &other_known_nodes ) {
         const tripoint_abs_omt cur_addr = open_set.top().addr;
         open_set.pop();
-        if( other_known_nodes.find( cur_addr ) != other_known_nodes.end() ) {
+        if( other_known_nodes.contains( cur_addr ) ) {
             meet = true;
             tripoint_abs_omt addr = cur_addr;
             tripoint_abs_omt other_start = start == source ? dest : source;

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -389,7 +389,7 @@ void submap::update_legacy_computer()
 
 bool submap::has_computer( point p ) const
 {
-    return computers.find( p ) != computers.end() || ( legacy_computer && ter[p.x][p.y] == t_console );
+    return computers.contains( p ) || ( legacy_computer && ter[p.x][p.y] == t_console );
 }
 
 const computer *submap::get_computer( point p ) const

--- a/src/text_snippets.cpp
+++ b/src/text_snippets.cpp
@@ -61,7 +61,7 @@ void snippet_library::add_snippet_from_json( const std::string &category, const 
         if( id.is_null() ) {
             jo.throw_error( "Null snippet id specified", "id" );
         }
-        if( snippets_by_id.find( id ) != snippets_by_id.end() ) {
+        if( snippets_by_id.contains( id ) ) {
             jo.throw_error( "Duplicate snippet id", "id" );
         }
         snippets_by_category[category].ids.emplace_back( id );
@@ -86,7 +86,7 @@ void snippet_library::clear_snippets()
 
 bool snippet_library::has_category( const std::string &category ) const
 {
-    return snippets_by_category.find( category ) != snippets_by_category.end();
+    return snippets_by_category.contains( category );
 }
 
 std::optional<translation> snippet_library::get_snippet_by_id( const snippet_id &id ) const
@@ -119,7 +119,7 @@ const translation &snippet_library::get_snippet_ref_by_id( const snippet_id &id 
 
 bool snippet_library::has_snippet_with_id( const snippet_id &id ) const
 {
-    return snippets_by_id.find( id ) != snippets_by_id.end();
+    return snippets_by_id.contains( id );
 }
 
 std::string snippet_library::expand( const std::string &str ) const

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2317,7 +2317,7 @@ bool vehicle::find_and_split_vehicles( int exclude )
             if( parts[ p ].removed ) {
                 continue;
             }
-            if( checked_parts.find( p ) == checked_parts.end() ) {
+            if( !checked_parts.contains( p ) ) {
                 test_part = p;
                 break;
             }
@@ -2343,7 +2343,7 @@ bool vehicle::find_and_split_vehicles( int exclude )
         while( !search_queue.empty() ) {
             std::pair<int, std::vector<int>> test_set = pop_neighbor();
             test_part = test_set.first;
-            if( checked_parts.find( test_part ) != checked_parts.end() ) {
+            if( checked_parts.contains( test_part ) ) {
                 continue;
             }
             for( auto p : test_set.second ) {
@@ -4086,7 +4086,7 @@ void vehicle::spew_field( double joules, int part, field_type_id type, int inten
     point p = parts[part].mount;
     intensity = std::max( joules / 10000, static_cast<double>( intensity ) );
     // Move back from engine/muffler until we find an open space
-    while( relative_parts.find( p ) != relative_parts.end() ) {
+    while( relative_parts.contains( p ) ) {
         p.x += ( velocity < 0 ? 1 : -1 );
     }
     point q = coord_translate( p );

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -589,7 +589,7 @@ vehicle_profile vehicle::autodrive_controller::compute_profile( orientation faci
         }
         tripoint pos;
         driven_veh.coord_translate( angle, pivot, part.mount, pos );
-        if( extent_map.find( pos.y ) == extent_map.end() ) {
+        if( !extent_map.contains( pos.y ) ) {
             extent_map[pos.y] = { pos.x, pos.x };
         } else {
             auto &extent = extent_map[pos.y];
@@ -617,7 +617,7 @@ vehicle_profile vehicle::autodrive_controller::compute_profile( orientation faci
     // we need to check for collision when the vehicle is moving in this direction
     const std::unordered_set<point> occupied_set( ret.occupied_zone.begin(), ret.occupied_zone.end() );
     for( point pt : ret.occupied_zone ) {
-        if( occupied_set.find( pt + increment ) == occupied_set.end() ) {
+        if( !occupied_set.contains( pt + increment ) ) {
             ret.collision_points.emplace_back( pt );
         }
     }
@@ -911,7 +911,7 @@ const
                 }
             } else if( !data.valid_position( next_addr ) ) {
                 ok = false;
-            } else if( !goal_found && data.goal_zone.find( next_addr ) != data.goal_zone.end() ) {
+            } else if( !goal_found && data.goal_zone.contains( next_addr ) ) {
                 goal_found = true;
             }
         }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -573,7 +573,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             // push the animal out of way until it's no longer in our vehicle and not in
             // anyone else's position
             while( g->critter_at( end_pos, true ) ||
-                   cur_points.find( end_pos ) != cur_points.end() ) {
+                   cur_points.contains( end_pos ) ) {
                 start_pos = end_pos;
                 calc_ray_end( angle, 2, start_pos, end_pos );
             }

--- a/src/vitamin.cpp
+++ b/src/vitamin.cpp
@@ -88,7 +88,7 @@ void vitamin::load_vitamin( const JsonObject &jo )
         vit.flags_.insert( e );
     }
 
-    if( vitamins_all.find( vit.id_ ) != vitamins_all.end() ) {
+    if( vitamins_all.contains( vit.id_ ) ) {
         jo.throw_error( "parsed vitamin overwrites existing definition", "id" );
     } else {
         vitamins_all[ vit.id_ ] = vit;

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -185,7 +185,7 @@ void weather_type::load( const JsonObject &jo, const std::string & )
                                        time_duration::units );
 
             bodypart_str_id bp_id = bodypart_str_id::NULL_ID();
-            if( bodypart_string != "" ) {
+            if( !bodypart_string.empty() ) {
                 bp_id = bodypart_str_id( bodypart_string );
             }
 

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -116,7 +116,7 @@ class wish_mutate_callback: public uilist_callback
                 // Extracting selected option & filtering traits on category presence
                 const auto entry = entries[ret];
                 auto predicate = [&]( const int idx ) {
-                    return entry->second.find( *vTraits[idx] ) != entry->second.end();
+                    return entry->second.contains( *vTraits[idx] );
                 };
                 menu->filterpredicate( predicate );
                 return true;
@@ -132,7 +132,7 @@ class wish_mutate_callback: public uilist_callback
                     vTraits.push_back( traits_iter.id );
                     pTraits[traits_iter.id] = p->has_trait( traits_iter.id );
                     for( auto &category : traits_iter.category ) {
-                        if( category_mutations.find( category ) == category_mutations.end() ) {
+                        if( !category_mutations.contains( category ) ) {
                             category_mutations[category] = std::set<mutation_branch>();
                         }
                         category_mutations[category].insert( traits_iter );


### PR DESCRIPTION

## Purpose of change (The Why)

makes code easier to read. death to iterators!

## Describe the solution (The How)

#7006 but only for `contains` and `empty`. 

## Describe alternatives you've considered

cri

## Testing

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/ecb651ae-3c81-4a3a-a6e4-8b8c0c51275c" />

minimap looks ok

@chaosvolt 99% certain this won't cause any issues but playtest needed to be sure

## Additional context

i will cry if this causes any issues

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

