### PR TITLE
feat: transparent floors

### DIFF
--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -191,7 +191,7 @@
     "symbol": "o",
     "color": "cyan",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "Z_TRANSPARENT", "INDOORS" ],
+    "flags": [ "TRANSPARENT", "Z_TRANSPARENT" ],
     "bash": { "str_min": 3, "str_max": 6, "sound": "glass braking!", "sound_fail": "whack!", "bash_below": true }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -9,7 +9,7 @@
     "move_cost": 2,
     "roof": "t_flat_roof",
     "trap": "tr_ledge",
-    "flags": [ "TRANSPARENT", "NO_FLOOR" ],
+    "flags": [ "TRANSPARENT", "NO_FLOOR", "NO_MEMORY" ],
     "examine_action": "ledge"
   },
   {
@@ -23,7 +23,7 @@
     "trap": "tr_ledge",
     "roof": "t_flat_roof",
     "examine_action": "ledge",
-    "flags": [ "TRANSPARENT", "NO_FLOOR", "INDOORS" ]
+    "flags": [ "TRANSPARENT", "NO_FLOOR", "INDOORS", "NO_MEMORY" ]
   },
   {
     "type": "terrain",
@@ -35,7 +35,7 @@
     "color": "i_cyan",
     "move_cost": 2,
     "trap": "tr_ledge",
-    "flags": [ "TRANSPARENT", "NO_FLOOR" ],
+    "flags": [ "TRANSPARENT", "NO_FLOOR", "NO_MEMORY" ],
     "examine_action": "ledge"
   },
   {

--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -189,11 +189,10 @@
     "name": "skylight",
     "description": "A giant sheet of glass inserted into the roof, lets light pass through.",
     "symbol": "o",
-    "looks_like": "t_linoleum_white",
+    "looks_like": "t_open_air",
     "color": "cyan",
     "move_cost": 2,
-    "trap": "tr_ledge",
-    "flags": [ "TRANSPARENT", "NO_FLOOR", "INDOORS" ],
+    "flags": [ "TRANSPARENT", "Z_TRANSPARENT", "INDOORS" ],
     "bash": { "str_min": 3, "str_max": 6, "sound": "glass braking!", "sound_fail": "whack!", "bash_below": true }
   },
   {
@@ -278,7 +277,7 @@
     "symbol": "#",
     "color": [ "light_green", "green", "yellow_yellow", "brown" ],
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "Z_TRANSPARENT" ],
     "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "bash_below": true }
   },
   {
@@ -289,7 +288,7 @@
     "symbol": "#",
     "color": [ "green" ],
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "Z_TRANSPARENT" ],
     "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "bash_below": true }
   },
   {
@@ -300,7 +299,7 @@
     "symbol": "#",
     "color": "brown",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "Z_TRANSPARENT" ],
     "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "bash_below": true }
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -189,7 +189,6 @@
     "name": "skylight",
     "description": "A giant sheet of glass inserted into the roof, lets light pass through.",
     "symbol": "o",
-    "looks_like": "t_open_air",
     "color": "cyan",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "Z_TRANSPARENT", "INDOORS" ],

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2685,7 +2685,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             // do something to get other terrain orientation values
         }
         const std::string &tname = t.id().str();
-        if( here.check_seen_cache( p ) && t != t_open_air ) {
+        if( here.check_seen_cache( p ) && !t->has_flag( TFLAG_NO_MEMORY ) && !t->has_flag( TFLAG_Z_TRANSPARENT ) ) {
             g->u.memorize_tile( here.getabs( p ), tname, subtile, rotation );
         }
         // draw the actual terrain if there's no override

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2685,7 +2685,8 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             // do something to get other terrain orientation values
         }
         const std::string &tname = t.id().str();
-        if( here.check_seen_cache( p ) && !t->has_flag( TFLAG_NO_MEMORY ) && !t->has_flag( TFLAG_Z_TRANSPARENT ) ) {
+        if( here.check_seen_cache( p ) && !t->has_flag( TFLAG_NO_MEMORY ) &&
+            !t->has_flag( TFLAG_Z_TRANSPARENT ) ) {
             g->u.memorize_tile( here.getabs( p ), tname, subtile, rotation );
         }
         // draw the actual terrain if there's no override

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1506,7 +1506,8 @@ void map::furn_set( const tripoint &p, const furn_id &new_furniture,
         set_outside_cache_dirty( p.z );
     }
 
-    if( (old_t.has_flag( TFLAG_NO_FLOOR ) != new_t.has_flag( TFLAG_NO_FLOOR )) ||  (old_t.has_flag( TFLAG_Z_TRANSPARENT ) != new_t.has_flag( TFLAG_Z_TRANSPARENT ))) {
+    if( ( old_t.has_flag( TFLAG_NO_FLOOR ) != new_t.has_flag( TFLAG_NO_FLOOR ) ) ||
+        ( old_t.has_flag( TFLAG_Z_TRANSPARENT ) != new_t.has_flag( TFLAG_Z_TRANSPARENT ) ) ) {
         set_floor_cache_dirty( p.z );
         set_seen_cache_dirty( p );
     }
@@ -1842,11 +1843,11 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain )
         support_cache_dirty.insert( p );
         set_seen_cache_dirty( p );
     }
-    
+
     if( new_t.has_flag( TFLAG_Z_TRANSPARENT ) != old_t.has_flag( TFLAG_Z_TRANSPARENT ) ) {
-		set_floor_cache_dirty( p.z );
+        set_floor_cache_dirty( p.z );
         set_seen_cache_dirty( p );
-	}
+    }
 
     if( new_t.has_flag( TFLAG_SUSPENDED ) != old_t.has_flag( TFLAG_SUSPENDED ) ) {
         set_suspension_cache_dirty( p.z );
@@ -2178,7 +2179,8 @@ bool map::has_floor( const tripoint &p, bool visible_only ) const
         return true;
     }
 
-    return get_cache_ref( p.z ).floor_cache[p.x][p.y] || (!visible_only && has_flag( TFLAG_Z_TRANSPARENT, p));
+    return get_cache_ref( p.z ).floor_cache[p.x][p.y] || ( !visible_only &&
+            has_flag( TFLAG_Z_TRANSPARENT, p ) );
 }
 
 bool map::floor_between( const tripoint &first, const tripoint &second ) const

--- a/src/map.h
+++ b/src/map.h
@@ -1531,8 +1531,8 @@ class map
 
         // Returns true if terrain at p has NO flag TFLAG_NO_FLOOR,
         // if we're not in z-levels mode or if we're at lowest level
-        bool has_floor( const tripoint &p, bool visible_only=false ) const;
-        
+        bool has_floor( const tripoint &p, bool visible_only = false ) const;
+
         /** Checks if there's a floor between the two tiles. They must be at most 1 tile away from each other in any dimension.
          *  If they're not at the same xy coord there must be floor on both of the relevant tiles
          */

--- a/src/map.h
+++ b/src/map.h
@@ -1531,8 +1531,8 @@ class map
 
         // Returns true if terrain at p has NO flag TFLAG_NO_FLOOR,
         // if we're not in z-levels mode or if we're at lowest level
-        bool has_floor( const tripoint &p ) const;
-
+        bool has_floor( const tripoint &p, bool visible_only=false ) const;
+        
         /** Checks if there's a floor between the two tiles. They must be at most 1 tile away from each other in any dimension.
          *  If they're not at the same xy coord there must be floor on both of the relevant tiles
          */

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -207,7 +207,8 @@ static void temp_remove_open_air( const shared_ptr_fast<mm_submap> &sm )
         for( int y = 0; y < SEEY; y++ ) {
             const memorized_terrain_tile &t = sm->tile( {x, y} );
 
-            if( !t.tile.empty() && (t.tile == "t_open_air" || t.tile == "t_open_air_rooved" || t.tile == "t_open_air_rooved_outside") ) {
+            if( !t.tile.empty() && ( t.tile == "t_open_air" || t.tile == "t_open_air_rooved" ||
+                                     t.tile == "t_open_air_rooved_outside" ) ) {
                 sm->set_tile( {x, y}, mm_submap::default_tile );
             }
         }

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -207,7 +207,7 @@ static void temp_remove_open_air( const shared_ptr_fast<mm_submap> &sm )
         for( int y = 0; y < SEEY; y++ ) {
             const memorized_terrain_tile &t = sm->tile( {x, y} );
 
-            if( !t.tile.empty() && t.tile == "t_open_air" ) {
+            if( !t.tile.empty() && (t.tile == "t_open_air" || t.tile == "t_open_air_rooved" || t.tile == "t_open_air_rooved_outside") ) {
                 sm->set_tile( {x, y}, mm_submap::default_tile );
             }
         }

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -202,6 +202,7 @@ static const std::unordered_map<std::string, ter_bitflags> ter_bitflags_map = { 
         { "FRIDGE",                   TFLAG_FRIDGE },         // This is an active fridge.
         { "FREEZER",                  TFLAG_FREEZER },        // This is an active freezer.
         { "ELEVATOR",                 TFLAG_ELEVATOR },       // This is an elevator.
+        { "NO_MEMORY",                TFLAG_NO_MEMORY },      // This should not be added to map memory
     }
 };
 

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -241,6 +241,7 @@ struct pry_result {
  * HIDE_PLACE - Creature on this tile can't be seen by other creature not standing on adjacent tiles
  * BLOCK_WIND - This tile will partially block wind
  * FLAT_SURF - Furniture or terrain or vehicle part with flat hard surface (ex. table, but not chair; tree stump, etc.).
+ * NO_MEMORY - Don't put this terrain in map memory. Used for open air and similar.
  *
  * Currently only used for Fungal conversions
  * WALL - This terrain is an upright obstacle
@@ -326,6 +327,7 @@ enum ter_bitflags : int {
     TFLAG_FRIDGE,
     TFLAG_FREEZER,
     TFLAG_ELEVATOR,
+    TFLAG_NO_MEMORY,
     NUM_TERFLAGS
 };
 


### PR DESCRIPTION
## Purpose of change (The Why)

Allows for transparent floors. Mostly to alleviate the performance problems of flying over forests.

## Describe the solution (The How)

Expands the Z_TRANSPARENT flag to make the floor truly transparent. Also removes the hard coding on open air not being added to map memory. There's now a NO_MEMORY flag which is also used by the "fake" open air tiles. This means they now render correctly.  

## Describe alternatives you've considered

There's a bit of overlap between the behavior of NO_FLOOR, Z_TRANSPARENT and NO_MEMORY, but this should be convenient to build tiles with. 

## Testing

Flying over a forest is significantly faster and skylights now look like a hole and work like a floor rather than the other way around.

## Additional context

Note that skylights are bulletproof but this is an existing bug that bullets don't bash floors, there's a todo about it in the ballistics code. 

![cata-skylight](https://github.com/user-attachments/assets/d30171dd-ac54-4d94-af68-20d44f541bc0)


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
