### PR TITLE
fix: remove redundant punctuation from `ALLOWS_X` flags descriptions

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -21,49 +21,49 @@
     "id": "ALLOWS_TAIL_SNAKE",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>serpentine bodies.</info>."
+    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>serpentine bodies</info>."
   },
   {
     "id": "ALLOWS_CLAWS",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>clawed fingers.</info>."
+    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>clawed fingers</info>."
   },
   {
     "id": "ALLOWS_CLAWS_FOOT",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>toe claws.</info>."
+    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>toe claws</info>."
   },
   {
     "id": "ALLOWS_HOOVES",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>hooves, foot-paws, or otherwise altered feet.</info>."
+    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>hooves, foot-paws, or otherwise altered feet</info>."
   },
   {
     "id": "ALLOWS_HORNS",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>horns on their head.</info>."
+    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>horns on their head</info>."
   },
   {
     "id": "ALLOWS_TAIL",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>a tail.</info>."
+    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>a tail</info>."
   },
   {
     "id": "ALLOWS_WINGS",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>wings.</info>."
+    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>wings</info>."
   },
   {
     "id": "ALLOWS_MUZZLE",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>a snout, beak, or mandibles.</info>."
+    "info": "This clothing is <good>uniquely compatible</good> with mutants possessing <info>a snout, beak, or mandibles</info>."
   },
   {
     "id": "EFFECT_INVISIBLE",


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Smol lil punctation fix caused by some copypaste errors on my part.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Eliminated redundant period in descriptions for `ALLOWS_X` flags.

## Describe alternatives you've considered

MORE PUNCTUATION...?!

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Demonstrated the mathematical prowess to observe that one period is fewer periods than two periods.

<img width="568" height="20" alt="image" src="https://github.com/user-attachments/assets/2f79a0ea-da5c-4c5b-8759-2a73fe6d4c7d" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
