### PR TITLE
fix: `round_up` now actually works for volume-based clothing mods

### DIFF
--- a/src/clothing_mod.cpp
+++ b/src/clothing_mod.cpp
@@ -99,7 +99,8 @@ float clothing_mod::get_mod_val( const clothing_mod_type &type, const item &it )
 {
     const int thickness = it.get_thickness();
     const int coverage = it.get_avg_coverage();
-    const int vol = it.base_volume() / 1_liter;
+    // This way ensures that items under a liter won't truncate down to 0 before it can reach round_up
+    const float vol = it.base_volume() / 1_ml / 1000.0f;
     float result = 0.0f;
     for( const mod_value &mv : mod_values ) {
         if( mv.type == type ) {


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This fixes an issue where `round_up` was failing to work right for the pockets clothing mod due to being the only clothing mod to scale based on item volume, which was forcing it to round down before it could get to the point where it checks for rounding up.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In clothing_mod.cpp, converted the volume calculation to use a float instead of an integer. I also had to change how it divides the volume because slapping volume units with a division by just `1_liters` would ALSO truncate it to death, so it has to convert the number into ml and then divide it by the desired scaling number accordingly.

## Describe alternatives you've considered

1. Chorus suggested trying to static_cast it into a float so we don't have to do weird division on it but every permutation I tried error'd.
2. Faking rounding by just giving the clothing mod itself a fixed +1 enc and storage boost as separate effects.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Confirmed that a bra (250 ml) and ankle socks (200 ml) now both gain some minimum level of encumbrance and storage instead of it being a complete waste of materials.
3. Confirmed a messenger bag (1 liter) also gains exactly +1 enc and +250 ml storage, as before.
4. Confirmed that a scabbard (1.5 liters) now gains +500 ml storage instead of only +250 ml, as it's now able to round up the extra 500 ml of item volume (enc is still only +1 because the enc penalty scales with coverage while the storage bonus doesn't).

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
