### PR TITLE
fix: add wrist computers to crafting standards

### DIFF
--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -135,7 +135,7 @@
     "id": "coding_standard",
     "type": "requirement",
     "//": "For writing software",
-    "tools": [ [ [ "laptop", 1 ], [ "control_laptop", 1 ], [ "wrist_comp_budget", 1 ] , [ "wrist_comp_control", 1 ]  ] ]
+    "tools": [ [ [ "laptop", 1 ], [ "control_laptop", 1 ], [ "wrist_comp_budget", 1 ], [ "wrist_comp_control", 1 ] ] ]
   },
   {
     "id": "hacking_standard",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -135,31 +135,31 @@
     "id": "coding_standard",
     "type": "requirement",
     "//": "For writing software",
-    "tools": [ [ [ "laptop", 1 ], [ "control_laptop", 1 ] ] ]
+    "tools": [ [ [ "laptop", 1 ], [ "control_laptop", 1 ], [ "wrist_comp_budget", 1 ] , [ "wrist_comp_control", 1 ]  ] ]
   },
   {
     "id": "hacking_standard",
     "type": "requirement",
     "//": "For hacking recipes and handwaving things like military encryption",
-    "tools": [ [ [ "software_hacking", 1 ], [ "control_laptop", 1 ] ] ]
+    "tools": [ [ [ "software_hacking", 1 ], [ "control_laptop", 1 ], [ "wrist_comp_control", 1 ] ] ]
   },
   {
     "id": "utility_software_standard",
     "type": "requirement",
     "//": "For hardware recipes requiring programming additional boards, unzipping, etc",
-    "tools": [ [ [ "software_utility", 1 ], [ "software_hacking", 1 ], [ "control_laptop", 1 ] ] ]
+    "tools": [ [ [ "software_utility", 1 ], [ "software_hacking", 1 ], [ "control_laptop", 1 ], [ "wrist_comp_control", 1 ] ] ]
   },
   {
     "id": "math_software_standard",
     "type": "requirement",
     "//": "For recipes requiring cracking passwords or automating similar heavy math operations",
-    "tools": [ [ [ "software_math", 1 ], [ "software_hacking", 1 ], [ "control_laptop", 1 ] ] ]
+    "tools": [ [ [ "software_math", 1 ], [ "software_hacking", 1 ], [ "control_laptop", 1 ], [ "wrist_comp_control", 1 ] ] ]
   },
   {
     "id": "medical_software_standard",
     "type": "requirement",
-    "//": "For recipes requiring cracking passwords or automating similar heavy math operations. However, software_hacking is not included because it presuambly wouldn't be on the OS.",
-    "tools": [ [ [ "software_medical", 1 ], [ "control_laptop", 1 ] ] ]
+    "//": "For recipes requiring advanced medical simulations or calibrating bionics. However, software_hacking is not included because medical software presuambly wouldn't be on the OS.",
+    "tools": [ [ [ "software_medical", 1 ] ] ]
   },
   {
     "id": "anesthetic",


### PR DESCRIPTION
## Purpose of change (The Why)
I seem to have missed this in #7276. woops

## Describe the solution (The How)
Add wrist computers to relevant toolset crafting standards. Those include utility, coding, hacking, and math.

Removes the control laptop from the medical standard, as intended.
## Describe alternatives you've considered
## Testing
Loaded in, didn't get any errors related to the changes and the game still works.
## Additional context
## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
