### PR TITLE
feat(balance): add composite plating version of welded shield, allow uncrafting plating and ballistic shields

### DIFF
--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -196,6 +196,17 @@
     "proportional": { "weight": 1.5, "material_thickness": 1.5, "price_postapoc": 2 }
   },
   {
+    "id": "shield_welded_composite",
+    "copy-from": "shield_welded_hard",
+    "type": "ARMOR",
+    "name": { "str": "welded composite shield" },
+    "description": "A shield made out of military grade vehicle armor with handles welded on.  Incredibly heavy but can also take a fair bit of punishment.",
+    "material": [ "hardsteel", "ceramic" ],
+    "color": "green",
+    "weight": "16500 g",
+    "relative": { "encumbrance": 5, "material_thickness": 2 }
+  },
+  {
     "id": "shield_welded_superalloy",
     "copy-from": "shield_welded",
     "type": "ARMOR",

--- a/data/json/recipes/armor/shield.json
+++ b/data/json/recipes/armor/shield.json
@@ -92,6 +92,7 @@
     "difficulty": 2,
     "time": "10 m",
     "autolearn": true,
+    "reversible": true,
     "using": [ [ "welding_standard", 10 ] ],
     "components": [ [ [ "steel_plate", 1 ], [ "manhole_cover", 1 ] ], [ [ "scrap", 4 ] ] ]
   },
@@ -104,8 +105,22 @@
     "difficulty": 4,
     "time": "10 m",
     "autolearn": true,
+    "reversible": true,
     "using": [ [ "welding_standard", 10 ] ],
     "components": [ [ [ "hard_plate", 1 ] ], [ [ "scrap", 4 ] ] ]
+  },
+  {
+    "result": "shield_welded_composite",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_SHIELD",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "10 m",
+    "autolearn": true,
+    "reversible": true,
+    "using": [ [ "welding_standard", 10 ] ],
+    "components": [ [ [ "mil_plate", 1 ] ], [ [ "scrap", 4 ] ] ]
   },
   {
     "result": "shield_welded_superalloy",
@@ -116,6 +131,7 @@
     "difficulty": 4,
     "time": "10 m",
     "autolearn": true,
+    "reversible": true,
     "using": [ [ "welding_standard", 10 ] ],
     "components": [ [ [ "alloy_plate", 1 ] ], [ [ "scrap", 4 ] ] ]
   },

--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -584,5 +584,14 @@
     "time": "1 m",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "components": [ [ [ "scrap", 1 ], [ "string_6", 1 ] ] ]
+  },
+  {
+    "result": "shield_ballistic",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "5 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "kevlar_plate", 18 ] ], [ [ "ceramic_armor", 4 ] ], [ [ "steel_chunk", 1 ] ] ]
   }
 ]

--- a/data/json/uncraft/vehicle/other.json
+++ b/data/json/uncraft/vehicle/other.json
@@ -7,5 +7,14 @@
     "time": "15 m",
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "material_aluminium_ingot", 18 ] ], [ [ "chem_aluminium_powder", 50 ] ] ]
+  },
+  {
+    "result": "mil_plate",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "time": "15 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "hard_steel_armor", 8 ] ], [ [ "ceramic_armor", 8 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Lil more content involving fancy armor plating stuff.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added a military composite plating version of the welded shield, another tier higher over the hard steel welded shield in thickness and encumbrance.
2. Added uncrafts to composite plating and to ballistic shields, letting you take them apart for materials.
3. Misc: set the welded shield recipes to be reversible.

## Describe alternatives you've considered

Adding the ability to craft composite plates at high levels, or SOME sort of top-tier crafting use for ceramic and hard steel armor plates.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

<img width="1741" height="649" alt="image" src="https://github.com/user-attachments/assets/c45e7ad7-efae-43aa-b527-272da0ca1464" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
