### PR TITLE
feat: rename swimming to athletics, encumbrance benefit

### DIFF
--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -61,7 +61,7 @@
     "type": "skill",
     "id": "swimming",
     "name": { "str": "Athletics" },
-    "description": "Your ability to stay afloat and move around in bodies of water.  This skill keeps you from drowning, affects your combat effectiveness and speed in deep water, and determines the detriment of swimming with heavier gear.",
+    "description": "Your capability to perform physically demanding tasks such as running, jumping, climbing, and swimming efficiently. This skill influences your overall ability in movement-related challenges, and determines how well you can handle exertion or heavy loads during strenuous activity.",
     "display_category": "display_interaction",
     "companion_skill_practice": [ { "skill": "", "weight": 5 }, { "skill": "gathering", "weight": 5 }, { "skill": "trapping", "weight": 5 } ]
   },

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -61,7 +61,7 @@
     "type": "skill",
     "id": "swimming",
     "name": { "str": "Athletics" },
-    "description": "Your capability to perform physically demanding tasks such as running, jumping, climbing, and swimming efficiently. This skill influences your overall ability in movement-related challenges, and determines how well you can handle exertion or heavy loads during strenuous activity.",
+    "description": "Your capability to perform physically demanding tasks such as running, jumping, climbing, and swimming efficiently. This skill influences your overall performance when swimming, and reduces the impact of encumbrance.",
     "display_category": "display_interaction",
     "companion_skill_practice": [ { "skill": "", "weight": 5 }, { "skill": "gathering", "weight": 5 }, { "skill": "trapping", "weight": 5 } ]
   },

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -60,7 +60,7 @@
   {
     "type": "skill",
     "id": "swimming",
-    "name": { "str": "Swimming" },
+    "name": { "str": "Athletics" },
     "description": "Your ability to stay afloat and move around in bodies of water.  This skill keeps you from drowning, affects your combat effectiveness and speed in deep water, and determines the detriment of swimming with heavier gear.",
     "display_category": "display_interaction",
     "companion_skill_practice": [ { "skill": "", "weight": 5 }, { "skill": "gathering", "weight": 5 }, { "skill": "trapping", "weight": 5 } ]

--- a/data/raw/tips.json
+++ b/data/raw/tips.json
@@ -88,7 +88,8 @@
       "Many types of furniture have a chance to intercept bullets, reducing some of the damage taken.  The bigger and harder the obstacle, the better.",
       "If you prefer a more subtle approach to breaking and entering, crouching will make you automatically prioritize lockpicking over prying tools.",
       "Crouching slows you down, but allows you to hide behind obstacles and makes you a smaller target when bullets start flying.",
-      "Make every shot count.  Take time to steady your aim, or crouch for more accurate fire."
+      "Make every shot count.  Take time to steady your aim, or crouch for more accurate fire.",
+      "Running, swimming, and other physical activity will increase your Athletics skill, making heavy armor less encumbering and making swimming easier."
     ]
   }
 ]

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4463,7 +4463,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
                 p->magic->mod_mana( *p, -cost );
                 break;
             case stamina_energy:
-                p->mod_stamina( -cost );
+                p->mod_stamina( -cost, spell_being_cast.has_flag( spell_flag::PHYSICAL ) );
                 break;
             case bionic_energy:
                 p->mod_power_level( -units::from_kilojoule( cost ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4178,6 +4178,17 @@ char_encumbrance_data Character::calc_encumbrance( const item &new_item ) const
     item_encumb( enc, new_item );
     mut_cbm_encumb( enc );
 
+    // Get swimming skill level
+    int swim_skill = get_skill_level( skill_swimming );
+
+    // Reduce encumbrance for each body part based on swimming skill
+    for( auto &iter : enc.elems ) {
+        encumbrance_data &edata = iter.second;
+
+        // Reduce encumbrance by swim_skill, clamped at 0
+        edata.encumbrance = std::max( 0, edata.encumbrance - swim_skill );
+    }
+
     return enc;
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7648,7 +7648,7 @@ void Character::mod_stamina( int mod, bool skill )
     stamina = clamp( stamina, 0, get_stamina_max() );
     // If we're burning stamina then train athletics, unless we're losing stamina due to status effects or other non-standard causes.
     if( skill && mod < 0 ) {
-        as_player()->practice( skill_swimming, roll_remainder( std::abs( mod ) / 100.0 ), 10, true );
+        as_player()->practice( skill_swimming, roll_remainder( std::abs( mod ) / 400.0 ), 10, true );
     }
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -770,7 +770,7 @@ void Character::mod_stat( const std::string &stat, float modifier )
     } else if( stat == "oxygen" ) {
         oxygen += modifier;
     } else if( stat == "stamina" ) {
-        mod_stamina( modifier );
+        mod_stamina( modifier, false );
     } else {
         Creature::mod_stat( stat, modifier );
     }
@@ -7642,10 +7642,19 @@ void Character::set_stamina( int new_stamina )
     stamina = new_stamina;
 }
 
-void Character::mod_stamina( int mod )
+void Character::mod_stamina( int mod, bool skill )
 {
     stamina += mod;
     stamina = clamp( stamina, 0, get_stamina_max() );
+    // If we're burning stamina then train athletics, unless we're losing stamina due to status effects or other non-standard causes.
+    if( skill && mod < 0 ) {
+        as_player()->practice( skill_swimming, roll_remainder( std::abs( mod ) / 100.0 ), 10, true );
+    }
+}
+
+void Character::mod_stamina( int mod )
+{
+    return mod_stamina( mod, true );
 }
 
 void Character::burn_move_stamina( int moves )
@@ -7750,7 +7759,7 @@ void Character::update_stamina( int turns )
         }
     }
 
-    mod_stamina( roll_remainder( stamina_recovery * turns ) );
+    mod_stamina( roll_remainder( stamina_recovery * turns ), false );
     add_msg( m_debug, "Stamina recovery: %d", roll_remainder( stamina_recovery * turns ) );
     // Cap at max
     set_stamina( std::min( std::max( get_stamina(), 0 ), max_stam ) );
@@ -8106,7 +8115,7 @@ void Character::cough( bool harmful, int loudness )
     if( harmful ) {
         const int stam = get_stamina();
         const int malus = get_stamina_max() * 0.05; // 5% max stamina
-        mod_stamina( -malus );
+        mod_stamina( -malus, false );
         if( stam < malus && x_in_y( malus - stam, malus ) && one_in( 6 ) ) {
             apply_damage( nullptr, bodypart_id( "torso" ), 1 );
         }

--- a/src/character.h
+++ b/src/character.h
@@ -1896,6 +1896,7 @@ class Character : public Creature, public location_visitable<Character>
         int get_stamina_max() const;
         void set_stamina( int new_stamina );
         void mod_stamina( int mod );
+        void mod_stamina( int mod, bool skill );
         void burn_move_stamina( int moves );
         float stamina_burn_cost_modifier() const;
         float running_move_cost_modifier() const;

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -544,7 +544,7 @@ void Character::process_one_effect( effect &it, bool is_new )
         if( is_new || it.activated( calendar::turn, "STAMINA", val, reduced, mod ) ) {
             mod_stamina( bound_mod_to_vals( get_stamina(), val,
                                             it.get_max_val( "STAMINA", reduced ),
-                                            it.get_min_val( "STAMINA", reduced ) ) );
+                                            it.get_min_val( "STAMINA", reduced ) ), false );
         }
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11770,7 +11770,7 @@ void game::process_artifact( item &it, Character &who )
                         if( calendar::once_every( 1_minutes ) ) {
                             add_msg( m_bad, _( "You feel fatigue seeping into your body." ) );
                             u.mod_fatigue( 3 * rng( 1, 3 ) );
-                            u.mod_stamina( -90 * rng( 1, 3 ) * rng( 1, 3 ) * rng( 2, 3 ) );
+                            u.mod_stamina( -90 * rng( 1, 3 ) * rng( 1, 3 ) * rng( 2, 3 ), false );
                             it.charges++;
                         }
                         break;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -930,7 +930,7 @@ void spell_effect::recover_energy( const spell &sp, Creature &caster, const trip
     if( energy_source == "MANA" ) {
         p->magic->mod_mana( *p, healing );
     } else if( energy_source == "STAMINA" ) {
-        p->mod_stamina( healing );
+        p->mod_stamina( healing, sp.has_flag( PHYSICAL ) );
     } else if( energy_source == "FATIGUE" ) {
         // fatigue is backwards
         p->mod_fatigue( -healing );
@@ -938,7 +938,7 @@ void spell_effect::recover_energy( const spell &sp, Creature &caster, const trip
         if( healing > 0 ) {
             p->mod_power_level( units::from_kilojoule( healing ) );
         } else {
-            p->mod_stamina( healing );
+            p->mod_stamina( healing, sp.has_flag( PHYSICAL ) );
         }
     } else if( energy_source == "PAIN" ) {
         // pain is backwards

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -417,7 +417,7 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character *c
             if( carrier ) {
                 carrier->add_msg_if_player( m_bad, _( "You feel fatigue seeping into your body." ) );
                 carrier->mod_fatigue( rng( rech.intensity_min, rech.intensity_max ) );
-                carrier->mod_stamina( -100 * rng( rech.intensity_min, rech.intensity_max ) );
+                carrier->mod_stamina( -100 * rng( rech.intensity_min, rech.intensity_max ), false );
             } else {
                 return false;
             }

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -219,7 +219,8 @@ static void assert_encumbrance( npc &shooter, int encumbrance )
 {
     for( const body_part bp : all_body_parts ) {
         INFO( "Body Part: " << body_part_name( bp ) );
-        REQUIRE( shooter.encumb( convert_bp( bp ) ) == encumbrance );
+        REQUIRE( shooter.encumb( convert_bp( bp ) ) == std::max( encumbrance - shooter.get_skill_level(
+                     skill_id( "swimming" ) ), 0 ) );
     }
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)
It was discussed in a development thread that we'd like to implement skill benefits based on the skills we currently have implemented. This is part one of the athletics portion.

## Describe the solution (The How)
Renames the swimming skill JSON to athletics, while leaving the code version the same as it'd likely cause issues with saves and such.

Modifies Character::calc_encumbrance to account for the current athletics skill. It then subtracts a point of encumbrance per level for each body part.

The player can now gain skill by any stamina burn. This is currently around 20% skill gain from level 0 for a sprint cycle.

## Describe alternatives you've considered

## Testing
Spawned in as a Punk Rock Girl, stripped to only my leather jacket (7 encumbrance). Noticed that at 0 athletics, it is the same as before. At 7 athletics, my encumbrance is effectively 0. At 10, my encumbrance is 0. (not negative)

## Additional context

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
