### PR TITLE
feat(balance): althetics skill reduces stamina burn, athletics and driving now no longer drain and are unaffected by focus

### DIFF
--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -55,7 +55,7 @@
     "id": "driving",
     "name": { "str": "Driving" },
     "description": "Your skill in operating and steering a vehicle in motion.  A higher level allows greater control over vehicles at higher speeds, and reduces the penalty of shooting while driving.",
-    "display_category": "display_interaction"
+    "display_category": "display_interaction",
     "tags": [ "unaffected_by_focus" ]
   },
   {

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -56,6 +56,7 @@
     "name": { "str": "Driving" },
     "description": "Your skill in operating and steering a vehicle in motion.  A higher level allows greater control over vehicles at higher speeds, and reduces the penalty of shooting while driving.",
     "display_category": "display_interaction"
+    "tags": [ "unaffected_by_focus" ]
   },
   {
     "type": "skill",

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -61,8 +61,9 @@
     "type": "skill",
     "id": "swimming",
     "name": { "str": "Athletics" },
-    "description": "Your capability to perform physically demanding tasks such as running, jumping, climbing, and swimming efficiently. This skill influences your overall performance when swimming, and reduces the impact of encumbrance.",
+    "description": "Your capability to perform physically demanding tasks such as running, jumping, climbing, and swimming efficiently. This skill influences your overall performance when swimming, reduces stamina consumption of physical activity, and reduces the impact of encumbrance.",
     "display_category": "display_interaction",
+    "tags": [ "unaffected_by_focus" ],
     "companion_skill_practice": [ { "skill": "", "weight": 5 }, { "skill": "gathering", "weight": 5 }, { "skill": "trapping", "weight": 5 } ]
   },
   {

--- a/data/raw/tips.json
+++ b/data/raw/tips.json
@@ -89,7 +89,7 @@
       "If you prefer a more subtle approach to breaking and entering, crouching will make you automatically prioritize lockpicking over prying tools.",
       "Crouching slows you down, but allows you to hide behind obstacles and makes you a smaller target when bullets start flying.",
       "Make every shot count.  Take time to steady your aim, or crouch for more accurate fire.",
-      "Running, swimming, and other physical activity will increase your Athletics skill, making heavy armor less encumbering and making swimming easier."
+      "Running, swimming, and other physical activity will increase your Athletics skill, making heavy armor less encumbering, let you consume less stamina, and making swimming easier."
     ]
   }
 ]

--- a/data/raw/tips.json
+++ b/data/raw/tips.json
@@ -89,7 +89,7 @@
       "If you prefer a more subtle approach to breaking and entering, crouching will make you automatically prioritize lockpicking over prying tools.",
       "Crouching slows you down, but allows you to hide behind obstacles and makes you a smaller target when bullets start flying.",
       "Make every shot count.  Take time to steady your aim, or crouch for more accurate fire.",
-      "Running, swimming, and other physical activity will increase your Athletics skill, making heavy armor less encumbering, let you consume less stamina, and making swimming easier."
+      "Running, swimming, and other physical activity will increase your Athletics skill, reducing encumbrance penalty, decreasing stamina consumption, and making swimming easier."
     ]
   }
 ]

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -1451,6 +1451,9 @@ These branches are also the valid entries for the categories of `dreams` in `dre
   "PRED2", "PRED3", and "PRED4" traits.
 - `contextual_skill` The skill is abstract, it depends on context (an indirect item to which it's
   applied). Neither player nor NPCs can possess it.
+- `unaffected_by_focus` Exercising this skill does not drain focus, and conversely focus does not
+  affect how fast this skill levels up (positively OR negatively).
+- `weapon_skill` Used by NPCs to decide what class of weapon they should generate with.
 
 ## Techniques
 

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -228,6 +228,12 @@ bool Skill::is_weapon_skill() const
     return _tags.contains( weapon_skill );
 }
 
+bool Skill::unaffected_by_focus() const
+{
+    static const std::string unaffected_by_focus( "unaffected_by_focus" );
+    return _tags.contains( unaffected_by_focus );
+}
+
 void SkillLevel::train( int amount, bool skip_scaling )
 {
     // Working off rust to regain levels goes twice as fast as reaching levels in the first place

--- a/src/skill.h
+++ b/src/skill.h
@@ -100,6 +100,7 @@ class Skill
         bool is_combat_skill() const;
         bool is_contextual_skill() const;
         bool is_weapon_skill() const;
+        bool unaffected_by_focus() const;
 
         // Required for LUA
         bool operator<( const Skill &rhs ) const {


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Follow-up to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7294 to make stamina burn affected by athletics skill, and allow for skills that are automatic and thus don't interact with focus at all.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In character.cpp, `Character::mod_stamina` now takes athletics skill into account, reducing stamina burned by up to a third at 10 athletics skill.
2. Also in character.cpp, moved the debug messages for printing stamina burn/recovery from `Character::burn_move_stamina` and `Character::update_stamina` to `Character::mod_stamina`, so that it prints an accurate number.
3. Set `Character::practice` so that skills with the new `unaffected_by_focus` tag (as defined below) no longer gain any modification from focus pool, and additionally no longer drain focus in turn.
4. In skill.cpp and skill.h, defined function `Skill::unaffected_by_focus` which accordingly looks for the tag `unaffected_by_focus` on the offending skill.

JSON changes:
1. Added `unaffected_by_focus` to athletics and driving skill, two fitting mind-numbing long-term movement skills.
2. Reworded main menu tip and skill description a bit to add mention of changes.

Documentation changes:
1. Documented new skill tag and added missing mention of `weapon_skill` to json_flags.md.

## Describe alternatives you've considered

Making impact of athletics skill on stamina drain more or less impactful? Currently it matches the amount of impact melee skill has on attack speed and stamina cost to attack (stacking in the case of stamina burn, for a total reduction down to 44.444% stamina cost when both skills are maxed out)

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Tested without changes, a basic survivor has the expected -15 stamina burn when walking.
2. Compiled and load-tested.
3. Walked around with no skill, still -15 stamina.
4. Set skills to 10, it's now -10 stamina to walk around as expected.
5. Also tested to confirm that running around no longer tanks my focus.
6. Added some messages temporarily to `Character::practice` to print EXP value before and after being run through `Character::adjust_for_focus`, to confirm that athletics was not being affected by focus and that it doing so didn't do anything weird to the expected EXP.

Test messages after ruining my focus with extreme levels of eepy, demonstrating that althetics skill is unaffected by it due to being tagged as `unaffected_by_focus`:
<img width="360" height="202" alt="image" src="https://github.com/user-attachments/assets/1e5947d9-3f40-4301-9901-50801aeccb45" />


## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
