### PR TITLE
feat(balance): driving skill affects fuel economy

### DIFF
--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -274,6 +274,14 @@ void vehicle::thrust( int thd, int z )
                 }
             }
         } else {
+            if( pl_ctrl ) {
+                // Driving skill reduces fuel consumption.
+                const float skill = get_player_character().get_skill_level( skill_driving );
+                const float skill_cost = std::max( 0.75f, ( 100.0f - ( skill * 2.5f ) ) / 100.0f );
+                // Up to 25% reduction at max skill, cap at idle rate.
+                const int load_cap = is_rotorcraft() ? 100 : 10;
+                load = std::max( static_cast<int>( load * skill_cost ), load_cap );
+            }
             //make noise and consume fuel
             noise_and_smoke( load );
             consume_fuel( load, 1 );


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

And the other idea that's been floated around for making skills more useful, this makes driving skill impact fuel consumption, on the basis that how you drive affects your fuel economy.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In vehicle_move.cpp, `vehicle::thrust` updated so load calculation modifies the impending fuel consumption by driving still, taking up to 25% off at max skill level. This is sanity-checked against the load values used by `vehicle::idle` however, so that a good driver going slow can't magically drive more efficiently that just sitting there idling the engines.

## Describe alternatives you've considered

Making impact of driving skill more or less powerful.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Temporarily added a message to print vehicle load mid-drive at 60 mph.
3. Message says vehicle load is 170 at zero skill, 127 (170 * 0.75 would be 127.5) at 10 skill.
4. Checked affected file for astyle.

<img width="328" height="78" alt="image" src="https://github.com/user-attachments/assets/829544e6-e6b5-49e7-8fa5-e08a681b648c" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

If this explodes vehicle tests I am gonna fucking cry.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
