### PR TITLE
feat(balance): spotting traps grants EXP based on trap visibility

### DIFF
--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -94,6 +94,7 @@ static const efftype_id effect_tapeworm( "tapeworm" );
 static const efftype_id effect_thirsty( "thirsty" );
 
 static const skill_id skill_swimming( "swimming" );
+static const skill_id skill_traps( "traps" );
 
 static const bionic_id bio_ground_sonar( "bio_ground_sonar" );
 static const bionic_id bio_hydraulics( "bio_hydraulics" );
@@ -1155,6 +1156,8 @@ void search_surroundings( Character &who )
                                                   direction_from( who.pos(), tp ) );
                 who.add_msg_if_player( _( "You've spotted a %1$s to the %2$s!" ),
                                        tr.name(), direction );
+                // Get a bit of experience for spotting traps.
+                who.practice( skill_traps, tr.get_visibility() );
             }
             who.add_known_trap( tp, tr );
         }


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Another minor skill-related feature on my to-do list: make spotting traps grant trapping EXP, so trying to deploy and disarm repeatedly isn't the only way to skill-grind them.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In character_turn.cpp, a successful trap detection in `search_surroundings` now exercises the trapping skill, granting EXP equal to the visibility stat of the trap (contrast disarming, giving EXP equal to 1.5x or 2x the difficulty instead). For reference, higher visibility means harder to spot (example: regular unburied landmines are visibility 1, while buried landmines have 10).

## Describe alternatives you've considered

Giving the EXP gain a multiplier. I feel 1x is fine since disarming traps should logically be more rewarding, and even at this rate doing a lap around a bandit camp with 100 perception gave me enough EXP to get to level 1 from nothing.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Gave myself absurdly high perception and spawned a bandit camp.
3. Meandered around outside the camp and detected some landmines.
4. Checked and found I gained some trapping experience.
5. Spotted a glass shard I debugged in (6 vis) vs a buried landmine (10 vis) to confirm EXP seems right (6% vs 10% level progression at level 0).

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="360" height="246" alt="image" src="https://github.com/user-attachments/assets/7b1c9297-80dc-4664-bbe8-9063401f7c3d" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
