### PR TITLE
feat(balance): shield armor values affect melee blocking

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11506,14 +11506,14 @@ auto get_shield_resist( const item &shield, const damage_unit &damage ) -> int
     // *INDENT-ON*
 }
 
-auto get_block_amount( const item &shield, const damage_unit &unit ) -> int
+} // namespace
+
+float Character::get_block_amount( const item &shield, const damage_unit &unit )
 {
     const int resist = get_shield_resist( shield, unit );
 
     return std::max( 0.0f, ( resist - unit.res_pen ) * unit.res_mult );
 }
-
-} // namespace
 
 bool Character::block_ranged_hit( Creature *source, bodypart_id &bp_hit, damage_instance &dam )
 {

--- a/src/character.h
+++ b/src/character.h
@@ -651,6 +651,7 @@ class Character : public Creature, public location_visitable<Character>
 
         bool uncanny_dodge() override;
 
+        float get_block_amount( const item &shield, const damage_unit &unit );
         /** Checks for chance that a ranged attack will hit other armor along the way */
         bool block_ranged_hit( Creature *source, bodypart_id &bp_hit, damage_instance &dam ) override;
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This makes the damage resistance of shields matter for melee combat as well as ranged combat.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In character.cpp and character.h, converted `get_block_amount` from an auto function to a proper character function since I'm going to need to use it in another file.
2. In melee.cpp, `Character::block_hit` can now roll to factor in the direct damage reduction of shields. When trying to block a hit to any part NOT already covered by the shield (as that would've already rolled its normal armor value), chance to add damage reduction is determined by the shield's average coverage percent, tier of block technique, the user's melee skill. A successful roll directly reduces incoming damage by its damage resistances the same as if it was applied as armor. In exchange however, fixed block bonus being applied twice if the part targeted is covered by a shield and lowered the bonus for tier-3 shields to scale more in line with the other tiers.
3. Misc: Fixed it so the "blocked all damage" line can actually trigger.

## Describe alternatives you've considered

We could possibly make it so the block bonuses are penalized in some way by stamina perhaps, so that characters ground down to be low on stamina start to lose the ability to mitigate damage via active/skill-based blocking but retain the passive effect of a shield.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Compiled and load-tested, overall blocking seems more reliable with shields now. Temporarily added some messages for testing and used a monster edited to always deal a specific amount of damage, riot shield makes less painful when it procs while a welded shield negates it. Negating a hit also no longer says you block "nearly" all the damage.

<img width="640" height="382" alt="image" src="https://github.com/user-attachments/assets/08dcc769-5d96-4847-8589-622e63dc13cd" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
