### PR TITLE
fix: Fix Null Ammo Error & add dams to maps

### DIFF
--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -90,6 +90,7 @@
         "hiway",
         "road",
         "bridge",
+        "dam",
         "fema_entrance",
         "bunker",
         "helipad",
@@ -117,6 +118,7 @@
         "hiway",
         "road",
         "bridge",
+        "dam",
         "s_pharm",
         "s_gun",
         "s_grocery",
@@ -145,6 +147,7 @@
         "hiway",
         "road",
         "bridge",
+        "dam",
         { "om_terrain": "shelter", "om_terrain_match_type": "TYPE" },
         "hospital",
         "school",
@@ -236,7 +239,7 @@
     "use_action": {
       "type": "reveal_map",
       "radius": 180,
-      "terrain": [ "hiway", "road", "bridge", "hotel_tower", "s_restaurant", "cathedral", "s_restaurant_fast", "megastore", "museum" ],
+      "terrain": [ "hiway", "road", "bridge", "dam", "hotel_tower", "s_restaurant", "cathedral", "s_restaurant_fast", "megastore", "museum" ],
       "message": "You add roads and tourist attractions to your map."
     }
   },
@@ -254,6 +257,7 @@
         "hiway",
         "road",
         "bridge",
+        "dam",
         "s_restaurant_coffee",
         "s_restaurant",
         { "om_terrain": "bar", "om_terrain_match_type": "TYPE" },
@@ -279,6 +283,7 @@
         "river_shore",
         "river_center",
         "bridge_under",
+        "dam_under",
         "railroad_bridge",
         "lake_shore",
         "lake_surface",
@@ -308,6 +313,7 @@
         "hiway",
         "road",
         "bridge",
+        "dam",
         "desolatebarn",
         "shoppingplaza",
         { "om_terrain": "office_tower_collapse_a2", "om_terrain_match_type": "TYPE" },
@@ -343,7 +349,7 @@
     "use_action": {
       "type": "reveal_map",
       "radius": 90,
-      "terrain": [ "hiway", "road", "bridge", "field", "swamp", "forest", "lake", "river" ],
+      "terrain": [ "hiway", "road", "bridge", "dam", "field", "swamp", "forest", "lake", "river" ],
       "message": "You add terrain and roads to your map."
     }
   }

--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -239,7 +239,18 @@
     "use_action": {
       "type": "reveal_map",
       "radius": 180,
-      "terrain": [ "hiway", "road", "bridge", "dam", "hotel_tower", "s_restaurant", "cathedral", "s_restaurant_fast", "megastore", "museum" ],
+      "terrain": [
+        "hiway",
+        "road",
+        "bridge",
+        "dam",
+        "hotel_tower",
+        "s_restaurant",
+        "cathedral",
+        "s_restaurant_fast",
+        "megastore",
+        "museum"
+      ],
       "message": "You add roads and tourist attractions to your map."
     }
   },

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -910,7 +910,11 @@ void Character::process_items()
         int used = std::min( ch_UPS, weap->ammo_capacity() - weap->ammo_remaining() );
         ch_UPS -= used;
         ch_UPS_used += used;
-        weap->ammo_set( weap->ammo_current(), weap->ammo_remaining() + used );
+        if( weap->ammo_current() != itype_id::NULL_ID() ) {
+            weap->ammo_set( weap->ammo_current(), weap->ammo_remaining() + used );
+        } else {
+            weap->ammo_set( weap->ammo_default(), weap->ammo_remaining() + used );
+        }
     }
     // Load all items that use the UPS to their minimal functional charge,
     // The tool is not really useful if its charges are below charges_to_use
@@ -922,7 +926,11 @@ void Character::process_items()
         int used = std::min( ch_UPS, it.ammo_capacity() - it.ammo_remaining() );
         ch_UPS -= used;
         ch_UPS_used += used;
-        it.ammo_set( it.ammo_current(), it.ammo_remaining() + used );
+        if( it.ammo_current() != itype_id::NULL_ID() ) {
+            it.ammo_set( it.ammo_current(), it.ammo_remaining() + used );
+        } else {
+            it.ammo_set( it.ammo_default(), it.ammo_remaining() + used );
+        }
     }
     for( item *worn_item : active_worn_items ) {
         if( ch_UPS <= 0 ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Fix the null ammo error when using a UPS to reload by falling back on ammo_default
Also fixes the lack of dams on maps, a true tragety

## Describe the solution (The How)
Fixes the error
Add dams to maps

## Describe alternatives you've considered
Split this into 2 PRs

## Testing
Read for the map
And attempt to replicate the UPS reload issue and fail ( I couldn't at least :) )

## Additional Context
I named the branch fixmymistakes for a reason :)

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.