### PR TITLE
fix: correct logic in sleep comfort calcaulations

### DIFF
--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -409,15 +409,21 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
 
     if( comfort >= static_cast<int>( comfort_level::very_comfortable ) ) {
         comfort_response.level = comfort_level::very_comfortable;
-    } else if( comfort > static_cast<int>( comfort_level::comfortable ) ) {
+        who.add_msg_if_player( m_info, _( "comfort_response level is very comfortable" ) );
+    } else if( comfort >= static_cast<int>( comfort_level::comfortable ) ) {
         comfort_response.level = comfort_level::comfortable;
-    } else if( comfort > static_cast<int>( comfort_level::slightly_comfortable ) ) {
+        who.add_msg_if_player( m_info, _( "comfort_response level is comfortable" ) );
+    } else if( comfort >= static_cast<int>( comfort_level::slightly_comfortable ) ) {
         comfort_response.level = comfort_level::slightly_comfortable;
-    } else if( comfort == static_cast<int>( comfort_level::neutral ) ) {
+        who.add_msg_if_player( m_info, _( "comfort_response level is slightly comfortable" ) );
+    } else if( comfort >= static_cast<int>( comfort_level::neutral ) ) {
         comfort_response.level = comfort_level::neutral;
+        who.add_msg_if_player( m_info, _( "comfort_response level is neutral" ) );
     } else {
         comfort_response.level = comfort_level::uncomfortable;
+        who.add_msg_if_player( m_info, _( "comfort_response level is uncomfortable" ) );
     }
+        who.add_msg_if_player( m_info, _( "Comfort is: %s" ), comfort );
     return comfort_response;
 }
 

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -409,21 +409,15 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
 
     if( comfort >= static_cast<int>( comfort_level::very_comfortable ) ) {
         comfort_response.level = comfort_level::very_comfortable;
-        who.add_msg_if_player( m_info, _( "comfort_response level is very comfortable" ) );
     } else if( comfort >= static_cast<int>( comfort_level::comfortable ) ) {
         comfort_response.level = comfort_level::comfortable;
-        who.add_msg_if_player( m_info, _( "comfort_response level is comfortable" ) );
     } else if( comfort >= static_cast<int>( comfort_level::slightly_comfortable ) ) {
         comfort_response.level = comfort_level::slightly_comfortable;
-        who.add_msg_if_player( m_info, _( "comfort_response level is slightly comfortable" ) );
     } else if( comfort >= static_cast<int>( comfort_level::neutral ) ) {
         comfort_response.level = comfort_level::neutral;
-        who.add_msg_if_player( m_info, _( "comfort_response level is neutral" ) );
     } else {
         comfort_response.level = comfort_level::uncomfortable;
-        who.add_msg_if_player( m_info, _( "comfort_response level is uncomfortable" ) );
     }
-        who.add_msg_if_player( m_info, _( "Comfort is: %s" ), comfort );
     return comfort_response;
 }
 


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7264 caused some regressions in sleep comfort levels, making it so sleeping in a car would report it to be a comfortable place to sleep but then be impossible to sleep in and claim later on to be uncomfortable.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In character_function.cpp, `base_comfort_value` set to consistently use `>=` for all if statements in the if/else chain, so it should now set comfort values to the expected amounts.

## Describe alternatives you've considered

Reversion.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Temporarily added test messages to confirm it says a car is slightly comfortable, prints a comfort number of 3 (evidently the target number for that value), and I can actually sleep in the car.

<img width="1173" height="935" alt="image" src="https://github.com/user-attachments/assets/48b4bf52-ff9e-4902-a000-ff81c402246d" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
