### PR TITLE
feat: Invisible Immobile Items

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2139,6 +2139,11 @@
     "context": [  ]
   },
   {
+    "id": "INVISIBLE",
+    "type": "json_flag",
+    "context": [ ]
+  },
+  {
     "id": "TRADER_KEEP",
     "type": "json_flag",
     "context": [  ]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2141,7 +2141,7 @@
   {
     "id": "INVISIBLE",
     "type": "json_flag",
-    "context": [ ]
+    "context": [  ]
   },
   {
     "id": "TRADER_KEEP",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -162,7 +162,7 @@
     "name": { "str_sp": "smoldering embers" },
     "description": "A handful of smoldering embers emitting smoke.  They are fading away even when you look at them.",
     "emits": [ "emit_small_smoke_plume" ],
-    "flags": [ "TRADER_AVOID", "FAKE_SMOKE" ]
+    "flags": [ "TRADER_AVOID", "FAKE_SMOKE", "INVISIBLE" ]
   },
   {
     "id": "fake_firestarter",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -991,7 +991,7 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
         }
 
         // Check that we can pick it up.
-        if( target->made_of( LIQUID ) ) {
+        if( target->made_of( LIQUID ) || target->has_flag( flag_INVISIBLE ) ) {
             continue;
         }
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3058,7 +3058,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
             it_type = &*it_id;
         } else if( !invisible[0] && here.sees_some_items( p, g->u ) ) {
             const maptile &tile = here.maptile_at( p );
-            const item &itm = tile.get_uppermost_item();
+            const item &itm = tile.get_uppermost_visible_item();
             const mtype *const mon = itm.get_mtype();
             it_id = itm.typeId();
             mon_id = mon ? mon->id : mtype_id::NULL_ID();

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -164,6 +164,7 @@ const flag_id flag_INITIAL_PART( "INITIAL_PART" );
 const flag_id flag_INSPIRATIONAL( "INSPIRATIONAL" );
 const flag_id flag_INSTALL_DIFFICULT( "INSTALL_DIFFICULT" );
 const flag_id flag_IN_CBM( "IN_CBM" );
+const flag_id flag_INVISIBLE( "INVISIBLE" );
 const flag_id flag_IRREMOVABLE( "IRREMOVABLE" );
 const flag_id flag_IR_EFFECT( "IR_EFFECT" );
 const flag_id flag_IS_ARMOR( "IS_ARMOR" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -165,6 +165,7 @@ extern const flag_id flag_INITIAL_PART;
 extern const flag_id flag_INSPIRATIONAL;
 extern const flag_id flag_INSTALL_DIFFICULT;
 extern const flag_id flag_IN_CBM;
+extern const flag_id flag_INVISIBLE;
 extern const flag_id flag_IRREMOVABLE;
 extern const flag_id flag_IR_EFFECT;
 extern const flag_id flag_IS_ARMOR;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9563,7 +9563,7 @@ point game::place_player( const tripoint &dest_loc )
                         break;
                     }
                 }
-                if( names.size() > 0 ){
+                if( names.size() > 0 ) {
                     for( size_t i = 0; i < names.size(); ++i ) {
                         if( !items[i]->count_by_charges() ) {
                             names[i] = items[i]->display_name( counts[i] );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9531,7 +9531,9 @@ point game::place_player( const tripoint &dest_loc )
                 std::vector<size_t> counts;
                 std::vector<item *> items;
                 for( auto &tmpitem : m.i_at( u.pos() ) ) {
-
+                    if( tmpitem->has_flag( flag_INVISIBLE ) ) {
+                        continue;
+                    }
                     std::string next_tname = tmpitem->tname();
                     std::string next_dname = tmpitem->display_name();
                     bool by_charges = tmpitem->count_by_charges();
@@ -9561,36 +9563,38 @@ point game::place_player( const tripoint &dest_loc )
                         break;
                     }
                 }
-                for( size_t i = 0; i < names.size(); ++i ) {
-                    if( !items[i]->count_by_charges() ) {
-                        names[i] = items[i]->display_name( counts[i] );
+                if( names.size() > 0 ){
+                    for( size_t i = 0; i < names.size(); ++i ) {
+                        if( !items[i]->count_by_charges() ) {
+                            names[i] = items[i]->display_name( counts[i] );
+                        } else {
+                            names[i] = items[i]->tname( counts[i] );
+                        }
+                    }
+                    int and_the_rest = 0;
+                    for( size_t i = 0; i < names.size(); ++i ) {
+                        //~ number of items: "<number> <item>"
+                        std::string fmt = vgettext( "%1$d %2$s", "%1$d %2$s", counts[i] );
+                        names[i] = string_format( fmt, counts[i], names[i] );
+                        // Skip the first two.
+                        if( i > 1 ) {
+                            and_the_rest += counts[i];
+                        }
+                    }
+                    if( names.size() == 1 ) {
+                        add_msg( _( "You see here %s." ), names[0] );
+                    } else if( names.size() == 2 ) {
+                        add_msg( _( "You see here %s and %s." ), names[0], names[1] );
+                    } else if( names.size() == 3 ) {
+                        add_msg( _( "You see here %s, %s, and %s." ), names[0], names[1], names[2] );
+                    } else if( and_the_rest < 7 ) {
+                        add_msg( vgettext( "You see here %s, %s and %d more item.",
+                                           "You see here %s, %s and %d more items.",
+                                           and_the_rest ),
+                                 names[0], names[1], and_the_rest );
                     } else {
-                        names[i] = items[i]->tname( counts[i] );
+                        add_msg( _( "You see here %s and many more items." ), names[0] );
                     }
-                }
-                int and_the_rest = 0;
-                for( size_t i = 0; i < names.size(); ++i ) {
-                    //~ number of items: "<number> <item>"
-                    std::string fmt = vgettext( "%1$d %2$s", "%1$d %2$s", counts[i] );
-                    names[i] = string_format( fmt, counts[i], names[i] );
-                    // Skip the first two.
-                    if( i > 1 ) {
-                        and_the_rest += counts[i];
-                    }
-                }
-                if( names.size() == 1 ) {
-                    add_msg( _( "You see here %s." ), names[0] );
-                } else if( names.size() == 2 ) {
-                    add_msg( _( "You see here %s and %s." ), names[0], names[1] );
-                } else if( names.size() == 3 ) {
-                    add_msg( _( "You see here %s, %s, and %s." ), names[0], names[1], names[2] );
-                } else if( and_the_rest < 7 ) {
-                    add_msg( vgettext( "You see here %s, %s and %d more item.",
-                                       "You see here %s, %s and %d more items.",
-                                       and_the_rest ),
-                             names[0], names[1], and_the_rest );
-                } else {
-                    add_msg( _( "You see here %s and many more items." ), names[0] );
                 }
             }
         }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -517,7 +517,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
                 if( pl && !i->is_owned_by( *pl, true ) && i->get_owner()->likes_u >= -10 ) {
                     continue;
                 }
-                if( allow_liquids || !i->made_of( LIQUID ) ) {
+                if( ( allow_liquids || !i->made_of( LIQUID ) ) && !i->has_flag( flag_INVISIBLE ) ) {
                     add_item_by_items_type_cache( *i, false, assign_invlet, false );
                 }
             }

--- a/src/item_hauling.cpp
+++ b/src/item_hauling.cpp
@@ -1,8 +1,9 @@
 #include "item_hauling.h"
+#include "flag.h"
 
 bool is_haulable( const item &item )
 {
-    return !item.made_of( phase_id::LIQUID );
+    return !item.made_of( phase_id::LIQUID ) && !item.has_flag( flag_INVISIBLE );
 }
 
 bool has_haulable_items( const tripoint &pos )

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4421,7 +4421,7 @@ bool map::has_visible_item( const tripoint &p ) const
     point l;
     submap *const current_submap = get_submap_at( p, l );
     for( item *i : current_submap->get_items( l ) ) {
-        if( !i->has_flag( flag_INVISIBLE ) ){
+        if( !i->has_flag( flag_INVISIBLE ) ) {
             return true;
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4412,6 +4412,22 @@ map_stack map::i_at( const tripoint &p )
     return map_stack{ &current_submap->get_items( l ), p, this };
 }
 
+bool map::has_visible_item( const tripoint &p ) const
+{
+    if( !inbounds( p ) ) {
+        return false;
+    }
+
+    point l;
+    submap *const current_submap = get_submap_at( p, l );
+    for( item *i : current_submap->get_items( l ) ) {
+        if( !i->has_flag( flag_INVISIBLE ) ){
+            return true;
+        }
+    }
+    return false;
+}
+
 map_stack::iterator map::i_rem( const tripoint &p, map_stack::const_iterator it,
                                 detached_ptr<item>  *out )
 {
@@ -5088,6 +5104,9 @@ bool map::could_see_items( const tripoint &p, const tripoint &from ) const
     const bool sealed = has_flag_ter_or_furn( TFLAG_SEALED, p );
     if( sealed && container ) {
         // never see inside of sealed containers
+        return false;
+    }
+    if( !has_visible_item( p ) ) {
         return false;
     }
     if( container ) {

--- a/src/map.h
+++ b/src/map.h
@@ -888,6 +888,7 @@ class map
          * Checks for existence of items. Faster than i_at(p).empty
          */
         bool has_items( const tripoint &p ) const;
+        bool has_visible_item( const tripoint &p ) const;
 
         /**
          * Calls the examine function of furniture or terrain at given tile, for given character.

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -25,6 +25,7 @@
 #include "drop_token.h"
 #include "enums.h"
 #include "faction.h"
+#include "flag.h"
 #include "game.h"
 #include "input.h"
 #include "int_id.h"
@@ -34,6 +35,7 @@
 #include "item_stack.h"
 #include "json.h"
 #include "line.h"
+#include "location_vector.h"
 #include "make_static.h"
 #include "map.h"
 #include "map_selector.h"
@@ -630,12 +632,16 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
     if( from_vehicle ) {
         vehicle_stack vehitems = veh->get_items( cargo_part );
         for( item_stack::iterator it = vehitems.begin(); it != vehitems.end(); ++it ) {
-            here.push_back( it );
+            if( !( *it )->has_flag( flag_INVISIBLE ) ) {
+                here.push_back( it );
+            }
         }
     } else {
         map_stack mapitems = g->m.i_at( p );
         for( item_stack::iterator it = mapitems.begin(); it != mapitems.end(); ++it ) {
-            here.push_back( it );
+            if( !( *it )->has_flag( flag_INVISIBLE ) ) {
+                here.push_back( it );
+            }
         }
     }
 

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -629,10 +629,12 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
 
     // which items are we grabbing?
     std::vector<item_stack::iterator> here;
+    bool added = false;
     if( from_vehicle ) {
         vehicle_stack vehitems = veh->get_items( cargo_part );
         for( item_stack::iterator it = vehitems.begin(); it != vehitems.end(); ++it ) {
             if( !( *it )->has_flag( flag_INVISIBLE ) ) {
+                added = true;
                 here.push_back( it );
             }
         }
@@ -640,11 +642,14 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
         map_stack mapitems = g->m.i_at( p );
         for( item_stack::iterator it = mapitems.begin(); it != mapitems.end(); ++it ) {
             if( !( *it )->has_flag( flag_INVISIBLE ) ) {
+                added = true;
                 here.push_back( it );
             }
         }
     }
-
+    if( !added ) {
+        return;
+    }
     if( min == -1 ) {
         // Recursively pick up adjacent items if that option is on.
         if( get_option<bool>( "AUTO_PICKUP_ADJACENT" ) && g->u.pos() == p ) {

--- a/src/submap.h
+++ b/src/submap.h
@@ -331,7 +331,7 @@ struct maptile {
         const item &get_uppermost_item() const {
             return **std::prev( sm->get_items( pos() ).cend() );
         }
-        
+
         const item &get_uppermost_visible_item() const {
             location_vector<item> *items = &sm->get_items( pos() );
             for( auto i = items->rbegin(); i != items->rend(); i++ ) {

--- a/src/submap.h
+++ b/src/submap.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <pthread.h>
 #include <vector>
 #include <string>
 #include <iterator>
@@ -13,9 +14,11 @@
 #include "calendar.h"
 #include "computer.h"
 #include "construction_partial.h"
+#include "flag.h"
 #include "field.h"
 #include "game_constants.h"
 #include "item.h"
+#include "location_vector.h"
 #include "type_id.h"
 #include "monster.h"
 #include "point.h"
@@ -327,6 +330,17 @@ struct maptile {
         // Assumes there is at least one item
         const item &get_uppermost_item() const {
             return **std::prev( sm->get_items( pos() ).cend() );
+        }
+        
+        const item &get_uppermost_visible_item() const {
+            location_vector<item> *items = &sm->get_items( pos() );
+            for( auto i = items->rbegin(); i != items->rend(); i++ ) {
+                if( !( *i )->has_flag( flag_INVISIBLE ) ) {
+                    return **i;
+                }
+            }
+            // Failsafe, cant be null
+            return get_uppermost_item();
         }
 };
 

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -45,9 +45,6 @@ static const bionic_id bio_tools( "bio_tools" );
 static const bionic_id bio_electrosense_voltmeter( "bio_electrosense_voltmeter" );
 static const bionic_id bio_ups( "bio_ups" );
 
-static const flag_id flag_BIONIC_ARMOR_INTERFACE( "BIONIC_ARMOR_INTERFACE" );
-static const flag_id flag_IS_UPS( "IS_UPS" );
-
 /** @relates visitable */
 template <typename T>
 item *visitable<T>::find_parent( const item &it )


### PR DESCRIPTION
## Purpose of change (The Why)
Furniture currently cannot store data, causing issues with persistent furnitures (including the smoker)
This is a workaround to let furniture store data in the form of invisible objects
Additionally mods could add and remove flags to create hidden unlockable loot, and that's just what I thought of this fine day

## Describe the solution (The How)
Add the INVISIBLE flag, which makes items invisible and uninteractable

## Describe alternatives you've considered
Completely bork save files and let furniture store data
I'm sure yall really want ME to be in charge of that version of these changes

## Testing
Spawn smoldering embers (fake should be uninteractable item for the smoker), drop them on the ground, they aren't visible nor grabbable
Figure out some way to determine it's still there (But I promise it is :) )

## Additional context
**I KNOW I HAVEN'T DOCUMENTED THE FLAG YET :P**
This will be pertinent to furniture multi-cookers, and perhaps other furniture.
It will also be needed for things like repair furniture (instead of items) that consume other materials
It has a ton of uses.

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
