### PR TITLE
fix: remove bonus EXP from swimming now that burning stamina generates EXP

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -569,7 +569,6 @@ void avatar_action::swim( map &m, avatar &you, const tripoint &p )
         you.set_underwater( true );
     }
     int movecost = you.swim_speed();
-    you.practice( skill_swimming, you.is_underwater() ? 2 : 1 );
     if( movecost >= 500 ) {
         if( !you.is_underwater() &&
             !( you.shoe_type_count( itype_swim_fins ) == 2 ||

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -569,6 +569,9 @@ void avatar_action::swim( map &m, avatar &you, const tripoint &p )
         you.set_underwater( true );
     }
     int movecost = you.swim_speed();
+    if( !you.worn_with_flag( flag_FLOTATION ) ) {
+        you.practice( skill_swimming, 1 );
+    }
     if( movecost >= 500 ) {
         if( !you.is_underwater() &&
             !( you.shoe_type_count( itype_swim_fins ) == 2 ||

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -569,7 +569,7 @@ void avatar_action::swim( map &m, avatar &you, const tripoint &p )
         you.set_underwater( true );
     }
     int movecost = you.swim_speed();
-    if( !you.worn_with_flag( flag_FLOTATION ) ) {
+    if( !you.worn_with_flag( flag_FLOTATION ) && x_in_y( 3, 4 ) ) {
         you.practice( skill_swimming, 1 );
     }
     if( movecost >= 500 ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7650,7 +7650,7 @@ void Character::mod_stamina( int mod, bool skill )
 {
     // If we're burning stamina then train athletics, unless we're losing stamina due to status effects or other non-standard causes.
     if( skill && mod < 0 ) {
-        as_player()->practice( skill_swimming, roll_remainder( std::abs( mod ) / 400.0 ), 10, true );
+        as_player()->practice( skill_swimming, roll_remainder( std::abs( mod ) / 500.0 ), 10, true );
         // Athletics skill also reduces stamina drain for relevant activities.
         const int skill = get_skill_level( skill_swimming );
         const float skill_cost = std::max( 0.667f, ( ( 30.0f - skill ) / 30.0f ) );

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -1042,7 +1042,6 @@ void do_pause( Character &who )
         }
 
         if( who.is_underwater() ) {
-            who.as_player()->practice( skill_swimming, 1 );
             who.drench( 100, { {
                     bodypart_str_id( "leg_l" ), bodypart_str_id( "leg_r" ), bodypart_str_id( "torso" ), bodypart_str_id( "arm_l" ),
                     bodypart_str_id( "arm_r" ), bodypart_str_id( "head" ), bodypart_str_id( "eyes" ), bodypart_str_id( "mouth" ),
@@ -1050,7 +1049,6 @@ void do_pause( Character &who )
                 }
             }, true );
         } else if( here.has_flag( TFLAG_DEEP_WATER, who.pos() ) ) {
-            who.as_player()->practice( skill_swimming, 1 );
             // Same as above, except no head/eyes/mouth
             who.drench( 100, { {
                     bodypart_str_id( "leg_l" ), bodypart_str_id( "leg_r" ), bodypart_str_id( "torso" ), bodypart_str_id( "arm_l" ),


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Waiting an hour in deep water while wearing a life jacket was generating several level's worth of swimming EXP. Far as I can tell this has always been a problem, but back when the swimming skill was as useless as it is in Deus Ex it didn't matter. Now that it's the athletics skill and does useful stuff elsewhere however...

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In avatar_action.cpp, per feedback I've kept the EXP gain to atheltics when actually moving around in the water, but nerfed it a bit to only be a 75% chance of granting 1 per turn whether underwater or not, which now no longer applies if you're wearing a life jacket.
2. In character_turn.cpp, removed the free EXP practice in `do_pause`.
3. And in character.cpp, after some testing and discussion in the discord, nerfed athletics gain from EXP a bit more in `Character::mod_stamina`, increasing the divisor factor from 400 to 500.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Waiting in the water in a flotation vest no longer generates free athletics EXP.
3. Swimming around however still generates EXP even with a flotation vest on since you're still burning stamina.
4. Swimming around naked also still generates EXP, and does so faster than if you had a flotation vest on.

Minor: sitting around in water may potentially still warrant EXP if you don't have a life jacket on since you'd be treading water, but this maybe should be modeled by having waiting in the water burn stamina at a lower rate than actively swimming unless being held up by a flotation device. Could add as a followup or in this PR if desired?

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
