### PR TITLE
fix: Tileset memory is no longer duplicated when overmap and terrain tiles are identical

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3029,12 +3029,14 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
         // Disable UIs below to avoid accessing the tile context during loading.
         ui_adaptor dummy( ui_adaptor::disable_uis_below {} );
         //try and keep SDL calls limited to source files that deal specifically with them
+        std::string tilesName = get_option<std::string>( "TILES" );
+        std::string omTilesName = get_option<std::string>( "OVERMAP_TILES" );
         try {
             tilecontext->reinit();
             std::vector<mod_id> dummy;
 
             tilecontext->load_tileset(
-                get_option<std::string>( "TILES" ),
+                tilesName,
                 ingame ? world_generator->active_world->info->active_mod_order : dummy,
                 /*precheck=*/false,
                 /*force=*/force_tile_change,
@@ -3051,27 +3053,31 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
             use_tiles = false;
             use_tiles_overmap = false;
         }
-        try {
-            overmap_tilecontext->reinit();
-            std::vector<mod_id> dummy;
+        if( tilesName == omTilesName ) {
+            overmap_tilecontext = tilecontext;
+        } else {
+            try {
+                repoint_overmap_tilecontext();
+                std::vector<mod_id> dummy;
 
-            overmap_tilecontext->load_tileset(
-                get_option<std::string>( "OVERMAP_TILES" ),
-                ingame ? world_generator->active_world->info->active_mod_order : dummy,
-                /*precheck=*/false,
-                /*force=*/force_tile_change,
-                /*pump_events=*/true
-            );
-            //game_ui::init_ui is called when zoom is changed
-            g->reset_zoom();
-            g->mark_main_ui_adaptor_resize();
-            overmap_tilecontext->do_tile_loading_report( []( const std::string & str ) {
-                DebugLog( DL::Info, DC::Main ) << str;
-            } );
-        } catch( const std::exception &err ) {
-            popup( _( "Loading the overmap tileset failed: %s" ), err.what() );
-            use_tiles = false;
-            use_tiles_overmap = false;
+                overmap_tilecontext->load_tileset(
+                    omTilesName,
+                    ingame ? world_generator->active_world->info->active_mod_order : dummy,
+                    /*precheck=*/false,
+                    /*force=*/force_tile_change,
+                    /*pump_events=*/true
+                );
+                //game_ui::init_ui is called when zoom is changed
+                g->reset_zoom();
+                g->mark_main_ui_adaptor_resize();
+                overmap_tilecontext->do_tile_loading_report( []( const std::string & str ) {
+                    DebugLog( DL::Info, DC::Main ) << str;
+                } );
+            } catch( const std::exception &err ) {
+                popup( _( "Loading the overmap tileset failed: %s" ), err.what() );
+                use_tiles = false;
+                use_tiles_overmap = false;
+            }
         }
     } else if( ingame && pixel_minimap_option && pixel_minimap_height_changed ) {
         g->mark_main_ui_adaptor_resize();

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -103,8 +103,8 @@
 //Globals                           *
 //***********************************
 
-std::unique_ptr<cata_tiles> tilecontext;
-std::unique_ptr<cata_tiles> overmap_tilecontext;
+std::shared_ptr<cata_tiles> tilecontext;
+std::shared_ptr<cata_tiles> overmap_tilecontext;
 static uint32_t lastupdate = 0;
 static uint32_t interval = 25;
 static bool needupdate = false;
@@ -3588,11 +3588,13 @@ void catacurses::init_interface()
     WinCreate();
 
     dbg( DL::Info ) << "Initializing SDL Tiles context";
-    tilecontext = std::make_unique<cata_tiles>( renderer, geometry );
+    tilecontext = std::make_shared<cata_tiles>( renderer, geometry );
+    std::string tilesName = get_option<std::string>( "TILES" );
+    std::string omTilesName = get_option<std::string>( "OVERMAP_TILES" );
     try {
         std::vector<mod_id> dummy;
         tilecontext->load_tileset(
-            get_option<std::string>( "TILES" ),
+            tilesName,
             dummy,
             /*precheck=*/true,
             /*force=*/false,
@@ -3605,24 +3607,27 @@ void catacurses::init_interface()
         // Setting it to false disables this from getting used.
         use_tiles = false;
     }
-    overmap_tilecontext = std::make_unique<cata_tiles>( renderer, geometry );
-    try {
-        std::vector<mod_id> dummy;
-        overmap_tilecontext->load_tileset(
-            get_option<std::string>( "OVERMAP_TILES" ),
-            dummy,
-            /*precheck=*/true,
-            /*force=*/false,
-            /*pump_events=*/true
-        );
-    } catch( const std::exception &err ) {
-        dbg( DL::Error ) << "failed to check for overmap tileset: " << err.what();
-        // use_tiles is the cached value of the USE_TILES option.
-        // most (all?) code refers to this to see if cata_tiles should be used.
-        // Setting it to false disables this from getting used.
-        use_tiles = false;
+    if( tilesName == omTilesName ) {
+        overmap_tilecontext = tilecontext;
+    } else {
+        try {
+            overmap_tilecontext = std::make_shared<cata_tiles>( renderer, geometry );
+            std::vector<mod_id> dummy;
+            overmap_tilecontext->load_tileset(
+                omTilesName,
+                dummy,
+                /*precheck=*/true,
+                /*force=*/false,
+                /*pump_events=*/true
+            );
+        } catch( const std::exception &err ) {
+            dbg( DL::Error ) << "failed to check for overmap tileset: " << err.what();
+            // use_tiles is the cached value of the USE_TILES option.
+            // most (all?) code refers to this to see if cata_tiles should be used.
+            // Setting it to false disables this from getting used.
+            use_tiles = false;
+        }
     }
-
     color_loader<SDL_Color>().load( windowsPalette );
     init_colors();
 
@@ -3653,8 +3658,10 @@ void load_tileset()
     if( !tilecontext || !use_tiles ) {
         return;
     }
+    std::string tilesName = get_option<std::string>( "TILES" );
+    std::string omTilesName = get_option<std::string>( "OVERMAP_TILES" );
     tilecontext->load_tileset(
-        get_option<std::string>( "TILES" ),
+        tilesName,
         world_generator->active_world->info->active_mod_order,
         /*precheck=*/false,
         /*force=*/false,
@@ -3664,17 +3671,22 @@ void load_tileset()
         DebugLog( DL::Info, DC::Main ) << str;
     } );
 
-    if( overmap_tilecontext ) {
-        overmap_tilecontext->load_tileset(
-            get_option<std::string>( "OVERMAP_TILES" ),
-            world_generator->active_world->info->active_mod_order,
-            /*precheck=*/false,
-            /*force=*/false,
-            /*pump_events=*/true
-        );
-        overmap_tilecontext->do_tile_loading_report( []( const std::string & str ) {
-            DebugLog( DL::Info, DC::Main ) << str;
-        } );
+    if( tilesName == omTilesName ) {
+        overmap_tilecontext = tilecontext;
+    } else {
+        if( overmap_tilecontext ) {
+            overmap_tilecontext = std::make_shared<cata_tiles>( renderer, geometry );
+            overmap_tilecontext->load_tileset(
+                omTilesName,
+                world_generator->active_world->info->active_mod_order,
+                /*precheck=*/false,
+                /*force=*/false,
+                /*pump_events=*/true
+            );
+            overmap_tilecontext->do_tile_loading_report( []( const std::string & str ) {
+                DebugLog( DL::Info, DC::Main ) << str;
+            } );
+        }
     }
 }
 
@@ -4004,6 +4016,10 @@ bool save_screenshot( const std::string &file_path )
     return true;
 }
 
+void repoint_overmap_tilecontext()
+{
+    overmap_tilecontext = std::make_shared<cata_tiles>( renderer, geometry );
+}
 #ifdef _WIN32
 HWND getWindowHandle()
 {

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -17,8 +17,8 @@ namespace catacurses
 class window;
 } // namespace catacurses
 
-extern std::unique_ptr<cata_tiles> tilecontext;
-extern std::unique_ptr<cata_tiles> overmap_tilecontext;
+extern std::shared_ptr<cata_tiles> tilecontext;
+extern std::shared_ptr<cata_tiles> overmap_tilecontext;
 extern std::array<SDL_Color, color_loader<SDL_Color>::COLOR_NAMES_COUNT> windowsPalette;
 
 // This function may refresh the screen, so it should not be used where tiles
@@ -28,7 +28,7 @@ void load_tileset();
 void rescale_tileset( float size );
 bool save_screenshot( const std::string &file_path );
 void toggle_fullscreen_window();
-
+extern void repoint_overmap_tilecontext();
 struct window_dimensions {
     point scaled_font_size;
     point window_pos_cell;


### PR DESCRIPTION
## Purpose of change (The Why)
Android players should be able to play the game
As #7168 caused overmap tiles and overmap terrain tiles to load the tileset twice even if they were the same value

## Describe the solution (The How)
As they are pointers, set them equal to each other if needed, additionally, remake the overmap terrain pointer as needed

## Describe alternatives you've considered
Keep the issue

## Testing
Swap between different setups of overmap tiles and not overmap tiles see that it works
Input a debug print and see that it goes down the copy route
Determine there are no regressions

## Additional context
Resolves #7254 

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.