### PR TITLE
fix: make treadmill & ball machine powered

### DIFF
--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -361,6 +361,8 @@
     "copy-from": "fake_item",
     "type": "TOOL",
     "name": { "str": "ball machine" },
+    "max_charges": 1000,
+    "charges_per_use": 1,
     "//": "below level two, you can't dodge the balls well enough to not get pummeled. should be higher than dancing furniture though, as this is actual dodging and requires power",
     "use_action": [
       {
@@ -375,7 +377,8 @@
         "training_skill_interval": 30,
         "training_skill_xp_chance": 90
       }
-    ]
+    ],
+    "flags": [ "USES_GRID_POWER" ]
   },
   {
     "id": "fake_training_electronics_high",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -295,6 +295,8 @@
     "copy-from": "fake_item",
     "type": "TOOL",
     "name": { "str": "treadmill" },
+    "max_charges": 1000,
+    "charges_per_use": 1,
     "//": "the treadmill should allow the user to train athletics most consistently besides actual running, but at the cost of fatigue and power drain",
     "use_action": [
       {
@@ -309,7 +311,8 @@
         "training_skill_interval": 30,
         "training_skill_xp_chance": 90
       }
-    ]
+    ],
+    "flags": [ "USES_GRID_POWER" ]
   },
   {
     "id": "fake_training_exercise_machine",


### PR DESCRIPTION
## Purpose of change (The Why)
Forgot to do it in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7295

## Describe the solution (The How)
Makes the treadmill furniture and ball machine furniture's fake item require power

## Describe alternatives you've considered
Doing it flintstones-style?

## Testing
## Additional context
## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
