### PR TITLE
feat(balance): balance `train_skill` activities around 10-minute intervals, sanity-check JSON comments

### DIFF
--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -256,15 +256,15 @@
     "//2": "training melee skill, steady but slow since we're punching a mostly stationary target",
     "use_action": [
       {
-        "//": "average of 162 xp/hr (1.5x walking rate, but unarmed)",
+        "//": "up to 36 xp/hr",
         "type": "train_skill",
         "training_msg": "You swing and jab at the punching bag, sweat dripping as your technique improves.",
         "training_skill": "unarmed",
         "training_skill_min_level": 0,
-        "training_skill_xp": 18,
+        "training_skill_xp": 6,
         "training_skill_max_level": 4,
         "training_skill_fatigue": 3,
-        "training_skill_interval": 30,
+        "training_skill_interval": 10,
         "training_skill_xp_chance": 90
       }
     ]
@@ -277,15 +277,15 @@
     "//": "similar to a treadmill, but doesn't require power, so should be slightly worse.",
     "use_action": [
       {
-        "//": "average of 162 xp/hr (1.5x walking rate)",
+        "//": "up to 36 xp/hr",
         "type": "train_skill",
         "training_msg": "You row steadily on the ergometer, building strength and endurance with each pull.",
         "training_skill": "swimming",
         "training_skill_min_level": 0,
-        "training_skill_xp": 18,
+        "training_skill_xp": 6,
         "training_skill_max_level": 4,
         "training_skill_fatigue": 2,
-        "training_skill_interval": 30,
+        "training_skill_interval": 10,
         "training_skill_xp_chance": 90
       }
     ]
@@ -300,15 +300,15 @@
     "//": "the treadmill should allow the user to train athletics most consistently besides actual running, but at the cost of fatigue and power drain",
     "use_action": [
       {
-        "//": "average of 216 xp/hr (2x walking)",
+        "//": "up to 54 xp/hr",
         "type": "train_skill",
         "training_msg": "You run steadily on the treadmill, training your stamina and athletics skill.",
         "training_skill": "swimming",
         "training_skill_min_level": 0,
-        "training_skill_xp": 27,
+        "training_skill_xp": 9,
         "training_skill_max_level": 8,
         "training_skill_fatigue": 3,
-        "training_skill_interval": 30,
+        "training_skill_interval": 10,
         "training_skill_xp_chance": 90
       }
     ],
@@ -322,15 +322,15 @@
     "//": "lifting weights, minimum level of 2 because otherwise it's dangerous.",
     "use_action": [
       {
-        "//": "average of 162 xp/hr (1.5x walking rate)",
+        "//": "up to 36 xp/hr",
         "type": "train_skill",
         "training_msg": "You work out on the exercise machine, training your stamina and athletics skill.",
         "training_skill": "swimming",
         "training_skill_min_level": 2,
-        "training_skill_xp": 18,
+        "training_skill_xp": 6,
         "training_skill_max_level": 8,
         "training_skill_fatigue": 2,
-        "training_skill_interval": 30,
+        "training_skill_interval": 10,
         "training_skill_xp_chance": 90
       }
     ]
@@ -343,15 +343,15 @@
     "//": "dancing = dodging skill. should be relatively steady, slow gain since it's just pole dancing.",
     "use_action": [
       {
-        "//": "average of 162 xp/hr (1.5x walking rate)",
+        "//": "up to 36 xp/hr",
         "type": "train_skill",
         "training_msg": "You focus on controlled spins, honing your ability to dodge and react.",
         "training_skill": "dodge",
         "training_skill_min_level": 0,
-        "training_skill_xp": 18,
+        "training_skill_xp": 6,
         "training_skill_max_level": 3,
         "training_skill_fatigue": 3,
-        "training_skill_interval": 30,
+        "training_skill_interval": 10,
         "training_skill_xp_chance": 90
       }
     ]
@@ -366,15 +366,15 @@
     "//": "below level two, you can't dodge the balls well enough to not get pummeled. should be higher than dancing furniture though, as this is actual dodging and requires power",
     "use_action": [
       {
-        "//": "average of 216 xp/hr",
+        "//": "up to 54 xp/hr",
         "type": "train_skill",
         "training_msg": "You focus on dodging the flying projectiles, greatly honing your ability to dodge and react.",
         "training_skill": "dodge",
         "training_skill_min_level": 0,
-        "training_skill_xp": 27,
+        "training_skill_xp": 8,
         "training_skill_max_level": 5,
         "training_skill_fatigue": 3,
-        "training_skill_interval": 30,
+        "training_skill_interval": 10,
         "training_skill_xp_chance": 90
       }
     ],
@@ -391,15 +391,15 @@
     "//2": "this is dangerous machinery, so require a minimum level of 2. currently can't require tool qualites or anything",
     "use_action": [
       {
-        "//": "average of 216 xp/hr",
+        "//": "up to 54 xp/hr",
         "type": "train_skill",
         "training_msg": "You study the electronics, tracing circuits and learning how the components interact.",
         "training_skill": "electronics",
         "training_skill_min_level": 2,
-        "training_skill_xp": 27,
+        "training_skill_xp": 9,
         "training_skill_max_level": 7,
         "training_skill_fatigue": 0,
-        "training_skill_interval": 30,
+        "training_skill_interval": 10,
         "training_skill_xp_chance": 90
       }
     ],
@@ -413,15 +413,15 @@
     "//": "mirror & mannequin speaking. you can only train so high when talking to yourself.",
     "use_action": [
       {
-        "//": "average of 108 xp/hr",
+        "//": "up to 18 xp/hr",
         "type": "train_skill",
         "training_msg": "You practice speaking, rehearsing your tone and delivery.",
         "training_skill": "speech",
         "training_skill_min_level": 0,
-        "training_skill_xp": 9,
+        "training_skill_xp": 3,
         "training_skill_max_level": 2,
         "training_skill_fatigue": 0,
-        "training_skill_interval": 30,
+        "training_skill_interval": 10,
         "training_skill_xp_chance": 90
       }
     ]
@@ -437,15 +437,15 @@
     "//2": "this is dangerous machinery, so require a minimum level of 2",
     "use_action": [
       {
-        "//": "average of 216 xp/hr",
+        "//": "up to 54 xp/hr",
         "type": "train_skill",
         "training_msg": "You inspect the fabrication machinery, learning how its components fit together and operate.",
         "training_skill": "fabrication",
         "training_skill_min_level": 2,
-        "training_skill_xp": 27,
+        "training_skill_xp": 9,
         "training_skill_max_level": 7,
         "training_skill_fatigue": 0,
-        "training_skill_interval": 30,
+        "training_skill_interval": 10,
         "training_skill_xp_chance": 90
       }
     ],
@@ -461,15 +461,15 @@
     "//": "fancy server stack. requires a bit of computer knowledge to know your way around, but allows steady computers training afterwards.",
     "use_action": [
       {
-        "//": "average of 216 xp/hr",
+        "//": "up to 54 xp/hr",
         "type": "train_skill",
         "training_msg": "You examine scripts and programs, learning how the system operates.",
         "training_skill": "computer",
         "training_skill_min_level": 3,
-        "training_skill_xp": 27,
+        "training_skill_xp": 9,
         "training_skill_max_level": 8,
         "training_skill_fatigue": 0,
-        "training_skill_interval": 30,
+        "training_skill_interval": 10,
         "training_skill_xp_chance": 90
       }
     ],


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

I advised making EXP gain from skill training furniture be spread out across MORE procs per hour, not bunched up into even fewer. Also the JSON comments did not match the actual EXP gain, and calling them averages is goofy since it's more like max given the 90% proc chance.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Sanity-checked the JSON comments to actually align with how much EXP they actually give, and set it to trigger EXP rolls every 10 minutes so interrupting the activity won't waste as much potential EXP.
2. Reduced the EXP per proc accordingly. I kept the same total numbers of EXP per hour unchanged though.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Used my eeeeyyyyeees.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I may follow this up with tiering the EXP gain per hour a bit better based on min skill required and/or grid power requirement. I can save that for a future PR though.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
