### PR TITLE
fix: skill training action enforces max skill, print skill name and level in relevant messages

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5627,12 +5627,16 @@ void train_skill_actor::load( JsonObject const &obj )
 int train_skill_actor::use( player &p, item &i, bool, const tripoint & ) const
 {
     if( p.get_skill_level( skill_id( training_skill ) ) < training_skill_min_level ) {
-        p.add_msg_if_player( "Your skill isn't high enough yet to train using that." );
+        p.add_msg_if_player( _( "Your skill isn't high enough yet to train using that (requires %s %s)." ), training_skill_min_level, skill_id( training_skill )->name() );
+        return 0;
+    }
+    if( p.get_skill_level( skill_id( training_skill ) ) >= training_skill_max_level ) {
+        p.add_msg_if_player( _( "You can't train your %s beyond %s using that." ), skill_id( training_skill )->name(), training_skill_max_level );
         return 0;
     }
 
     int hours = string_input_popup()
-                .title( string_format( _( "Train %s for how long (hours)?" ),
+                .title( string_format( _( "Train %s for how many hours?" ),
                                        skill_id( training_skill )->name() ) )
                 .width( 3 )
                 .text( "" )


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Two more lil UI improvements to skill training, including a fix to implement unused max skill.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In iuse_actor.cpp, changed `train_skill_actor::use` so the cancellation message when trying to use skill training items you lack the skill for now says what skill and how much you need to use it.
2. Also in `train_skill_actor::use`, added an if statement so that it now actually checks when you've hit max skill, and if so prevents you from using it, with message telling you the skill and level in question.
3. Minor: lil tweak to the phrasing of the skill prompt.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. First, tested before adding the extra if statement to confirm it was indeed letting you train past the max skill.
2. Compiled and load-tested.
3. Spawned in a exercise machine and confirmed it tells me I need Athletics skill of 2 to use it.
4. Set Electrics skill to 7 and spawned a conduit, confirmed it prevents me from using it and tells me what the skill limit is.

<img width="524" height="59" alt="image" src="https://github.com/user-attachments/assets/7dfc9990-1765-4952-951d-6a63fef53c09" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR modifies BN's lua API.
  - [ ] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.
-->
