### PR TITLE
fix: train skill actor once again supports unpowered items

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2639,10 +2639,12 @@ void activity_handlers::train_skill_do_turn( player_activity *act, player *p )
         } else if( skill_training_item.ammo_required() > 0 ) {
             act->moves_left = 0;
             add_msg( m_info, _( "The %s runs out of power." ), skill_training_item.tname() );
+            return;
         }
         if( p->get_skill_level( skill_id( training_skill ) ) >= training_skill_max_level ) {
             act->moves_left = 0;
             add_msg( m_info, _( "You can no longer learn anything from this." ) );
+            return;
         }
         if( rng( 1, 100 ) < training_skill_xp_chance ) {
             p->practice( skill_id( training_skill ), training_skill_xp,

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2628,14 +2628,6 @@ void activity_handlers::train_skill_do_turn( player_activity *act, player *p )
         p->mod_fatigue( training_skill_fatigue );
         if( skill_training_item.ammo_remaining() > 0 ) {
             skill_training_item.ammo_consume( 1, p->pos() );
-            if( rng( 1, 100 ) < training_skill_xp_chance ) {
-                p->practice( skill_id( training_skill ), training_skill_xp,
-                             training_skill_max_level );
-            }
-            if( p->get_skill_level( skill_id( training_skill ) ) >= training_skill_max_level ) {
-                act->moves_left = 0;
-                add_msg( m_info, _( "You can no longer learn anything from this." ) );
-            }
             if( hack_type.has_value() ) {
                 hack::discharge_real_power_source(
                     hack_type.value(),
@@ -2644,9 +2636,17 @@ void activity_handlers::train_skill_do_turn( player_activity *act, player *p )
                     hack_original_charges
                 );
             }
-        } else {
+        } else if( skill_training_item.ammo_required() > 0 ){
             act->moves_left = 0;
             add_msg( m_info, _( "The %s runs out of power." ), skill_training_item.tname() );
+        }
+        if( p->get_skill_level( skill_id( training_skill ) ) >= training_skill_max_level ) {
+            act->moves_left = 0;
+            add_msg( m_info, _( "You can no longer learn anything from this." ) );
+        }
+        if( rng( 1, 100 ) < training_skill_xp_chance ) {
+            p->practice( skill_id( training_skill ), training_skill_xp,
+                         training_skill_max_level );
         }
     }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2636,7 +2636,7 @@ void activity_handlers::train_skill_do_turn( player_activity *act, player *p )
                     hack_original_charges
                 );
             }
-        } else if( skill_training_item.ammo_required() > 0 ){
+        } else if( skill_training_item.ammo_required() > 0 ) {
             act->moves_left = 0;
             add_msg( m_info, _( "The %s runs out of power." ), skill_training_item.tname() );
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5626,7 +5626,7 @@ void train_skill_actor::load( JsonObject const &obj )
 
 int train_skill_actor::use( player &p, item &i, bool, const tripoint & ) const
 {
-    if( i.ammo_remaining() <= i.ammo_required() ) {
+    if( i.ammo_remaining() < i.ammo_required() ) {
         p.add_msg_if_player( _( "This tool doesn't have enough charges." ) );
         return 0;
     }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5626,7 +5626,7 @@ void train_skill_actor::load( JsonObject const &obj )
 
 int train_skill_actor::use( player &p, item &i, bool, const tripoint & ) const
 {
-    if( i.ammo_remaining() < i.ammo_required() ) {
+    if( i.ammo_remaining() <= i.ammo_required() ) {
         p.add_msg_if_player( _( "This tool doesn't have enough charges." ) );
         return 0;
     }


### PR DESCRIPTION
## Purpose of change (The Why)
Mirrors aren't powered right?

## Describe the solution (The How)
Shuffle some stuffs around
Make sure the power if statement applies only when there is ammo needed
Do some more early returns
Stuff like that

## Describe alternatives you've considered
Screm

## Testing
The order looks slightly better, it might be able to give 1 extra tick though, I'm not sure

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.