### PR TITLE
feat: Faction Menu NPC swapping, Swapping NPCs swaps thirst and removes thermal conditions

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -359,6 +359,8 @@ std::string action_ident( action_id act )
             return "TOGGLE_CHARACTER_PREVIEW_CLOTHES";
         case ACTION_NULL:
             return "null";
+        case ACTION_SWAP_TO_NPC:
+            return "SWAPTONPC";
         default:
             return "unknown";
     }

--- a/src/action.h
+++ b/src/action.h
@@ -336,6 +336,8 @@ enum action_id : int {
     ACTION_DISPLAY_SUBMAP_GRID,
     /** Toggle timing of the game hours */
     ACTION_TOGGLE_HOUR_TIMER,
+    /** Swap to an NPC in faction menu **/
+    ACTION_SWAP_TO_NPC,
     /** Not an action, serves as count of enumerated actions */
     NUM_ACTIONS
     /**@}*/

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include "action.h"
+#include "bodypart.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "catacharset.h"
@@ -82,6 +83,9 @@ static const efftype_id effect_alarm_clock( "alarm_clock" );
 static const efftype_id effect_contacts( "contacts" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_slept_through_alarm( "slept_through_alarm" );
+static const efftype_id effect_cold( "cold" );
+static const efftype_id effect_hot( "hot" );
+static const efftype_id effect_hot_speed( "hot_speed" );
 
 static const itype_id itype_guidebook( "guidebook" );
 
@@ -146,6 +150,18 @@ void avatar::control_npc( npc &np )
     // move shadow npc character data into avatar
     swap_character( *shadow_npc, tmp );
     set_save_id( save_id );
+    // Swappy the thirst and kcal so swapping is not infinite food with no food
+    if( get_option<bool>( "NO_NPC_FOOD" ) ) {
+        set_thirst( np.get_thirst( ) );
+        set_stored_kcal( np.get_stored_kcal() );
+    }
+    for( auto &pr : get_body() ) {
+        const bodypart_id &bp = pr.first;
+        np.remove_effect( effect_cold, bp.id() );
+        np.remove_effect( effect_hot, bp.id() );
+        np.remove_effect( effect_hot_speed, bp.id() );
+    }
+        
     np.onswapsetpos( np.pos() );
     // the avatar character is no longer a follower NPC
     g->remove_npc_follower( getID() );

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -893,7 +893,7 @@ void faction_manager::display() const
             }
         } else if( action == "QUIT" ) {
             break;
-        } else if( action == "SELECT" && guy ) {
+        } else if( action == "SELECT" && guy && interactable ) {
             get_avatar().control_npc( *guy );
         }
     }

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -638,6 +638,7 @@ void faction_manager::display() const
     ctxt.register_action( "ANY_INPUT" );
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "PREV_TAB" );
+    ctxt.register_action( "SELECT" );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
@@ -892,6 +893,8 @@ void faction_manager::display() const
             }
         } else if( action == "QUIT" ) {
             break;
+        } else if( action == "SELECT" && guy ) {
+            if( guy)
         }
     }
 }

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -894,7 +894,7 @@ void faction_manager::display() const
         } else if( action == "QUIT" ) {
             break;
         } else if( action == "SELECT" && guy ) {
-            if( guy)
+            get_avatar().control_npc( *guy );
         }
     }
 }

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -638,7 +638,7 @@ void faction_manager::display() const
     ctxt.register_action( "ANY_INPUT" );
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "PREV_TAB" );
-    ctxt.register_action( "SELECT" );
+    ctxt.register_action( "SWAPTONPC", to_translation( "Swap to NPC" ) );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
@@ -893,7 +893,7 @@ void faction_manager::display() const
             }
         } else if( action == "QUIT" ) {
             break;
-        } else if( action == "SELECT" && guy && interactable ) {
+        } else if( action == "SWAPTONPC" && guy && interactable ) {
             get_avatar().control_npc( *guy );
         }
     }


### PR DESCRIPTION
## Purpose of change (The Why)
A few stray changes that are helpful for NPC swapping

## Describe the solution (The How)
Set thirst of the new player to the old players thirst
Same for kcals
Remove cold and heat effects once swapped

## Describe alternatives you've considered
None

## Testing
Spawn an NPC and swap to him using the new menu keybind (you need to set it I could not find where to add a new default)
Equip 2 fur coats, get toasty
Swap back to the player
You are not engorged, nor is the npc toasty

## Additional context
I could make the NPCs smart enough to deserve temp, but that's way too much work

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.