### PR TITLE
fix: update improved multi cooker recipe

### DIFF
--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -998,7 +998,7 @@
     "autolearn": true,
     "using": [ [ "soldering_standard", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "components": [ [ [ "power_supply", 1 ] ], [ [ "e_scrap", 1 ] ] ]
+    "components": [ [ [ "power_supply", 1 ] ], [ [ "e_scrap", 1 ] ], [ [ "multi_cooker", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
## Purpose of change (The Why)

Fix an exploit introduced in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/7158 by having the improved multi cooker cost a multi cooker. This stops a steel exploit.

## Describe the solution (The How)

Recipe costs prerequisite

## Describe alternatives you've considered

More reviewers 

## Testing

Unnecessary

## Additional context
## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.